### PR TITLE
docs: revamp docs with three-pathway architecture (Pipeline, Skills, Harness)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Fluent builder API for Google's [Agent Development Kit (ADK)](https://google.git
 
 - [Install](#install)
 - [Quick Start](#quick-start)
+- [Three Pathways](#three-pathways)
 - [Zero to Running](#zero-to-running)
 - [Why adk-fluent](#why-adk-fluent)
 - [Expression Language](#expression-language)
@@ -220,6 +221,130 @@ graph TD
     n2 -. "intent" .-> n3
 ```
 
+
+## Three Pathways
+
+Once you know the builder basics, adk-fluent offers three distinct development pathways -- a fork in the road where each branch produces native ADK objects but solves different problems at different abstraction levels.
+
+```
+                              adk-fluent
+                                  |
+              ┌───────────────────┼───────────────────┐
+              |                   |                    |
+       PIPELINE PATH        SKILLS PATH          HARNESS PATH
+      Python builders      Declarative YAML     Autonomous runtimes
+              |                   |                    |
+    ┌─────────┴─────────┐ ┌──────┴───────┐ ┌──────────┴──────────┐
+    | Agent >> Agent     | | SKILL.md     | | H namespace (Python) |
+    | >> | * // @        | | Topology in  | | 5-layer architecture |
+    | S, C, P, M, T, G  | | config, not  | | EventBus, sandbox    |
+    | Full Python control| | code         | | Permissions, budgets |
+    └─────────┬─────────┘ └──────┬───────┘ └──────────┬──────────┘
+              |                   |                    |
+     Custom workflows      Reusable agent       Coding agents
+     Complex routing       libraries             DevOps runtimes
+     Dynamic topologies    Cross-team sharing    Research harnesses
+```
+
+### Pipeline Path -- Python-First Builders
+
+The core path. Full Python control with expression operators and 9 namespace modules. Build any topology -- sequential, parallel, loops, routing, fallbacks -- with type-checked, IDE-friendly builders.
+
+```python
+from adk_fluent import Agent, S, C, until
+
+# Compose any topology with operators
+research = (
+    S.capture("query")
+    >> Agent("planner", "gemini-2.5-flash").instruct("Decompose the query.").writes("plan")
+    >> (Agent("web", "gemini-2.5-flash").instruct("Search web.").writes("web")
+        | Agent("papers", "gemini-2.5-flash").instruct("Search papers.").writes("papers"))
+    >> Agent("writer", "gemini-2.5-pro").instruct("Synthesize {web} and {papers}.")
+)
+
+# Loops, routing, fallbacks, typed output -- all composable
+loop = (writer >> critic) * until(lambda s: s.get("score", 0) >= 0.8, max=3)
+routed = classifier >> Route("intent").eq("billing", billing).otherwise(general)
+safe = fast_model // strong_model  # Fallback chain
+```
+
+**Best for:** Custom workflows with complex routing, dynamic topologies, callback-heavy agents, full programmatic control. This is where most development starts.
+
+[User Guide](https://vamsiramakrishnan.github.io/adk-fluent/user-guide/) -- [Expression Language](https://vamsiramakrishnan.github.io/adk-fluent/user-guide/expression-language/) -- [74 Cookbook Recipes](https://vamsiramakrishnan.github.io/adk-fluent/cookbook/)
+
+### Skills Path -- Declarative Agent Packages
+
+Turn YAML + Markdown into executable agent graphs. Domain experts write prompts and topology; engineers inject tools and deploy. One file is simultaneously documentation, coding-agent context, and a runnable pipeline.
+
+```python
+from adk_fluent import Skill
+
+# Load a skill -- parses YAML into an agent graph
+research = Skill("skills/research_pipeline/")
+
+# Compose skills with the same operators as agents
+pipeline = Skill("skills/research/") >> Skill("skills/writing/") >> Skill("skills/review/")
+
+# Override models, inject tools
+fast = research.model("gemini-2.5-flash").inject(web_search=my_search_fn)
+```
+
+**Best for:** Stable topologies where the main variation is prompts, models, and tools. Teams with non-Python domain experts. Reusable capability libraries.
+
+[Skills Guide](https://vamsiramakrishnan.github.io/adk-fluent/user-guide/skills/) -- [Example SKILL.md files](examples/skills/)
+
+### Harness Path -- Autonomous Coding Runtimes
+
+Build Claude-Code-class autonomous agents with the `H` namespace. Five composable layers: intelligence, tools, safety, observability, and runtime.
+
+```python
+from adk_fluent import Agent, H, C
+
+# Intelligence + Tools
+agent = (
+    Agent("coder", "gemini-2.5-pro")
+    .instruct("You are an expert coding assistant.")
+    .tools(H.workspace("/project", diff_mode=True) + H.web() + H.git_tools("/project"))
+)
+
+# Safety + Observability + Runtime
+agent = agent.harness(
+    permissions=H.auto_allow("read_file", "grep_search").merge(H.ask_before("edit_file", "bash")),
+    sandbox=H.workspace_only("/project"),
+)
+
+bus = H.event_bus()
+repl = H.repl(agent.build(), hooks=H.hooks("/project").on_edit("ruff check {file_path}"))
+await repl.run()
+```
+
+**Best for:** Agents that act autonomously -- reading codebases, editing files, running tests, managing processes. When you need permissions, sandboxing, token budgets, and observability.
+
+[Harness Guide](https://vamsiramakrishnan.github.io/adk-fluent/user-guide/harness/) -- [Full harness example](examples/cookbook/79_coding_agent_harness.py)
+
+### Which Path?
+
+| Question | Pipeline | Skills | Harness |
+|----------|----------|--------|---------|
+| Who writes the agent logic? | Engineers (Python) | Domain experts (YAML) | Engineers (Python) |
+| Abstraction level | Low -- full control | High -- config-driven | Medium -- composable layers |
+| Topology flexibility | Unlimited | Fixed per skill | Agent + tools |
+| Does the agent need file/shell access? | Optional | No | Yes |
+| Does the agent need permissions/sandbox? | No | No | Yes |
+| Is reusability across teams important? | Moderate -- share code | High -- share SKILL.md files | Low -- custom per-domain |
+| Is it a multi-turn autonomous runtime? | No -- pipeline execution | No -- pipeline execution | Yes -- REPL with memory |
+
+**All three compose together.** A harness can load skills for domain expertise, while pipelines define the internal agent topology:
+
+```python
+agent = (
+    Agent("coder", "gemini-2.5-pro")
+    .use_skill("skills/code_review/")          # Skills for domain knowledge
+    .use_skill("skills/python_best_practices/")
+    .tools(H.workspace("/project") + H.web())  # Harness for autonomous capability
+)
+# Inside a skill, the agents are wired as pipelines with >> | * operators
+```
 
 ## Zero to Running
 

--- a/README.template.md
+++ b/README.template.md
@@ -18,6 +18,7 @@ Fluent builder API for Google's [Agent Development Kit (ADK)](https://google.git
 
 - [Install](#install)
 - [Quick Start](#quick-start)
+- [Three Pathways](#three-pathways)
 - [Zero to Running](#zero-to-running)
 - [Why adk-fluent](#why-adk-fluent)
 - [Expression Language](#expression-language)
@@ -208,6 +209,130 @@ escalation_pipeline = classify >> Agent("escalate", "gemini-2.5-flash").instruct
 ```
 
 <!-- INJECT_MERMAID_DIAGRAM -->
+
+## Three Pathways
+
+Once you know the builder basics, adk-fluent offers three distinct development pathways -- a fork in the road where each branch produces native ADK objects but solves different problems at different abstraction levels.
+
+```
+                              adk-fluent
+                                  |
+              ┌───────────────────┼───────────────────┐
+              |                   |                    |
+       PIPELINE PATH        SKILLS PATH          HARNESS PATH
+      Python builders      Declarative YAML     Autonomous runtimes
+              |                   |                    |
+    ┌─────────┴─────────┐ ┌──────┴───────┐ ┌──────────┴──────────┐
+    | Agent >> Agent     | | SKILL.md     | | H namespace (Python) |
+    | >> | * // @        | | Topology in  | | 5-layer architecture |
+    | S, C, P, M, T, G  | | config, not  | | EventBus, sandbox    |
+    | Full Python control| | code         | | Permissions, budgets |
+    └─────────┬─────────┘ └──────┬───────┘ └──────────┬──────────┘
+              |                   |                    |
+     Custom workflows      Reusable agent       Coding agents
+     Complex routing       libraries             DevOps runtimes
+     Dynamic topologies    Cross-team sharing    Research harnesses
+```
+
+### Pipeline Path -- Python-First Builders
+
+The core path. Full Python control with expression operators and 9 namespace modules. Build any topology -- sequential, parallel, loops, routing, fallbacks -- with type-checked, IDE-friendly builders.
+
+```python
+from adk_fluent import Agent, S, C, until
+
+# Compose any topology with operators
+research = (
+    S.capture("query")
+    >> Agent("planner", "gemini-2.5-flash").instruct("Decompose the query.").writes("plan")
+    >> (Agent("web", "gemini-2.5-flash").instruct("Search web.").writes("web")
+        | Agent("papers", "gemini-2.5-flash").instruct("Search papers.").writes("papers"))
+    >> Agent("writer", "gemini-2.5-pro").instruct("Synthesize {web} and {papers}.")
+)
+
+# Loops, routing, fallbacks, typed output -- all composable
+loop = (writer >> critic) * until(lambda s: s.get("score", 0) >= 0.8, max=3)
+routed = classifier >> Route("intent").eq("billing", billing).otherwise(general)
+safe = fast_model // strong_model  # Fallback chain
+```
+
+**Best for:** Custom workflows with complex routing, dynamic topologies, callback-heavy agents, full programmatic control. This is where most development starts.
+
+[User Guide](https://vamsiramakrishnan.github.io/adk-fluent/user-guide/) -- [Expression Language](https://vamsiramakrishnan.github.io/adk-fluent/user-guide/expression-language/) -- [74 Cookbook Recipes](https://vamsiramakrishnan.github.io/adk-fluent/cookbook/)
+
+### Skills Path -- Declarative Agent Packages
+
+Turn YAML + Markdown into executable agent graphs. Domain experts write prompts and topology; engineers inject tools and deploy. One file is simultaneously documentation, coding-agent context, and a runnable pipeline.
+
+```python
+from adk_fluent import Skill
+
+# Load a skill -- parses YAML into an agent graph
+research = Skill("skills/research_pipeline/")
+
+# Compose skills with the same operators as agents
+pipeline = Skill("skills/research/") >> Skill("skills/writing/") >> Skill("skills/review/")
+
+# Override models, inject tools
+fast = research.model("gemini-2.5-flash").inject(web_search=my_search_fn)
+```
+
+**Best for:** Stable topologies where the main variation is prompts, models, and tools. Teams with non-Python domain experts. Reusable capability libraries.
+
+[Skills Guide](https://vamsiramakrishnan.github.io/adk-fluent/user-guide/skills/) -- [Example SKILL.md files](examples/skills/)
+
+### Harness Path -- Autonomous Coding Runtimes
+
+Build Claude-Code-class autonomous agents with the `H` namespace. Five composable layers: intelligence, tools, safety, observability, and runtime.
+
+```python
+from adk_fluent import Agent, H, C
+
+# Intelligence + Tools
+agent = (
+    Agent("coder", "gemini-2.5-pro")
+    .instruct("You are an expert coding assistant.")
+    .tools(H.workspace("/project", diff_mode=True) + H.web() + H.git_tools("/project"))
+)
+
+# Safety + Observability + Runtime
+agent = agent.harness(
+    permissions=H.auto_allow("read_file", "grep_search").merge(H.ask_before("edit_file", "bash")),
+    sandbox=H.workspace_only("/project"),
+)
+
+bus = H.event_bus()
+repl = H.repl(agent.build(), hooks=H.hooks("/project").on_edit("ruff check {file_path}"))
+await repl.run()
+```
+
+**Best for:** Agents that act autonomously -- reading codebases, editing files, running tests, managing processes. When you need permissions, sandboxing, token budgets, and observability.
+
+[Harness Guide](https://vamsiramakrishnan.github.io/adk-fluent/user-guide/harness/) -- [Full harness example](examples/cookbook/79_coding_agent_harness.py)
+
+### Which Path?
+
+| Question | Pipeline | Skills | Harness |
+|----------|----------|--------|---------|
+| Who writes the agent logic? | Engineers (Python) | Domain experts (YAML) | Engineers (Python) |
+| Abstraction level | Low -- full control | High -- config-driven | Medium -- composable layers |
+| Topology flexibility | Unlimited | Fixed per skill | Agent + tools |
+| Does the agent need file/shell access? | Optional | No | Yes |
+| Does the agent need permissions/sandbox? | No | No | Yes |
+| Is reusability across teams important? | Moderate -- share code | High -- share SKILL.md files | Low -- custom per-domain |
+| Is it a multi-turn autonomous runtime? | No -- pipeline execution | No -- pipeline execution | Yes -- REPL with memory |
+
+**All three compose together.** A harness can load skills for domain expertise, while pipelines define the internal agent topology:
+
+```python
+agent = (
+    Agent("coder", "gemini-2.5-pro")
+    .use_skill("skills/code_review/")          # Skills for domain knowledge
+    .use_skill("skills/python_best_practices/")
+    .tools(H.workspace("/project") + H.web())  # Harness for autonomous capability
+)
+# Inside a skill, the agents are wired as pipelines with >> | * operators
+```
 
 ## Zero to Running
 

--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -93,9 +93,48 @@ hero-workflows/dispatch-join-pipeline
 
 ---
 
+## Skills & Harness Pathways
+
+These recipes demonstrate adk-fluent's [three development pathways](../user-guide/index.md#three-pathways) beyond the core Pipeline path. Skills turn YAML into agent graphs; harnesses build autonomous coding runtimes.
+
+````{grid} 1 2 3 3
+---
+gutter: 3
+---
+
+```{grid-item-card} Skill-Based Agents
+:link: ../generated/cookbook/77_skill_based_agents
+:link-type: doc
+
+11 patterns: load, compose, inject, discover, and introspect skills from SKILL.md files.
+
+**Pathway:** Skills
+```
+
+```{grid-item-card} Skill-Powered Harness
+:link: ../generated/cookbook/78_harness_and_skills
+:link-type: doc
+
+8 patterns combining skill expertise with sandboxed workspace tools, permissions, and context.
+
+**Pathway:** Skills + Harness
+```
+
+```{grid-item-card} Production Coding Agent
+:link: ../generated/cookbook/79_coding_agent_harness
+:link-type: doc
+
+27-test proof: a Claude-Code-class autonomous runtime built from 5 composable layers.
+
+**Pathway:** Harness
+```
+````
+
+---
+
 ## All Recipes
 
-For the complete flat listing of all 68 recipes with side-by-side native ADK
+For the complete flat listing of all recipes with side-by-side native ADK
 comparisons, see the [auto-generated cookbook](../generated/cookbook/index.md).
 
 For recipes organized by use case (support, e-commerce, research, etc.), see

--- a/docs/decision-guide.md
+++ b/docs/decision-guide.md
@@ -5,6 +5,35 @@ This page answers the question every developer asks: **"Which pattern should I u
 Use it as a flowchart when you're staring at a blank file and know what you
 want but not how to express it in adk-fluent.
 
+## Choosing a Pathway
+
+Before picking a topology, pick a pathway. adk-fluent has three:
+
+```
+Is the topology stable and owned by non-Python users?
+  └── Yes → SKILLS PATH: Skill("path/").ask("prompt")
+      └── YAML + Markdown → agent graph. See: Skills Guide
+
+Does the agent need autonomous file/shell/web access?
+  └── Yes → HARNESS PATH: Agent("x").tools(H.workspace() + H.web())
+      └── 5-layer architecture (tools, safety, observability, runtime). See: Harness Guide
+
+Everything else (most development starts here):
+  └── PIPELINE PATH: Agent("a") >> Agent("b") | Agent("c")
+      └── Full Python control, expression operators, 9 namespace modules. See: User Guide
+```
+
+| | Pipeline | Skills | Harness |
+|---|---|---|---|
+| **Abstraction** | Low -- full Python control | High -- YAML config | Medium -- composable layers |
+| **Topology** | Any (unlimited) | Fixed per skill file | Agent + toolset |
+| **Who writes it** | Engineers | Domain experts + engineers | Engineers |
+| **File/shell access** | Optional | No | Yes (sandboxed) |
+| **Multi-turn runtime** | No | No | Yes (REPL, memory) |
+| **Reusability** | Code sharing | SKILL.md sharing (30+ platforms) | Per-domain |
+
+**All three compose.** A harness loads skills, skills wire agents as pipelines, pipelines use the full expression algebra.
+
 ## Choosing a Topology
 
 ```

--- a/docs/editor-setup/index.md
+++ b/docs/editor-setup/index.md
@@ -70,6 +70,18 @@ Both approaches can be used independently, but combining them gives the best res
 All rules files (`CLAUDE.md`, `.cursor/rules/adk-fluent.mdc`, `.windsurfrules`, etc.) are **auto-generated** from the same source of truth by `scripts/llms_generator.py`. They update automatically when the API changes, so they never go stale. Run `just llms` to regenerate them locally, or let CI handle it.
 :::
 
+## Connection to the three pathways
+
+AI coding agents benefit from understanding which [development pathway](../user-guide/index.md#three-pathways) you're using:
+
+| Pathway | What the AI agent needs to know | Key rules/skills |
+|---|---|---|
+| **Pipeline** | Expression operators, namespace modules, builder methods | Rules files (auto-generated), `/cheatsheet` skill |
+| **Skills** | SKILL.md format, topology expressions, `.inject()` | `/scaffold-project` skill, `/dev-guide` skill |
+| **Harness** | H namespace, 5-layer architecture, safety patterns | `/architect-agents` skill, `/deploy-agent` skill |
+
+The rules files cover all three pathways. The [Agent Skills](#agent-skills) provide deeper procedural guidance for each.
+
 ```{toctree}
 ---
 hidden: true

--- a/docs/generated/cookbook/77_skill_based_agents.md
+++ b/docs/generated/cookbook/77_skill_based_agents.md
@@ -1,0 +1,257 @@
+# Skill-Based Agents -- Composable Skills from SKILL.md Files
+
+:::{tip} What you'll learn
+How to declare agent topologies in YAML, load them as `Skill()` builders, compose them with operators, inject tools, and discover skills via `SkillRegistry`. This is the **Skills Path** -- one of adk-fluent's [three development pathways](../../user-guide/index.md#three-pathways).
+:::
+
+_Source: `77_skill_based_agents.py`_ · **Pathway: Skills**
+
+## Why Skills?
+
+A single SKILL.md file serves **four purposes simultaneously**:
+
+| Consumer | What happens |
+|----------|-------------|
+| **Claude Code / Gemini CLI** | Coding agent reads the prose and learns how to use the skill |
+| **ADK SkillToolset** | Progressive disclosure -- LLM loads instructions on demand |
+| **adk-fluent `Skill()`** | Parses `agents:` block into executable agent graph |
+| **Humans reading GitHub** | Markdown renders as documentation |
+
+Without skills, you maintain two artifacts (Python + README) that drift apart. With skills, one file cannot drift from itself.
+
+## Architecture
+
+```
+              SKILL.md File
+      ┌──────────────────────────┐
+      │ ---                      │
+      │ name: research_pipeline  │    parse_skill_file()
+      │ agents:                  │ ──────────────────────►  SkillDefinition
+      │   researcher: ...        │                               │
+      │   writer: ...            │                               │
+      │ topology: a >> b         │                               │
+      │ ---                      │                               ▼
+      │ # Documentation          │                         Skill("path/")
+      │ Use when user needs...   │                               │
+      └──────────────────────────┘                               │ .build()
+                                                                 ▼
+                                                        Native ADK Agent
+                                                   (SequentialAgent, etc.)
+```
+
+## 11 Patterns
+
+### Pattern 1: Load and run a skill
+
+```python
+from adk_fluent import Skill
+
+skill = Skill("examples/skills/research_pipeline/")
+built = skill.build()
+
+# It's a real ADK SequentialAgent with 3 sub-agents
+assert len(built.sub_agents) == 3
+assert built.sub_agents[0].name == "researcher"
+assert built.sub_agents[1].name == "fact_checker"
+assert built.sub_agents[2].name == "synthesizer"
+```
+
+### Pattern 2: Override model for all agents
+
+```python
+skill = Skill("examples/skills/research_pipeline/").model("gemini-2.5-pro")
+built = skill.build()
+# All agents now use the overridden model
+for agent in built.sub_agents:
+    assert agent.model == "gemini-2.5-pro"
+```
+
+### Pattern 3: Inject tool implementations
+
+Tools referenced by name in the YAML are resolved via `.inject()`:
+
+```python
+def my_search(query: str) -> str:
+    """Custom web search implementation."""
+    return f"Results for: {query}"
+
+skill = Skill("examples/skills/research_pipeline/").inject(web_search=my_search)
+built = skill.build()
+# The researcher agent has the injected tool
+```
+
+### Pattern 4: Skill composition with `>>` (pipeline)
+
+```python
+research = Skill("examples/skills/research_pipeline/")
+review = Skill("examples/skills/code_reviewer/")
+
+# Skill >> Skill creates a Pipeline of skills
+pipeline = research >> review
+built = pipeline.build()
+assert len(built.sub_agents) == 2
+```
+
+### Pattern 5: Skill + Agent mixing
+
+```python
+from adk_fluent import Agent
+
+research = Skill("examples/skills/research_pipeline/")
+editor = Agent("editor", "gemini-2.5-flash").instruct("Polish the report.")
+
+pipeline = research >> editor
+built = pipeline.build()
+assert len(built.sub_agents) == 2
+```
+
+### Pattern 6: Skill as AgentTool (coordinator pattern)
+
+The coordinator LLM decides **when** to invoke each skill:
+
+```python
+from adk_fluent import Agent
+
+research = Skill("examples/skills/research_pipeline/")
+
+coordinator = (
+    Agent("coordinator", "gemini-2.5-pro")
+    .instruct("You have access to a research skill. Use it when needed.")
+    .agent_tool(research.describe("Deep multi-source research with citations"))
+)
+built = coordinator.build()
+assert len(built.tools) > 0
+```
+
+### Pattern 7: Fan-out parallel skills
+
+```python
+research = Skill("examples/skills/research_pipeline/")
+review = Skill("examples/skills/code_reviewer/")
+
+parallel = research | review
+built = parallel.build()
+assert len(built.sub_agents) == 2
+```
+
+### Pattern 8: Skill registry and discovery
+
+```python
+from adk_fluent import SkillRegistry
+
+registry = SkillRegistry("examples/skills/")
+
+# List all skills
+all_skills = registry.list()
+assert len(all_skills) >= 2
+
+# Find by tags
+research_skills = registry.find(tags=["research"])
+assert len(research_skills) >= 1
+
+# Get by name
+skill = registry.get("research_pipeline")
+```
+
+### Pattern 9: Introspection
+
+```python
+skill = Skill("examples/skills/research_pipeline/")
+
+# Topology expression
+assert skill.topology_expr() == "researcher >> fact_checker >> synthesizer"
+
+# Input/output contract
+contract = skill.contract()
+assert contract["input"] == {"topic": "str"}
+assert contract["output"] == {"report": "str"}
+```
+
+### Pattern 10: Configure specific agent within skill
+
+```python
+skill = Skill("examples/skills/research_pipeline/").configure(
+    "synthesizer", model="gemini-2.5-pro"
+)
+built = skill.build()
+assert built.sub_agents[2].model == "gemini-2.5-pro"
+```
+
+### Pattern 11: FanOut topology from SKILL.md
+
+Skills can declare parallel topology in their YAML `topology:` field:
+
+```python
+skill = Skill("examples/skills/code_reviewer/")
+built = skill.build()
+
+# (analyzer | style_checker | security_auditor) >> summarizer
+# = Pipeline with 2 sub_agents: FanOut and summarizer
+assert len(built.sub_agents) == 2
+fanout = built.sub_agents[0]
+assert len(fanout.sub_agents) == 3
+```
+
+## SKILL.md File Format
+
+```yaml
+---
+name: research_pipeline
+description: Multi-step research with fact-checking and synthesis.
+version: "1.0.0"
+tags: [research, synthesis, citations]
+
+agents:
+  researcher:
+    model: gemini-2.5-flash
+    instruct: |
+      Research {topic} thoroughly.
+      Find primary sources and extract key findings.
+    tools: [web_search]
+    writes: findings
+
+  fact_checker:
+    model: gemini-2.5-flash
+    instruct: |
+      Verify the claims in {findings}.
+      Flag unsupported assertions.
+    reads: [findings]
+    writes: verified_findings
+
+  synthesizer:
+    model: gemini-2.5-pro
+    instruct: |
+      Synthesize {verified_findings} into a coherent report
+      with citations.
+    reads: [verified_findings]
+    writes: report
+
+topology: researcher >> fact_checker >> synthesizer
+
+input:
+  topic: str
+output:
+  report: str
+---
+
+# Research Pipeline
+
+Use when the user needs comprehensive research with citations.
+```
+
+## When to Use Skills vs Pipeline Python
+
+| Scenario | Use Skills | Use Pipeline Python |
+|----------|-----------|-------------------|
+| Topology is stable, variation is in prompts/models | Yes | Overkill |
+| Domain experts (non-Python) own the agent logic | Yes | No |
+| Sharing capabilities across teams | Yes | Harder |
+| Complex conditional routing, dynamic tool registration | No | Yes |
+| Deep callback customization | No | Yes |
+| One-off agents that won't be reused | No | Yes |
+
+:::{seealso}
+- [Skills User Guide](../../user-guide/skills.md) -- full reference
+- [Example SKILL.md files](../../../examples/skills/) -- research_pipeline, code_reviewer
+- [Three Pathways](../../user-guide/index.md#three-pathways) -- how Skills fits into the bigger picture
+:::

--- a/docs/generated/cookbook/78_harness_and_skills.md
+++ b/docs/generated/cookbook/78_harness_and_skills.md
@@ -1,0 +1,229 @@
+# Skill-Powered Harness -- Building a CodAct Coding Agent
+
+:::{tip} What you'll learn
+How to combine the **Skills Path** and **Harness Path** -- loading domain expertise from SKILL.md files into autonomous agents with sandboxed workspace tools, permission policies, and context engineering. This recipe bridges two of adk-fluent's [three development pathways](../../user-guide/index.md#three-pathways).
+:::
+
+_Source: `78_harness_and_skills.py`_ · **Pathway: Skills + Harness**
+
+## The Three Skill Layers
+
+adk-fluent provides three levels of skill integration, each solving a different problem:
+
+| Layer | Method | What it does | When to use |
+|-------|--------|-------------|-------------|
+| **L1** | `.use_skill("path/")` | Loads SKILL.md body into `static_instruction` (cached, not re-sent every turn) | Always -- domain expertise |
+| **L2** | `T.skill("path/")` | Progressive disclosure via ADK `SkillToolset` (LLM loads on demand) | Many skills, LLM picks which |
+| **L3** | `Skill("path/")` | Pre-composed agent graph from `agents:` block | Predetermined topology |
+
+## Architecture
+
+```
+┌──────────────────────────────────────┐
+│          Agent + Skills              │
+│  .use_skill("code-review/")         │  ← L1: expertise (static, cached)
+│  .use_skill("python-best-practices/")│
+│  .instruct("Review the code.")       │  ← per-task instruction
+│  .tools(H.workspace("/project"))     │  ← sandboxed tools
+│  .harness(permissions=..., sandbox=.)│  ← permission + sandbox
+└──────────────────────────────────────┘
+```
+
+## 8 Patterns
+
+### Pattern 1: Minimal harness -- agent + workspace tools
+
+The simplest harness: an agent with sandboxed file/shell tools.
+
+```python
+from adk_fluent import Agent, H
+
+agent = (
+    Agent("coder", "gemini-2.5-flash")
+    .instruct("You are a coding assistant. Help the user with their project.")
+    .tools(H.workspace("/path/to/project"))
+)
+built = agent.build()
+# 7 tools: read_file, edit_file, write_file, glob_search, grep_search, bash, list_dir
+assert len(built.tools) == 7
+```
+
+### Pattern 2: Skilled harness -- agent + expertise + workspace
+
+Agent with domain expertise from SKILL.md files plus workspace tools:
+
+```python
+agent = (
+    Agent("reviewer", "gemini-2.5-pro")
+    .use_skill("examples/skills/code_reviewer/")
+    .instruct("Review the code in this project. Focus on security.")
+    .tools(H.workspace(project, read_only=True))
+)
+built = agent.build()
+# Skills go to static_instruction (cached, not re-sent every turn)
+assert "<skills>" in (built.static_instruction or "")
+assert "code_reviewer" in (built.static_instruction or "")
+# Instruction is separate (per-task)
+assert "security" in (built.instruction or "")
+```
+
+### Pattern 3: Multi-skill agent -- stacked expertise
+
+Stack multiple skills for compound expertise:
+
+```python
+agent = (
+    Agent("analyst", "gemini-2.5-pro")
+    .use_skill("examples/skills/research_pipeline/")
+    .use_skill("examples/skills/code_reviewer/")
+    .instruct("Analyze this codebase for quality and maintainability.")
+)
+built = agent.build()
+static = built.static_instruction or ""
+# Both skills present, order preserved
+assert "research_pipeline" in static
+assert "code_reviewer" in static
+assert static.index("research_pipeline") < static.index("code_reviewer")
+```
+
+### Pattern 4: Permission-gated harness
+
+Dangerous tools require approval:
+
+```python
+agent = (
+    Agent("coder", "gemini-2.5-flash")
+    .instruct("Help with the project.")
+    .tools(H.workspace(project))
+    .harness(
+        permissions=(
+            H.auto_allow("read_file", "glob_search", "grep_search", "list_dir")
+            .merge(H.ask_before("edit_file", "write_file", "bash"))
+        ),
+        sandbox=H.workspace_only(project),
+    )
+)
+built = agent.build()
+# Permission callback is registered as before_tool_callback
+assert built.before_tool_callback is not None
+```
+
+### Pattern 5: Skilled agents in a pipeline
+
+Each agent in a pipeline can have different expertise:
+
+```python
+from adk_fluent import Agent
+
+researcher = (
+    Agent("researcher", "gemini-2.5-flash")
+    .use_skill("examples/skills/research_pipeline/")
+    .instruct("Research the topic: {topic}")
+    .writes("findings")
+)
+reviewer = (
+    Agent("reviewer", "gemini-2.5-flash")
+    .use_skill("examples/skills/code_reviewer/")
+    .instruct("Review the findings for accuracy.")
+    .reads("findings")
+    .writes("review")
+)
+pipeline = researcher >> reviewer
+built = pipeline.build()
+# Each agent has its own skill
+assert "research_pipeline" in (built.sub_agents[0].static_instruction or "")
+assert "code_reviewer" in (built.sub_agents[1].static_instruction or "")
+```
+
+### Pattern 6: Mixing L1 and L3 skill layers
+
+Combine `.use_skill()` (L1 expertise) with `Skill()` builder (L3 recipe):
+
+```python
+from adk_fluent import Skill
+
+# L3: Skill builder creates a pre-composed agent graph
+research_pipeline = Skill("examples/skills/research_pipeline/")
+
+# L1: Agent with expertise from a different skill
+editor = (
+    Agent("editor", "gemini-2.5-pro")
+    .use_skill("examples/skills/code_reviewer/")
+    .instruct("Polish the research report.")
+    .reads("report")
+)
+
+# Compose them: recipe >> skilled agent
+pipeline = research_pipeline >> editor
+built = pipeline.build()
+assert len(built.sub_agents) == 2
+```
+
+### Pattern 7: Workspace tool isolation
+
+Workspace tools are sandboxed to the project directory:
+
+```python
+tools = H.workspace("/path/to/project")
+read_fn = [t for t in tools if t.__name__ == "read_file"][0]
+
+# Can read inside workspace
+result = read_fn("test.txt")  # OK
+
+# Cannot read outside workspace
+result = read_fn("/etc/hostname")
+assert "Error" in result or "outside" in result
+```
+
+### Pattern 8: Full harness -- the Claude-Code-like pattern
+
+The complete pattern combining skills + workspace + permissions + context:
+
+```python
+from adk_fluent._context import C
+
+harness_agent = (
+    Agent("coder", "gemini-2.5-pro")
+    # L1: Domain expertise
+    .use_skill("examples/skills/code_reviewer/")
+    .use_skill("examples/skills/research_pipeline/")
+    # Per-task instruction
+    .instruct("You are an expert coding assistant. Use your skills and tools.")
+    # Sandboxed workspace tools
+    .tools(H.workspace(project))
+    # Context engineering
+    .context(C.rolling(n=20))
+    # Harness configuration
+    .harness(
+        permissions=(
+            H.auto_allow("read_file", "glob_search", "grep_search", "list_dir")
+            .merge(H.ask_before("edit_file", "write_file", "bash"))
+        ),
+        sandbox=H.workspace_only(project),
+        auto_compress=100_000,
+    )
+)
+built = harness_agent.build()
+
+# Full setup verified
+assert "<skills>" in (built.static_instruction or "")
+assert len(built.tools) == 7
+assert built.before_tool_callback is not None
+```
+
+## Key Insight: Skills + Harness Composition
+
+Skills provide **what the agent knows** (domain expertise, cached as static instructions). The harness provides **what the agent can do** (tools, permissions, sandbox). Together they create an autonomous agent that is both expert and safe:
+
+```
+Skills  →  static_instruction  →  Cached expertise (never re-sent)
+Harness →  tools + callbacks   →  Sandboxed capabilities
+Prompt  →  instruction         →  Per-task directive (changes each turn)
+```
+
+:::{seealso}
+- [Skills User Guide](../../user-guide/skills.md) -- declarative agent packages
+- [Harness User Guide](../../user-guide/harness.md) -- autonomous runtime building
+- [Recipe 77: Skill-Based Agents](77_skill_based_agents.md) -- pure Skills patterns
+- [Recipe 79: Coding Agent Harness](79_coding_agent_harness.md) -- full 5-layer harness
+:::

--- a/docs/generated/cookbook/79_coding_agent_harness.md
+++ b/docs/generated/cookbook/79_coding_agent_harness.md
@@ -1,0 +1,425 @@
+# Gemini CLI / Claude Code Clone -- Production Coding Agent Harness
+
+:::{tip} What you'll learn
+How to build a fully-functional autonomous coding runtime using adk-fluent's harness primitives -- the **Harness Path**. This is the proof that the same framework that builds single-purpose agents can build a Claude-Code-class system. Covers all 5 layers and all 4 foundation primitives.
+:::
+
+_Source: `79_coding_agent_harness.py`_ · **Pathway: Harness** · _27 tests_
+
+## The 5-Layer Architecture
+
+Every production harness has five layers. Skip one and your harness will be fragile in a specific, predictable way.
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  5. RUNTIME         REPL, slash commands, interrupt       │
+│  4. OBSERVABILITY   EventBus, tape, hooks, renderer       │
+│  3. SAFETY          Permissions, sandbox, budgets          │
+│  2. TOOLS           Workspace, web, git, processes, MCP    │
+│  1. INTELLIGENCE    Agent + skills + manifold              │
+└──────────────────────────────────────────────────────────┘
+```
+
+| Layer | What it does | What breaks without it |
+|---|---|---|
+| **Intelligence** | LLM + expertise + capability discovery | Agent doesn't know how to do the task |
+| **Tools** | File I/O, shell, search, web, git | Agent can think but can't act |
+| **Safety** | Permissions, sandboxing, token budgets | Agent can act but might destroy things |
+| **Observability** | Events, logging, hooks, replay | You can't debug when things go wrong |
+| **Runtime** | REPL, streaming, compression, interrupts | No way to interact with the agent |
+
+---
+
+## Layer 1: Intelligence
+
+Agent with domain expertise from skills and rolling context window:
+
+```python
+from adk_fluent import Agent, H
+from adk_fluent._context import C
+
+agent = (
+    Agent("coder", "gemini-2.5-pro")
+    .use_skill("examples/skills/code_reviewer/")
+    .instruct(
+        "You are an expert coding assistant. Read the codebase, "
+        "edit files, run tests, and self-correct until the task is done."
+    )
+    .context(C.rolling(n=20, summarize=True))
+)
+built = agent.build()
+# Skills compile to cached static_instruction (not re-sent every turn)
+assert "<skills>" in (built.static_instruction or "")
+```
+
+## Layer 2: Tools
+
+### Workspace tools with diff-mode and multimodal
+
+```python
+tools = H.workspace(project, diff_mode=True, multimodal=True)
+names = [t.__name__ for t in tools]
+
+assert "apply_edit" in names   # diff_mode adds apply_edit
+assert "edit_file" in names
+assert "read_file" in names    # multimodal version for images/PDFs
+assert "glob_search" in names
+assert "grep_search" in names
+assert "bash" in names
+```
+
+### Tool composition with `+` operator
+
+```python
+tools = (
+    H.workspace(project)       # read, edit, write, glob, grep, bash, ls (7)
+    + H.web()                  # fetch + search (2)
+    + H.git_tools(project)     # status, diff, log, commit, branch (5)
+    + H.processes(project)     # start, check, stop (3)
+)
+assert len(tools) >= 15
+```
+
+### Streaming workspace (PTY-based)
+
+```python
+chunks = []
+tools = H.workspace(
+    project,
+    streaming=True,
+    on_output=lambda chunk: chunks.append(chunk),
+)
+```
+
+## Layer 3: Safety
+
+### Permission policies (allow / ask / deny)
+
+```python
+permissions = (
+    H.auto_allow("read_file", "glob_search", "grep_search", "list_dir")
+    .merge(H.ask_before("edit_file", "write_file", "bash"))
+    .merge(H.deny("rm_rf"))
+)
+# Deny wins over ask wins over allow
+assert "rm_rf" in permissions.deny
+assert "bash" in permissions.ask
+assert "read_file" in permissions.allow
+```
+
+### Pattern-based permissions
+
+```python
+permissions = (
+    H.allow_patterns("read_*", "list_*", "grep_*")
+    .merge(H.deny_patterns("*_delete", "*_destroy"))
+)
+```
+
+### Sandbox policy
+
+```python
+sandbox = H.sandbox(
+    workspace=project,
+    allow_shell=True,
+    allow_network=True,
+    read_paths=["/usr/share/dict"],
+    write_paths=["/tmp/agent-work"],
+)
+```
+
+### Budget monitor with threshold callbacks
+
+```python
+monitor = (
+    H.budget_monitor(200_000)
+    .on_threshold(0.7, lambda m: print(f"Warning: {m.utilization:.0%}"))
+    .on_threshold(0.9, lambda m: print("Critical: compressing..."))
+)
+
+# Simulate usage
+for _ in range(5):
+    monitor.record_usage(input_tokens=20_000, output_tokens=10_000)
+
+# At 150k/200k = 75%, warning fires
+assert monitor.estimated_turns_remaining > 0
+
+# After compression, adjust resets utilization
+monitor.adjust(50_000)
+```
+
+### Per-tool error recovery
+
+```python
+policy = (
+    H.tool_policy()
+    .retry("bash", max_attempts=3, backoff=1.0)
+    .retry("web_fetch", max_attempts=2, backoff=0.5)
+    .skip("glob_search", fallback="No matching files found.")
+    .ask("edit_file", handler=lambda name, args, err: True)
+)
+assert policy.rule_for("bash").action == "retry"
+assert policy.rule_for("glob_search").action == "skip"
+assert policy.rule_for("unknown_tool").action == "propagate"
+```
+
+## Layer 4: Observability
+
+### EventBus backbone
+
+Everything subscribes to the EventBus instead of building its own observation layer:
+
+```python
+bus = H.event_bus(max_buffer=100)
+events = []
+
+bus.on("tool_call_start", lambda e: events.append(("start", e.tool_name)))
+bus.on("tool_call_end", lambda e: events.append(("end", e.tool_name)))
+
+bus.emit(ToolCallStart(tool_name="read_file", args={"path": "main.py"}))
+bus.emit(ToolCallEnd(tool_name="read_file", result="...", duration_ms=42.0))
+
+assert events == [("start", "read_file"), ("end", "read_file")]
+assert len(bus.buffer) == 2  # buffered for late subscribers
+```
+
+### Error isolation
+
+One failing subscriber never blocks others:
+
+```python
+def bad_handler(e):
+    raise RuntimeError("observer crashed")
+
+def good_handler(e):
+    results.append(e.tool_name)
+
+bus.on("tool_call_start", bad_handler)
+bus.on("tool_call_start", good_handler)
+
+bus.emit(ToolCallStart(tool_name="bash"))
+assert results == ["bash"]  # good handler runs despite bad handler crash
+```
+
+### Session tape (replayable recording)
+
+```python
+tape = bus.tape(max_events=1000)
+
+bus.emit(ToolCallStart(tool_name="read_file"))
+bus.emit(ToolCallEnd(tool_name="read_file", duration_ms=15.0))
+bus.emit(UsageUpdate(input_tokens=1000, output_tokens=500))
+
+assert tape.size == 3
+```
+
+### Hooks (shell commands on events)
+
+```python
+hooks = (
+    H.hooks(project)
+    .on_edit("ruff check {file_path}")
+    .on_error("notify-send 'Agent error: {error}'")
+    .on("turn_complete", "echo 'turn done'")
+)
+```
+
+### Event renderer
+
+```python
+renderer = H.renderer("plain", show_timing=True, show_args=True)
+text = renderer.render(ToolCallStart(tool_name="edit_file", args={"path": "main.py"}))
+assert "edit_file" in text
+```
+
+### Foundation primitives compose through EventBus
+
+```python
+bus = H.event_bus()
+
+# All four foundations emit through the single bus
+policy = H.tool_policy().retry("bash").with_bus(bus)
+monitor = H.budget_monitor(100).on_threshold(0.9, lambda m: None).with_bus(bus)
+ledger = H.task_ledger().with_bus(bus)
+```
+
+## Layer 5: Runtime
+
+### Slash commands
+
+```python
+cmds = H.commands()
+cmds.register("model", lambda args: f"Model: {args}", description="Switch model")
+cmds.register("clear", lambda args: "Context cleared.", description="Clear context")
+cmds.register("compact", lambda args: "Compacted.", description="Compress context")
+cmds.register("help", lambda args: cmds.help_text(), description="Show commands")
+
+assert cmds.dispatch("/model gemini-2.5-flash") == "Model: gemini-2.5-flash"
+```
+
+### Cooperative cancellation (interrupt and resume)
+
+```python
+token = H.cancellation_token()
+token.begin_turn("Fix the bug in auth.py")
+token.record_tool_call("read_file", {"path": "auth.py"})
+token.record_tool_call("grep_search", {"pattern": "authenticate"})
+
+# User hits Ctrl-C
+token.cancel()
+
+# Snapshot captures mid-turn state
+snapshot = token.snapshot
+resume = snapshot.resume_prompt()
+assert "Resuming" in resume
+assert "read_file" in resume
+
+# Reset for next turn
+token.reset()
+```
+
+### Task ledger (LLM-callable background tasks)
+
+```python
+ledger = H.task_ledger(max_tasks=5).with_bus(bus)
+tools = ledger.tools()
+# [launch_task, check_task, list_tasks, cancel_task]
+
+launch, check, list_tasks, cancel = tools
+result = launch("run-tests", "Execute pytest suite")
+assert "registered" in result
+
+ledger.start("run-tests")
+ledger.complete("run-tests", "All 47 tests passed")
+result = check("run-tests")
+assert "47 tests passed" in result
+```
+
+---
+
+## Full Assembly: Complete Coding Agent (~50 lines)
+
+All 5 layers wired together into a production-ready autonomous runtime:
+
+```python
+from adk_fluent import Agent, H
+from adk_fluent._context import C
+from adk_fluent._harness import make_cancellation_callback, ReplConfig
+
+project = "/path/to/project"
+
+# --- EventBus backbone ---
+bus = H.event_bus(max_buffer=1000)
+tape = bus.tape()
+
+# --- Layer 1: Intelligence ---
+agent = (
+    Agent("coder", "gemini-2.5-pro")
+    .use_skill("skills/code_review/")
+    .instruct("You are an expert coding assistant.")
+    .context(C.rolling(n=20, summarize=True))
+)
+
+# --- Layer 2: Tools ---
+ledger = H.task_ledger().with_bus(bus)
+agent = agent.tools(
+    H.workspace(project, diff_mode=True, multimodal=True)
+    + H.web()
+    + H.git_tools(project)
+    + H.processes(project)
+    + ledger.tools()
+)
+
+# --- Layer 3: Safety ---
+agent = agent.harness(
+    permissions=(
+        H.auto_allow("read_file", "glob_search", "grep_search", "list_dir")
+        .merge(H.ask_before("edit_file", "write_file", "bash"))
+        .merge(H.deny("rm_rf"))
+    ),
+    sandbox=H.workspace_only(project),
+    memory=H.memory(f"{project}/.agent-memory.md"),
+    on_error=H.on_error(retry={"bash", "web_fetch"}, skip={"glob_search"}),
+)
+
+# --- Layer 4: Observability ---
+token = H.cancellation_token()
+monitor = H.budget_monitor(200_000).on_threshold(0.9, lambda m: None).with_bus(bus)
+policy = H.tool_policy().retry("bash", max_attempts=3).with_bus(bus)
+hooks = H.hooks(project).on_edit("ruff check {file_path}")
+bus.hooks(hooks)
+
+agent = (
+    agent
+    .before_tool(bus.before_tool_hook())
+    .before_tool(make_cancellation_callback(token))
+    .after_tool(bus.after_tool_hook())
+    .after_tool(policy.after_tool_hook())
+    .after_model(bus.after_model_hook())
+    .after_model(monitor.after_model_hook())
+)
+
+# --- Layer 5: Runtime ---
+cmds = H.commands()
+cmds.register("clear", lambda a: "Context cleared.", description="Clear context")
+cmds.register("model", lambda a: f"Model: {a}", description="Switch model")
+cmds.register("help", lambda a: cmds.help_text(), description="Show commands")
+
+built = agent.build()
+
+repl = H.repl(
+    built,
+    hooks=hooks,
+    compressor=H.compressor(100_000),
+    config=ReplConfig(
+        prompt_prefix="coder> ",
+        welcome_message="Coding agent ready. Type /help for commands.",
+        auto_checkpoint=True,
+    ),
+)
+# await repl.run()  # Start the interactive loop
+```
+
+## Manifold: Runtime Capability Discovery
+
+When you have 100+ tools but the LLM can only handle ~30 at once:
+
+```python
+manifold = H.manifold(
+    tools=None,           # ToolRegistry (BM25-indexed)
+    skills="skills/",     # Skill directory
+    always_loaded=["search_code"],
+    max_tools=30,
+)
+# Provides meta-tools: search_capabilities, load_capability, finalize_capabilities
+result = manifold.search("code review")
+```
+
+## Design Philosophy
+
+### Why composable layers, not a monolithic `HarnessAgent`?
+
+Every harness is different:
+- **Code review** needs diff-mode editing + git tools but no web access
+- **Research** needs web tools but no file editing
+- **DevOps** needs process management + MCP servers but no notebooks
+
+The `H` namespace gives you building blocks. You compose what you need. The composition _is_ the configuration.
+
+### The Four Foundation Primitives
+
+| Primitive | What it prevents | Composes with |
+|---|---|---|
+| `EventBus` | Building separate observation layers | SessionTape, HookRegistry, Renderer |
+| `ToolPolicy` | Reimplementing per-tool retry/fallback | `M.retry()`, ErrorStrategy |
+| `BudgetMonitor` | Reimplementing token tracking | `C.rolling()`, ContextCompressor |
+| `TaskLedger` | Reimplementing task tracking | Core dispatch primitives |
+
+They exist because the core framework (S, C, M, T, G) is **declarative and agent-scoped**. Harness building needs **imperative, session-scoped** control.
+
+:::{seealso}
+- [Harness User Guide](../../user-guide/harness.md) -- full reference
+- [Recipe 78: Harness + Skills](78_harness_and_skills.md) -- combining skills with harness
+- [Recipe 77: Skill-Based Agents](77_skill_based_agents.md) -- pure skills patterns
+- [Three Pathways](../../user-guide/index.md#three-pathways) -- how Harness fits into the bigger picture
+:::

--- a/docs/generated/cookbook/index.md
+++ b/docs/generated/cookbook/index.md
@@ -1165,6 +1165,46 @@ How to compose agents into a sequential pipeline.
 ```
 ````
 
+## Skills & Harness Pathways
+
+These recipes demonstrate the [Skills](../../user-guide/skills.md) and [Harness](../../user-guide/harness.md) development pathways -- two of adk-fluent's [three distinct pathways](../../user-guide/index.md#three-pathways) for building agents at different abstraction levels.
+
+````{grid} 1 2 2 2
+---
+gutter: 3
+---
+```{grid-item-card} Skill-Based Agents -- Composable Skills from SKILL.md Files
+
+11 patterns for declaring agent topologies in YAML, loading them as `Skill()` builders, composing with operators, injecting tools, and discovering skills via `SkillRegistry`.
+
+**Pathway:** Skills
+:link: 77_skill_based_agents
+:link-type: doc
+
+How to use declarative SKILL.md files for composable agent packages.
+```
+```{grid-item-card} Skill-Powered Harness -- Building a CodAct Coding Agent
+
+8 patterns combining Skills + Harness: loading domain expertise from SKILL.md into agents with sandboxed workspace tools, permission policies, and context engineering.
+
+**Pathway:** Skills + Harness
+:link: 78_harness_and_skills
+:link-type: doc
+
+How to combine skill expertise with harness runtime primitives.
+```
+```{grid-item-card} Gemini CLI / Claude Code Clone -- Production Coding Agent Harness
+
+27 tests building a complete 5-layer autonomous coding runtime: intelligence, tools, safety, observability, and runtime. Includes EventBus, budget monitor, task ledger, cancellation, and REPL.
+
+**Pathway:** Harness
+:link: 79_coding_agent_harness
+:link-type: doc
+
+How to build a production autonomous coding runtime with the H namespace.
+```
+````
+
 ```{toctree}
 :hidden:
 
@@ -1196,6 +1236,9 @@ How to compose agents into a sequential pipeline.
 72_a2ui_operators
 73_a2ui_llm_guided
 74_a2ui_pipeline
+77_skill_based_agents
+78_harness_and_skills
+79_coding_agent_harness
 ```
 
 ```{toctree}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -369,6 +369,54 @@ async with agent.session() as chat:
 ```
 :::
 
+## Choose Your Path
+
+Now that you know the basics, adk-fluent offers three distinct pathways for agent building. All produce native ADK objects -- they solve different problems at different abstraction levels.
+
+````{grid} 1 2 3 3
+---
+gutter: 3
+---
+
+```{grid-item-card} Pipeline Path -- Python-First Builders
+:link: user-guide/expression-language
+:link-type: doc
+
+Full Python control with expression operators (`>>` `|` `*` `@` `//`) and 9 namespace modules. Build any topology with type-checked, IDE-friendly builders.
+
+**Best for:** Custom workflows, complex routing, dynamic topologies, callback-heavy agents.
+
++++
+`Agent("a") >> (Agent("b") | Agent("c")) * 3`
+```
+
+```{grid-item-card} Skills Path -- Declarative Agent Packages
+:link: user-guide/skills
+:link-type: doc
+
+Turn YAML + Markdown into executable agent graphs. Domain experts write prompts and topology; engineers inject tools and deploy. One file is docs AND runtime.
+
+**Best for:** Stable topologies, reusable capability libraries, teams with non-Python domain experts.
+
++++
+`Skill("skills/research/") >> Skill("skills/writing/")`
+```
+
+```{grid-item-card} Harness Path -- Autonomous Coding Runtimes
+:link: user-guide/harness
+:link-type: doc
+
+Build Claude-Code-class autonomous agents with the `H` namespace. Five composable layers: intelligence, tools, safety, observability, and runtime.
+
+**Best for:** Agents that need file/shell access, permissions, sandboxing, token budgets, multi-turn REPL.
+
++++
+`H.workspace() + H.web() + H.git_tools()`
+```
+````
+
+**Not sure which?** See the [Decision Guide](decision-guide.md) for a flowchart. All three compose together -- a harness can load skills for domain expertise, and skills wire agents as pipelines internally.
+
 ## What's Next
 
 ````{grid} 1 2 2 2

--- a/docs/index.md
+++ b/docs/index.md
@@ -200,6 +200,63 @@ Every `.build()` returns a real ADK object -- fully compatible with `adk web`, `
 </div>
 ```
 
+## Three Pathways
+
+Once you know the builder basics, adk-fluent splits into three distinct development pathways -- a **fork in the road** that matches how you think about agent building.
+
+```{raw} html
+<div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 1.5rem; margin: 2rem 0;">
+
+  <div style="border: 2px solid #10b981; border-radius: 14px; padding: 1.5rem; background: #10b98108;">
+    <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.75rem;">
+      <svg width="36" height="36" viewBox="0 0 36 36" fill="none">
+        <rect x="4" y="4" width="28" height="28" rx="6" stroke="#10b981" stroke-width="1.5" fill="#10b98110"/>
+        <text x="18" y="22" text-anchor="middle" fill="#10b981" font-size="12" font-weight="700" font-family="monospace">&gt;&gt;</text>
+      </svg>
+      <h3 style="margin: 0; font-size: 1.05rem; font-weight: 700; color: #10b981;">Pipeline Path</h3>
+    </div>
+    <p style="font-size: 0.9rem; margin-bottom: 0.5rem; font-weight: 600;">Python-first builders</p>
+    <p style="font-size: 0.82rem; color: var(--adk-text-muted); line-height: 1.6; margin-bottom: 1rem;">Full Python control with expression operators (<code>&gt;&gt;</code> <code>|</code> <code>*</code> <code>@</code> <code>//</code>) and 9 namespace modules. Build any topology with type-checked, IDE-friendly builders.</p>
+    <code style="font-size: 0.78rem; color: #10b981;">Agent("a") >> Agent("b") | Agent("c")</code>
+    <p style="margin-top: 1rem; font-size: 0.82rem;"><strong>Best for:</strong> Custom workflows, complex routing, dynamic topologies</p>
+    <p style="margin-top: 0.5rem;"><a href="user-guide/expression-language.html" style="font-weight: 600; color: #10b981;">Expression Language &rarr;</a></p>
+  </div>
+
+  <div style="border: 2px solid #E65100; border-radius: 14px; padding: 1.5rem; background: #E6510008;">
+    <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.75rem;">
+      <svg width="36" height="36" viewBox="0 0 36 36" fill="none">
+        <rect x="4" y="4" width="28" height="28" rx="6" stroke="#E65100" stroke-width="1.5" fill="#E6510010"/>
+        <text x="18" y="22" text-anchor="middle" fill="#E65100" font-size="14" font-weight="700" font-family="monospace">S</text>
+      </svg>
+      <h3 style="margin: 0; font-size: 1.05rem; font-weight: 700; color: #E65100;">Skills Path</h3>
+    </div>
+    <p style="font-size: 0.9rem; margin-bottom: 0.5rem; font-weight: 600;">Declarative agent packages</p>
+    <p style="font-size: 0.82rem; color: var(--adk-text-muted); line-height: 1.6; margin-bottom: 1rem;">YAML + Markdown &rarr; executable agent graphs. Domain experts write prompts and topology. One file is docs, coding-agent context, and a runnable pipeline.</p>
+    <code style="font-size: 0.78rem; color: #F57C00;">Skill("research/") >> Skill("writing/")</code>
+    <p style="margin-top: 1rem; font-size: 0.82rem;"><strong>Best for:</strong> Stable topologies, reusable libraries, non-Python teams</p>
+    <p style="margin-top: 0.5rem;"><a href="user-guide/skills.html" style="font-weight: 600; color: #E65100;">Skills Guide &rarr;</a></p>
+  </div>
+
+  <div style="border: 2px solid #0ea5e9; border-radius: 14px; padding: 1.5rem; background: #0ea5e908;">
+    <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.75rem;">
+      <svg width="36" height="36" viewBox="0 0 36 36" fill="none">
+        <rect x="4" y="4" width="28" height="28" rx="6" stroke="#0ea5e9" stroke-width="1.5" fill="#0ea5e910"/>
+        <text x="18" y="22" text-anchor="middle" fill="#0ea5e9" font-size="14" font-weight="700" font-family="monospace">H</text>
+      </svg>
+      <h3 style="margin: 0; font-size: 1.05rem; font-weight: 700; color: #0ea5e9;">Harness Path</h3>
+    </div>
+    <p style="font-size: 0.9rem; margin-bottom: 0.5rem; font-weight: 600;">Autonomous coding runtimes</p>
+    <p style="font-size: 0.82rem; color: var(--adk-text-muted); line-height: 1.6; margin-bottom: 1rem;">Build Claude-Code-class agents with the H namespace. Five layers: intelligence, tools, safety, observability, runtime. Permissions, sandboxing, token budgets.</p>
+    <code style="font-size: 0.78rem; color: #0ea5e9;">H.workspace() + H.web() + H.git()</code>
+    <p style="margin-top: 1rem; font-size: 0.82rem;"><strong>Best for:</strong> Autonomous agents, file/shell access, multi-turn runtimes</p>
+    <p style="margin-top: 0.5rem;"><a href="user-guide/harness.html" style="font-weight: 600; color: #0ea5e9;">Harness Guide &rarr;</a></p>
+  </div>
+
+</div>
+```
+
+**All three compose together** -- a harness loads skills for domain expertise, skills wire agents as pipelines internally, and pipelines use the full expression algebra. See the [Decision Guide](decision-guide.md) for a flowchart.
+
 ## Quick Navigation
 
 ````{grid} 1 2 2 4
@@ -234,13 +291,19 @@ Complete reference for all 135 builders.
 
 ## Common Starting Points
 
-**"I have native ADK code and want to simplify it"** -- Start with the [Migration Guide](generated/migration/from-native-adk.md), then browse the [Cookbook](cookbook/index.md) for your pattern.
+**"I'm building agents from scratch"** -- Start with [Getting Started](getting-started.md), then [choose your path](#three-pathways).
 
-**"I'm building agents from scratch"** -- Start with [Getting Started](getting-started.md), then follow the [User Guide](user-guide/index.md) sequentially.
+**"I want full Python control with operators"** -- Take the [Pipeline Path](user-guide/expression-language.md). `>>` `|` `*` `@` `//` compose any topology.
+
+**"I want declarative, reusable agent packages"** -- Take the [Skills Path](user-guide/skills.md). YAML + Markdown = docs + runtime.
+
+**"I want an autonomous coding agent"** -- Take the [Harness Path](user-guide/harness.md). Five layers from tools to REPL.
+
+**"I have native ADK code and want to simplify it"** -- Start with the [Migration Guide](generated/migration/from-native-adk.md), then browse the [Cookbook](cookbook/index.md) for your pattern.
 
 **"I need a specific pattern (routing, loops, parallel)"** -- Jump to [Patterns](user-guide/patterns.md) or search the [Cookbook by use case](generated/cookbook/recipes-by-use-case.md).
 
-**"I want my AI coding agent to know adk-fluent"** -- Set up [Editor & AI Agent Setup](editor-setup/index.md) for rules files and MCP servers.
+**"I want my AI coding agent to know adk-fluent"** -- Set up [Editor & AI Agent Setup](editor-setup/index.md) for rules files, skills, and MCP servers.
 
 ---
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -25,6 +25,36 @@ support = (
 Each line maps to a concept you'll learn below. Hover over any builder method in your IDE to see its type signature.
 :::
 
+## Three Pathways
+
+adk-fluent offers three distinct development pathways. All produce native ADK objects -- they solve different problems at different abstraction levels. Pick the one that matches your use case, or combine them.
+
+```{raw} html
+<div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 1rem; margin: 1.5rem 0; font-size: 0.9rem;">
+
+  <div style="border-left: 3px solid #10b981; padding: 0.75rem 1rem; background: #10b98108; border-radius: 0 8px 8px 0;">
+    <strong style="color: #10b981;">Pipeline Path</strong><br>
+    Python-first builders with <code>&gt;&gt;</code> <code>|</code> <code>*</code> operators and 9 namespace modules. Full programmatic control.<br>
+    <em>Most development starts here.</em>
+  </div>
+
+  <div style="border-left: 3px solid #E65100; padding: 0.75rem 1rem; background: #E6510008; border-radius: 0 8px 8px 0;">
+    <strong style="color: #E65100;">Skills Path</strong><br>
+    YAML + Markdown &rarr; agent graphs. Domain experts write prompts and topology. One file = docs + runtime.<br>
+    <em>Reusable, cross-team, config-driven.</em>
+  </div>
+
+  <div style="border-left: 3px solid #0ea5e9; padding: 0.75rem 1rem; background: #0ea5e908; border-radius: 0 8px 8px 0;">
+    <strong style="color: #0ea5e9;">Harness Path</strong><br>
+    Build autonomous coding runtimes with the H namespace. 5 layers: intelligence, tools, safety, observability, runtime.<br>
+    <em>File/shell access, permissions, REPL.</em>
+  </div>
+
+</div>
+```
+
+**Not sure which?** See the [Decision Guide](../decision-guide.md). All three compose: harnesses load skills, skills wire pipelines, pipelines use the full expression algebra.
+
 ## Foundations
 
 Start here if you're new to adk-fluent.
@@ -35,9 +65,9 @@ Start here if you're new to adk-fluent.
 | [Best Practices](best-practices.md) | Opinionated guidance on when to use what |
 | [Framework Comparison](comparison.md) | Side-by-side with LangGraph, CrewAI, and native ADK |
 
-## Building Agents
+## Pipeline Path -- Building Agents in Python
 
-The core of the library.
+The core of the library. Full programmatic control with expression operators, namespace modules, and type-checked builders.
 
 | Chapter | What you'll learn |
 |---|---|
@@ -47,9 +77,7 @@ The core of the library.
 | [Prompts](prompts.md) | The P module: `P.role()`, `P.task()`, `P.constraint()`, section ordering, composition |
 | [Execution](execution.md) | `.ask()`, `.stream()`, `.session()`, `.map()`, `.events()` |
 
-## Advanced Capabilities
-
-Where adk-fluent's power shows.
+### Advanced Pipeline Capabilities
 
 | Chapter | What you'll learn |
 |---|---|
@@ -60,9 +88,25 @@ Where adk-fluent's power shows.
 | [Context Engineering](context-engineering.md) | The C module: `C.none()`, `C.from_state()`, `C.window()`, token budgets |
 | [Patterns](patterns.md) | `review_loop`, `map_reduce`, `cascade`, `fan_out_merge`, `conditional`, `supervised` |
 
+## Skills Path -- Declarative Agent Packages
+
+Turn YAML + Markdown into executable agent graphs. One file is simultaneously documentation, coding-agent context, and a runnable pipeline.
+
+| Chapter | What you'll learn |
+|---|---|
+| [Skills](skills.md) | `Skill()`, `SkillRegistry`, `T.skill()`, SKILL.md format, composition with operators, tool injection |
+
+## Harness Path -- Autonomous Coding Runtimes
+
+Build Claude-Code-class autonomous agents. Five composable layers: intelligence, tools, safety, observability, and runtime.
+
+| Chapter | What you'll learn |
+|---|---|
+| [Harness](harness.md) | The `H` namespace, 5-layer architecture, EventBus, permissions, sandbox, budgets, REPL |
+
 ## Infrastructure
 
-Production concerns.
+Production concerns that apply across all three pathways.
 
 | Chapter | What you'll learn |
 |---|---|
@@ -78,8 +122,6 @@ Production concerns.
 | [Testing](testing.md) | `.mock()`, `.test()`, `check_contracts()`, `AgentHarness`, pytest integration |
 | [A2A](a2a.md) | Remote agent-to-agent communication: `RemoteAgent`, `A2AServer`, discovery, resilience |
 | [A2UI](a2ui.md) | Declarative agent UIs: `UI` namespace, components, operators, surfaces, presets |
-| [Skills](skills.md) | Composable agent packages from SKILL.md files: `Skill`, `SkillRegistry`, `T.skill()` |
-| [Harness](harness.md) | Building autonomous coding runtimes: the `H` namespace, 5-layer architecture, foundation primitives |
 
 :::{admonition} Backend maturity at a glance
 :class: tip


### PR DESCRIPTION
Surface the three distinct development pathways as a first-class concept
across all documentation entry points. Each pathway (Pipeline for Python-first
builders, Skills for declarative YAML packages, Harness for autonomous runtimes)
gets visual prominence and clear decision guidance.

Updated files:
- README.template.md / README.md: Three Pathways section with ASCII diagram
- docs/index.md: Three-column visual cards for each pathway
- docs/getting-started.md: Choose Your Path section with grid cards
- docs/decision-guide.md: Pathway selection flowchart at top
- docs/user-guide/index.md: Restructured around pathway sections
- docs/editor-setup/index.md: Pathway connection table for AI agents