### PR TITLE
docs: harmonize README and docs for python/ts monorepo split

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,43 +30,61 @@ Run 'just all' to generate code, or 'just fmt' to format existing files.
 ### Prerequisites
 
 - Python 3.11+
+- Node.js 20+ (only if you're touching the TypeScript package under `ts/`)
 - [just](https://github.com/casey/just) command runner
 - [uv](https://github.com/astral-sh/uv) (recommended) or pip
 
 ## How the Codebase Works
 
-adk-fluent is **auto-generated** from the installed `google-adk` package:
+adk-fluent is a **dual-language monorepo**: the Python package (`adk-fluent`) lives under `python/`, the TypeScript package (`adk-fluent-ts`) lives under `ts/`, and a single shared pipeline under `shared/` drives code generation for both from one ADK scan.
 
 ```
-scanner.py --> manifest.json --> seed_generator.py --> seed.toml --> generator.py --> Python code
+shared/scripts/scanner.py ─► shared/manifest.json ─► shared/scripts/seed_generator.py
+                                                                │
+                                                     shared/seeds/seed.toml
+                                                                │
+                                  ┌─────────────────────────────┴─────────────────────────────┐
+                                  ▼                                                           ▼
+                    shared/scripts/generator.py                                shared/scripts/generator.py
+                      --target python                                            --target typescript
+                                  ▼                                                           ▼
+                    python/src/adk_fluent/*.py (+ .pyi stubs)                     ts/src/builders/*.ts
 ```
 
 ### Key directories
 
-| Path                            | What it is                        | Hand-written?                     |
-| ------------------------------- | --------------------------------- | --------------------------------- |
-| `src/adk_fluent/agent.py`       | Agent builder                     | Auto-generated                    |
-| `src/adk_fluent/workflow.py`    | Pipeline/FanOut/Loop builders     | Auto-generated                    |
-| `src/adk_fluent/_base.py`       | Operators, primitives             | Hand-written                      |
-| `src/adk_fluent/_routing.py`    | Route builder                     | Hand-written                      |
-| `src/adk_fluent/_transforms.py` | S.\* state transforms             | Hand-written                      |
-| `src/adk_fluent/_prompt.py`     | Prompt builder                    | Hand-written                      |
-| `scripts/`                      | Codegen pipeline                  | Hand-written                      |
-| `seeds/seed.toml`               | Generator configuration           | Auto-generated + manual overrides |
-| `seeds/seed.manual.toml`        | Manual overrides merged into seed | Hand-written                      |
-| `examples/cookbook/`            | 68 runnable examples              | Hand-written                      |
-| `tests/generated/`              | Auto-generated tests              | Auto-generated                    |
-| `tests/manual/`                 | Hand-written tests                | Hand-written                      |
+| Path                                    | What it is                        | Hand-written?                     |
+| --------------------------------------- | --------------------------------- | --------------------------------- |
+| `python/src/adk_fluent/agent.py`        | Agent builder (Python)            | Auto-generated                    |
+| `python/src/adk_fluent/workflow.py`     | Pipeline/FanOut/Loop (Python)     | Auto-generated                    |
+| `python/src/adk_fluent/_base.py`        | Operators, primitives             | Hand-written                      |
+| `python/src/adk_fluent/_routing.py`     | Route builder                     | Hand-written                      |
+| `python/src/adk_fluent/_transforms.py`  | S.\* state transforms             | Hand-written                      |
+| `python/src/adk_fluent/_prompt.py`      | Prompt builder                    | Hand-written                      |
+| `python/examples/cookbook/`             | Python runnable examples          | Hand-written                      |
+| `python/tests/generated/`               | Auto-generated Python tests       | Auto-generated                    |
+| `python/tests/manual/`                  | Hand-written Python tests         | Hand-written                      |
+| `ts/src/builders/`                      | Agent/workflow builders (TS)      | Auto-generated                    |
+| `ts/src/core/`                          | TS builder base, types, runtime   | Hand-written                      |
+| `ts/src/namespaces/`                    | S/C/P/T/G/M/A/E/UI for TS         | Hand-written                      |
+| `ts/src/patterns/`, `primitives/`, etc. | Hand-written TS extras            | Hand-written                      |
+| `ts/examples/cookbook/`                 | TS runnable examples              | Hand-written                      |
+| `ts/tests/`                             | TS test suites (vitest)           | Hand-written                      |
+| `shared/scripts/`                       | Codegen pipeline (scan/seed/gen)  | Hand-written                      |
+| `shared/manifest.json`                  | ADK scan (canonical source)       | Auto-generated                    |
+| `shared/seeds/seed.toml`                | Generator configuration           | Auto-generated + manual overrides |
+| `shared/seeds/seed.manual.toml`         | Manual overrides merged into seed | Hand-written                      |
+| `docs/`                                 | Sphinx docs site                  | Hand-written + `docs/generated/`  |
 
 ### Important: editing generated files
 
-Files in `src/adk_fluent/agent.py`, `workflow.py`, and other generated modules will be **overwritten** when the generator runs. To make persistent changes:
+Files listed as "Auto-generated" above will be **overwritten** when the generator runs. To make persistent changes:
 
-1. Update `scripts/seed_generator.py` (for extras, aliases, docstrings)
-1. Update `seeds/seed.toml` or `seeds/seed.manual.toml` (for config)
-1. Update `scripts/generator.py` (for new behavior types)
-1. Regenerate: `just generate`
-1. Verify the generated output matches your intent
+1. Update `shared/scripts/seed_generator.py` (for extras, aliases, docstrings)
+1. Update `shared/seeds/seed.toml` or `shared/seeds/seed.manual.toml` (for config)
+1. Update `shared/scripts/generator.py` (for new behavior types)
+1. Regenerate Python: `just generate` — or regenerate both languages: `just generate-all`
+1. Verify the generated output matches your intent: `git diff python/src/adk_fluent ts/src/builders`
 
 ## Making Changes
 
@@ -82,18 +100,18 @@ Files in `src/adk_fluent/agent.py`, `workflow.py`, and other generated modules w
 
 1. Open an issue first to discuss the approach
 1. Fork and branch: `git checkout -b feat/description`
-1. Add tests in `tests/manual/` for hand-written code
-1. Add a cookbook example in `examples/cookbook/` if applicable
-1. Run the full suite: `just test`
+1. Add tests in `python/tests/manual/` (and/or `ts/tests/` if the feature touches TypeScript)
+1. Add a cookbook example in `python/examples/cookbook/` — and the mirrored TS version in `ts/examples/cookbook/` when applicable
+1. Run the full suite: `just test` (Python) and `just ts-test` (TypeScript), or `just test-all` for both
 1. Open a PR
 
 ### Adding a new primitive or operator
 
-1. Implement in `src/adk_fluent/_base.py`
-1. Export from `src/adk_fluent/__init__.py`
-1. Add tests in `tests/manual/`
-1. Add a cookbook example
-1. Update the README expression language tables
+1. Implement in `python/src/adk_fluent/_base.py` (Python) and `ts/src/core/builder-base.ts` + `ts/src/primitives/` (TypeScript)
+1. Export from `python/src/adk_fluent/__init__.py` and `ts/src/index.ts`
+1. Add tests in `python/tests/manual/` and `ts/tests/`
+1. Add matching cookbook examples in both `python/examples/cookbook/` and `ts/examples/cookbook/`
+1. Update the README expression language tables **and** the operator mapping in `docs/user-guide/typescript.md`
 
 ### When Google releases a new ADK version
 
@@ -103,12 +121,13 @@ For manual upgrades or to prepare a PR yourself:
 
 ```bash
 just archive                              # Save current manifest state
-uv pip install --upgrade google-adk       # Install new ADK version
-just scan                                 # Introspect new ADK → manifest.json
+cd python && uv pip install --upgrade google-adk && cd ..   # Install new ADK version
+just scan                                 # Introspect new ADK → shared/manifest.json
 just diff                                 # Review what changed (JSON diff)
-# Edit seeds/seed.manual.toml if needed   # e.g. new aliases, custom extras
-just all                                  # Regenerate code, stubs, tests, docs
-just test && just typecheck               # Verify everything passes
+# Edit shared/seeds/seed.manual.toml if needed   # e.g. new aliases, custom extras
+just all                                  # Regenerate Python code, stubs, tests, docs
+just ts-generate                          # Regenerate TypeScript builders from the same manifest
+just test-all && just typecheck           # Verify Python + TypeScript pass
 git diff --stat                           # Review generated diff
 ```
 
@@ -145,27 +164,70 @@ Skills are already installed in `.claude/skills/` and `.gemini/skills/`. See [Ag
 
 ## Code Style
 
-- We use [ruff](https://docs.astral.sh/ruff/) for linting and formatting
-- Run `uv run ruff check .` and `uv run ruff format .` before committing
-- Pre-commit hooks handle this automatically
+- **Python:** we use [ruff](https://docs.astral.sh/ruff/) for linting and formatting. Run `just lint` / `just fmt` before committing (both operate inside `python/`). Pre-commit hooks handle formatting automatically on hand-written files only — generated files are owned by `just generate`.
+- **TypeScript:** we use [eslint](https://eslint.org/) and [prettier](https://prettier.io/). Run `just ts-lint` / `cd ts && npm run format` before committing. Generated TS files under `ts/src/builders/` are owned by `just ts-generate` and should never be hand-edited.
+
+### Dual-language documentation
+
+The docs site (`docs/`) is Python-first but ships dual-language code samples for almost everything. When you add or update a code block in `docs/`, use synced `sphinx-design` tabs so readers see their chosen language across the entire site:
+
+````md
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
+```python
+from adk_fluent import Agent
+
+agent = Agent("helper", "gemini-2.5-flash").instruct("...").build()
+```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent } from "adk-fluent-ts";
+
+const agent = new Agent("helper", "gemini-2.5-flash").instruct("...").build();
+```
+:::
+::::
+````
+
+**Rules:**
+
+1. Use the sync keys **`python`** and **`ts`** exactly — anything else breaks the site-wide toggle.
+2. Pair every `:sync: python` block with a `:sync: ts` block in the same `tab-set`. Never leave a tab-set with only one language.
+3. If a feature exists only in Python, put a short callout in the TypeScript tab (e.g. "Not yet available in `adk-fluent-ts` — track in [`ts/README.md`](../../ts/README.md).") instead of omitting the tab.
+4. Shared prose lives outside the tab-set. Only *code* and language-specific callouts go inside tabs.
+5. Auto-generated pages (`docs/generated/**`) are emitted by `shared/scripts/` and don't need manual tab-set conversion — the generator will grow dual-language support separately.
 
 ## Testing
 
 ```bash
-# All tests
+# Python — everything
 just test
 
-# Specific test file
-uv run pytest tests/manual/test_operators.py -v
+# Python — specific test file
+cd python && uv run pytest tests/manual/test_operators.py -v
 
-# Cookbook examples (each is a runnable test)
-uv run pytest examples/cookbook/ -v
+# Python — cookbook examples (each is a runnable test)
+cd python && uv run pytest examples/cookbook/ -v
 
-# Type checking
-just typecheck
+# TypeScript — everything
+just ts-test
 
-# Full local CI (mirrors GitHub Actions exactly)
+# Type checking (Python stubs + hand-written)
+just typecheck && just typecheck-core
+
+# Type checking (TypeScript)
+just ts-typecheck
+
+# Full local CI (mirrors GitHub Actions exactly — Python side)
 just ci
+
+# Both languages at once
+just test-all
 ```
 
 ## Commit Messages

--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ Fluent builder API for Google's [Agent Development Kit (ADK)](https://google.git
 [![Coverage](https://codecov.io/gh/vamsiramakrishnan/adk-fluent/branch/master/graph/badge.svg)](https://codecov.io/gh/vamsiramakrishnan/adk-fluent)
 [![Status](https://img.shields.io/badge/status-beta-yellow)](https://github.com/vamsiramakrishnan/adk-fluent)
 
+> **Monorepo:** This repository is a dual-language monorepo. The Python package (`adk-fluent`) lives in [`python/`](python/) and the TypeScript package (`adk-fluent-ts`) lives in [`ts/`](ts/). Shared generation tooling, manifests, and seeds live in [`shared/`](shared/). Both packages are generated from the same manifest and expose the same surface area.
+
 ## Table of Contents
 
+- [Packages](#packages)
 - [Install](#install)
 - [Quick Start](#quick-start)
 - [Three Pathways](#three-pathways)
@@ -36,13 +39,63 @@ Fluent builder API for Google's [Agent Development Kit (ADK)](https://google.git
 - [AI Coding Skills](#ai-coding-skills)
 - [Development](#development)
 
+## Packages
+
+adk-fluent is released as two sibling packages driven by a single shared manifest. Pick the language you ship in — both expose the same builders, operators, and namespaces.
+
+| Package              | Language   | Source      | Registry                                                      | Entry README                              |
+| -------------------- | ---------- | ----------- | ------------------------------------------------------------- | ----------------------------------------- |
+| `adk-fluent`         | Python 3.11+ | [`python/`](python/) | [PyPI](https://pypi.org/project/adk-fluent/)                  | [`python/README.md`](python/README.md)    |
+| `adk-fluent-ts`      | TypeScript | [`ts/`](ts/) | npm (coming soon)                                             | [`ts/README.md`](ts/README.md)            |
+
+Shared generator scripts, ADK scan manifests, and seed files live in [`shared/`](shared/). The Python and TypeScript builders are both regenerated from `shared/manifest.json` + `shared/seeds/seed.toml`, so API parity is enforced at generation time.
+
+```text
+adk-fluent/
+├── python/      # adk-fluent (PyPI) — builders, namespaces, tests, docs fixtures
+├── ts/          # adk-fluent-ts (npm) — TypeScript port with method-chained operators
+├── shared/      # manifest.json, seeds, scripts/ (scanner, generator, doc gen)
+├── docs/        # Sphinx docs site (Python-first, TS guide embedded)
+├── skills/      # AI coding agent skills
+└── justfile     # Monorepo-aware commands (`just test`, `just ts-test`, `just test-all`)
+```
+
 ## Install
+
+### Python (`adk-fluent`)
 
 ```bash
 pip install adk-fluent
 ```
 
 Autocomplete works immediately -- the package ships with `.pyi` type stubs for every builder. Type `Agent("name").` and your IDE shows all available methods with type hints.
+
+### TypeScript (`adk-fluent-ts`)
+
+The TypeScript port mirrors the Python API surface with method-chained operators (`.then()`, `.parallel()`, `.times()`, `.fallback()`, `.outputAs()`).
+
+```bash
+# From the monorepo (until the package is published to npm)
+cd ts
+npm install
+npm run build
+```
+
+```ts
+import { Agent, Pipeline } from "adk-fluent-ts";
+
+const pipeline = new Agent("writer", "gemini-2.5-flash")
+  .instruct("Write a draft about {topic}.")
+  .writes("draft")
+  .then(
+    new Agent("reviewer", "gemini-2.5-flash")
+      .instruct("Review the draft: {draft}")
+      .writes("feedback"),
+  )
+  .build();
+```
+
+See [`ts/README.md`](ts/README.md) for the full TypeScript API, the [operator → method-chain mapping](ts/CLAUDE.md), and [`ts/examples/`](ts/examples) for runnable recipes. The rest of this README focuses on the Python package.
 
 > **Full walkthrough:** [Getting Started guide](https://vamsiramakrishnan.github.io/adk-fluent/getting-started/) covers install, credentials, first agent, and IDE setup.
 
@@ -1551,20 +1604,20 @@ A custom web frontend for interactively running and debugging all cookbook agent
 ### Quick Start (from scratch)
 
 ```bash
-# 1. Clone and install
+# 1. Clone and install the Python package
 git clone https://github.com/vamsiramakrishnan/adk-fluent.git
 cd adk-fluent
-pip install -e ".[a2a,yaml,rich]"      # or: uv sync --all-extras
+cd python && uv sync --all-extras && cd ..    # or: pip install -e "./python[a2a,yaml,rich]"
 
 # 2. Configure credentials
-cp visual/.env.example visual/.env
-# Edit visual/.env — add your Gemini API key or Vertex AI credentials
+cp python/visual/.env.example python/visual/.env
+# Edit python/visual/.env — add your Gemini API key or Vertex AI credentials
 
 # 3. Generate agent folders from cookbooks (one-time)
-just agents                             # or: uv run python scripts/cookbook_to_agents.py --force
+just agents                             # or: uv run --project python python -m shared.scripts.cookbook_to_agents --force
 
 # 4. Launch the visual runner
-just visual                             # or: uv run uvicorn visual.server:app --port 8099 --reload
+just visual                             # or: cd python && uv run uvicorn visual.server:app --port 8099 --reload
 ```
 
 Opens at **http://localhost:8099** with:
@@ -1585,11 +1638,12 @@ This exports surfaces from cookbooks 70-74 and opens a static gallery in your br
 ### Visual Regression Tests
 
 ```bash
+cd python
 uv run pytest tests/visual/ -v                      # run tests (no API key needed)
 uv run pytest tests/visual/ -v --update-golden       # update golden snapshots
 ```
 
-See [`visual/README.md`](visual/README.md) for full architecture details.
+See [`python/visual/README.md`](python/visual/README.md) for full architecture details.
 
 ## Performance
 
@@ -1600,7 +1654,7 @@ adk-fluent is a **build-time layer**. Calling `.build()` produces a native ADK o
 Verify yourself:
 
 ```bash
-python scripts/benchmark.py
+uv run --project python python shared/scripts/benchmark.py
 ```
 
 ## ADK Compatibility
@@ -1633,25 +1687,38 @@ A [weekly sync workflow](.github/workflows/sync-adk.yml) scans for new ADK relea
 
 > **Deep dive:** [Architecture & Concepts](https://vamsiramakrishnan.github.io/adk-fluent/user-guide/architecture-and-concepts/) · [IR & Backends](https://vamsiramakrishnan.github.io/adk-fluent/user-guide/ir-and-backends/)
 
-adk-fluent is **auto-generated** from the installed ADK package:
+adk-fluent is **auto-generated** from the installed ADK package. A single shared pipeline produces both the Python and TypeScript builders:
 
 ```
-scanner.py ──> manifest.json ──> seed_generator.py ──> seed.toml ──> generator.py ──> Python code
-                                      ^
-                              seed.manual.toml
-                              (hand-crafted extras)
+shared/scripts/scanner.py ─> shared/manifest.json
+                                        │
+                                        ▼
+                             shared/scripts/seed_generator.py
+                                        │
+                                        ▼
+                               shared/seeds/seed.toml  ◄── shared/seeds/seed.manual.toml
+                                        │
+                         ┌──────────────┴──────────────┐
+                         ▼                             ▼
+               shared/scripts/generator.py   shared/scripts/generator.py
+                 --target python               --target typescript
+                         │                             │
+                         ▼                             ▼
+               python/src/adk_fluent/         ts/src/builders/
+                 (builders + .pyi stubs)        (TypeScript classes)
 ```
 
-1. **Scanner** introspects all ADK modules and produces `manifest.json`
-1. **Seed Generator** classifies classes and produces `seed.toml` (merged with manual extras)
-1. **Code Generator** emits fluent builders, `.pyi` type stubs, and test scaffolds
+1. **Scanner** introspects all ADK modules and produces `shared/manifest.json`
+1. **Seed Generator** classifies classes and produces `shared/seeds/seed.toml` (merged with manual extras)
+1. **Code Generator** emits fluent builders for both Python (`python/src/adk_fluent/`) and TypeScript (`ts/src/builders/`)
 
 This means adk-fluent automatically stays in sync with ADK updates:
 
 ```bash
 pip install --upgrade google-adk
-just all   # Regenerate everything
-just test  # Verify
+just all              # Regenerate Python (scan → seed → generate → docs)
+just ts-generate      # Regenerate TypeScript from the same manifest
+just test-all         # Verify both languages
 ```
 
 ## API Reference
@@ -1728,26 +1795,65 @@ Works with Gemini CLI, Claude Code, Cursor, GitHub Copilot, Amp, and more.
 
 ## Development
 
-**Requires:** Python 3.11+, [just](https://github.com/casey/just#installation), [uv](https://docs.astral.sh/uv/)
+**Requires:** Python 3.11+, Node.js 20+, [just](https://github.com/casey/just#installation), [uv](https://docs.astral.sh/uv/)
 
 **Container:** Open in VS Code or GitHub Codespaces with the included Dev Container for a pre-configured environment.
 
-```bash
-# Setup
-uv venv .venv && source .venv/bin/activate
-uv pip install -e ".[dev]"
+### Monorepo layout
 
-# Full pipeline: scan -> seed -> generate -> docs
+```text
+adk-fluent/
+├── python/      # adk-fluent — uv-managed Python package (PyPI)
+├── ts/          # adk-fluent-ts — npm-managed TypeScript package
+├── shared/      # Manifests, seeds, generator/scanner/doc-gen scripts
+├── docs/        # Sphinx docs (built from python/ + shared/)
+├── skills/      # AI coding agent skills (auto-regenerated)
+└── justfile     # Monorepo-aware task runner
+```
+
+Generated files (`agent.py`, `config.py`, `.pyi` stubs, `ts/src/builders/*.ts`) are owned by `just generate` / `just ts-generate`. Hand-written files are owned by developers. Formatters and pre-commit hooks only touch hand-written files — see [`.gitattributes`](.gitattributes) for the full generated-file list.
+
+### First-time setup
+
+```bash
+just setup    # uv sync (python/) + npm install (ts/) + pre-commit hooks
+```
+
+### Python workflow
+
+```bash
+# Full pipeline: scan -> seed -> generate -> docs (Python)
 just all
 
-# Run tests (780+ tests)
+# Run the Python test suite (780+ tests)
 just test
 
-# Type check hand-written code
+# Type check hand-written Python code
 just typecheck-core
 
-# Local CI (lint + check-gen + test)
+# Local CI (preflight + check-gen + test)
 just ci
+```
+
+All Python commands run against `python/` under the hood — e.g. `just test` is equivalent to `cd python && uv run pytest tests/`.
+
+### TypeScript workflow
+
+```bash
+just ts-setup        # npm install inside ts/
+just ts-generate     # Regenerate TS builders from shared/manifest.json
+just ts-build        # tsc build
+just ts-typecheck    # tsc --noEmit
+just ts-lint         # eslint
+just ts-test         # vitest run
+```
+
+### Monorepo commands
+
+```bash
+just generate-all    # Regenerate Python AND TypeScript builders
+just build-all       # Generate + build both packages
+just test-all        # Run Python + TypeScript test suites
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) and the [Contributing guide](https://vamsiramakrishnan.github.io/adk-fluent/contributing/) for the full development guide.
@@ -1764,7 +1870,7 @@ See [CHANGELOG.md](CHANGELOG.md) for the full release history, or browse it on t
 
 ## Releases
 
-Only one file to edit: `src/adk_fluent/_version.py`. Everything else auto-syncs.
+Only one file to edit: `python/src/adk_fluent/_version.py`. Everything else auto-syncs. (The TypeScript package versions independently via `ts/package.json`.)
 
 ```bash
 just release patch   # or: minor, major
@@ -1775,7 +1881,7 @@ just release-tag     # creates and pushes the git tag
 # → CI auto-publishes to PyPI + rebuilds versioned docs
 ```
 
-The version in `_version.py` is the single source of truth — `pyproject.toml`, `docs/conf.py`, and the announcement banner all read from it automatically.
+The version in `python/src/adk_fluent/_version.py` is the single source of truth for the Python package — `python/pyproject.toml`, `docs/conf.py`, and the announcement banner all read from it automatically.
 
 ## License
 

--- a/README.template.md
+++ b/README.template.md
@@ -14,8 +14,11 @@ Fluent builder API for Google's [Agent Development Kit (ADK)](https://google.git
 [![Coverage](https://codecov.io/gh/vamsiramakrishnan/adk-fluent/branch/master/graph/badge.svg)](https://codecov.io/gh/vamsiramakrishnan/adk-fluent)
 [![Status](https://img.shields.io/badge/status-beta-yellow)](https://github.com/vamsiramakrishnan/adk-fluent)
 
+> **Monorepo:** This repository is a dual-language monorepo. The Python package (`adk-fluent`) lives in [`python/`](python/) and the TypeScript package (`adk-fluent-ts`) lives in [`ts/`](ts/). Shared generation tooling, manifests, and seeds live in [`shared/`](shared/). Both packages are generated from the same manifest and expose the same surface area.
+
 ## Table of Contents
 
+- [Packages](#packages)
 - [Install](#install)
 - [Quick Start](#quick-start)
 - [Three Pathways](#three-pathways)
@@ -36,13 +39,63 @@ Fluent builder API for Google's [Agent Development Kit (ADK)](https://google.git
 - [AI Coding Skills](#ai-coding-skills)
 - [Development](#development)
 
+## Packages
+
+adk-fluent is released as two sibling packages driven by a single shared manifest. Pick the language you ship in — both expose the same builders, operators, and namespaces.
+
+| Package              | Language   | Source      | Registry                                                      | Entry README                              |
+| -------------------- | ---------- | ----------- | ------------------------------------------------------------- | ----------------------------------------- |
+| `adk-fluent`         | Python 3.11+ | [`python/`](python/) | [PyPI](https://pypi.org/project/adk-fluent/)                  | [`python/README.md`](python/README.md)    |
+| `adk-fluent-ts`      | TypeScript | [`ts/`](ts/) | npm (coming soon)                                             | [`ts/README.md`](ts/README.md)            |
+
+Shared generator scripts, ADK scan manifests, and seed files live in [`shared/`](shared/). The Python and TypeScript builders are both regenerated from `shared/manifest.json` + `shared/seeds/seed.toml`, so API parity is enforced at generation time.
+
+```text
+adk-fluent/
+├── python/      # adk-fluent (PyPI) — builders, namespaces, tests, docs fixtures
+├── ts/          # adk-fluent-ts (npm) — TypeScript port with method-chained operators
+├── shared/      # manifest.json, seeds, scripts/ (scanner, generator, doc gen)
+├── docs/        # Sphinx docs site (Python-first, TS guide embedded)
+├── skills/      # AI coding agent skills
+└── justfile     # Monorepo-aware commands (`just test`, `just ts-test`, `just test-all`)
+```
+
 ## Install
+
+### Python (`adk-fluent`)
 
 ```bash
 pip install adk-fluent
 ```
 
 Autocomplete works immediately -- the package ships with `.pyi` type stubs for every builder. Type `Agent("name").` and your IDE shows all available methods with type hints.
+
+### TypeScript (`adk-fluent-ts`)
+
+The TypeScript port mirrors the Python API surface with method-chained operators (`.then()`, `.parallel()`, `.times()`, `.fallback()`, `.outputAs()`).
+
+```bash
+# From the monorepo (until the package is published to npm)
+cd ts
+npm install
+npm run build
+```
+
+```ts
+import { Agent, Pipeline } from "adk-fluent-ts";
+
+const pipeline = new Agent("writer", "gemini-2.5-flash")
+  .instruct("Write a draft about {topic}.")
+  .writes("draft")
+  .then(
+    new Agent("reviewer", "gemini-2.5-flash")
+      .instruct("Review the draft: {draft}")
+      .writes("feedback"),
+  )
+  .build();
+```
+
+See [`ts/README.md`](ts/README.md) for the full TypeScript API, the [operator → method-chain mapping](ts/CLAUDE.md), and [`ts/examples/`](ts/examples) for runnable recipes. The rest of this README focuses on the Python package.
 
 > **Full walkthrough:** [Getting Started guide](https://vamsiramakrishnan.github.io/adk-fluent/getting-started/) covers install, credentials, first agent, and IDE setup.
 
@@ -1539,20 +1592,20 @@ A custom web frontend for interactively running and debugging all cookbook agent
 ### Quick Start (from scratch)
 
 ```bash
-# 1. Clone and install
+# 1. Clone and install the Python package
 git clone https://github.com/vamsiramakrishnan/adk-fluent.git
 cd adk-fluent
-pip install -e ".[a2a,yaml,rich]"      # or: uv sync --all-extras
+cd python && uv sync --all-extras && cd ..    # or: pip install -e "./python[a2a,yaml,rich]"
 
 # 2. Configure credentials
-cp visual/.env.example visual/.env
-# Edit visual/.env — add your Gemini API key or Vertex AI credentials
+cp python/visual/.env.example python/visual/.env
+# Edit python/visual/.env — add your Gemini API key or Vertex AI credentials
 
 # 3. Generate agent folders from cookbooks (one-time)
-just agents                             # or: uv run python scripts/cookbook_to_agents.py --force
+just agents                             # or: uv run --project python python -m shared.scripts.cookbook_to_agents --force
 
 # 4. Launch the visual runner
-just visual                             # or: uv run uvicorn visual.server:app --port 8099 --reload
+just visual                             # or: cd python && uv run uvicorn visual.server:app --port 8099 --reload
 ```
 
 Opens at **http://localhost:8099** with:
@@ -1573,11 +1626,12 @@ This exports surfaces from cookbooks 70-74 and opens a static gallery in your br
 ### Visual Regression Tests
 
 ```bash
+cd python
 uv run pytest tests/visual/ -v                      # run tests (no API key needed)
 uv run pytest tests/visual/ -v --update-golden       # update golden snapshots
 ```
 
-See [`visual/README.md`](visual/README.md) for full architecture details.
+See [`python/visual/README.md`](python/visual/README.md) for full architecture details.
 
 ## Performance
 
@@ -1588,7 +1642,7 @@ adk-fluent is a **build-time layer**. Calling `.build()` produces a native ADK o
 Verify yourself:
 
 ```bash
-python scripts/benchmark.py
+uv run --project python python shared/scripts/benchmark.py
 ```
 
 ## ADK Compatibility
@@ -1621,25 +1675,38 @@ A [weekly sync workflow](.github/workflows/sync-adk.yml) scans for new ADK relea
 
 > **Deep dive:** [Architecture & Concepts](https://vamsiramakrishnan.github.io/adk-fluent/user-guide/architecture-and-concepts/) · [IR & Backends](https://vamsiramakrishnan.github.io/adk-fluent/user-guide/ir-and-backends/)
 
-adk-fluent is **auto-generated** from the installed ADK package:
+adk-fluent is **auto-generated** from the installed ADK package. A single shared pipeline produces both the Python and TypeScript builders:
 
 ```
-scanner.py ──> manifest.json ──> seed_generator.py ──> seed.toml ──> generator.py ──> Python code
-                                      ^
-                              seed.manual.toml
-                              (hand-crafted extras)
+shared/scripts/scanner.py ─> shared/manifest.json
+                                        │
+                                        ▼
+                             shared/scripts/seed_generator.py
+                                        │
+                                        ▼
+                               shared/seeds/seed.toml  ◄── shared/seeds/seed.manual.toml
+                                        │
+                         ┌──────────────┴──────────────┐
+                         ▼                             ▼
+               shared/scripts/generator.py   shared/scripts/generator.py
+                 --target python               --target typescript
+                         │                             │
+                         ▼                             ▼
+               python/src/adk_fluent/         ts/src/builders/
+                 (builders + .pyi stubs)        (TypeScript classes)
 ```
 
-1. **Scanner** introspects all ADK modules and produces `manifest.json`
-1. **Seed Generator** classifies classes and produces `seed.toml` (merged with manual extras)
-1. **Code Generator** emits fluent builders, `.pyi` type stubs, and test scaffolds
+1. **Scanner** introspects all ADK modules and produces `shared/manifest.json`
+1. **Seed Generator** classifies classes and produces `shared/seeds/seed.toml` (merged with manual extras)
+1. **Code Generator** emits fluent builders for both Python (`python/src/adk_fluent/`) and TypeScript (`ts/src/builders/`)
 
 This means adk-fluent automatically stays in sync with ADK updates:
 
 ```bash
 pip install --upgrade google-adk
-just all   # Regenerate everything
-just test  # Verify
+just all              # Regenerate Python (scan → seed → generate → docs)
+just ts-generate      # Regenerate TypeScript from the same manifest
+just test-all         # Verify both languages
 ```
 
 ## API Reference
@@ -1716,26 +1783,65 @@ Works with Gemini CLI, Claude Code, Cursor, GitHub Copilot, Amp, and more.
 
 ## Development
 
-**Requires:** Python 3.11+, [just](https://github.com/casey/just#installation), [uv](https://docs.astral.sh/uv/)
+**Requires:** Python 3.11+, Node.js 20+, [just](https://github.com/casey/just#installation), [uv](https://docs.astral.sh/uv/)
 
 **Container:** Open in VS Code or GitHub Codespaces with the included Dev Container for a pre-configured environment.
 
-```bash
-# Setup
-uv venv .venv && source .venv/bin/activate
-uv pip install -e ".[dev]"
+### Monorepo layout
 
-# Full pipeline: scan -> seed -> generate -> docs
+```text
+adk-fluent/
+├── python/      # adk-fluent — uv-managed Python package (PyPI)
+├── ts/          # adk-fluent-ts — npm-managed TypeScript package
+├── shared/      # Manifests, seeds, generator/scanner/doc-gen scripts
+├── docs/        # Sphinx docs (built from python/ + shared/)
+├── skills/      # AI coding agent skills (auto-regenerated)
+└── justfile     # Monorepo-aware task runner
+```
+
+Generated files (`agent.py`, `config.py`, `.pyi` stubs, `ts/src/builders/*.ts`) are owned by `just generate` / `just ts-generate`. Hand-written files are owned by developers. Formatters and pre-commit hooks only touch hand-written files — see [`.gitattributes`](.gitattributes) for the full generated-file list.
+
+### First-time setup
+
+```bash
+just setup    # uv sync (python/) + npm install (ts/) + pre-commit hooks
+```
+
+### Python workflow
+
+```bash
+# Full pipeline: scan -> seed -> generate -> docs (Python)
 just all
 
-# Run tests (780+ tests)
+# Run the Python test suite (780+ tests)
 just test
 
-# Type check hand-written code
+# Type check hand-written Python code
 just typecheck-core
 
-# Local CI (lint + check-gen + test)
+# Local CI (preflight + check-gen + test)
 just ci
+```
+
+All Python commands run against `python/` under the hood — e.g. `just test` is equivalent to `cd python && uv run pytest tests/`.
+
+### TypeScript workflow
+
+```bash
+just ts-setup        # npm install inside ts/
+just ts-generate     # Regenerate TS builders from shared/manifest.json
+just ts-build        # tsc build
+just ts-typecheck    # tsc --noEmit
+just ts-lint         # eslint
+just ts-test         # vitest run
+```
+
+### Monorepo commands
+
+```bash
+just generate-all    # Regenerate Python AND TypeScript builders
+just build-all       # Generate + build both packages
+just test-all        # Run Python + TypeScript test suites
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) and the [Contributing guide](https://vamsiramakrishnan.github.io/adk-fluent/contributing/) for the full development guide.
@@ -1748,7 +1854,7 @@ See [CHANGELOG.md](CHANGELOG.md) for the full release history, or browse it on t
 
 ## Releases
 
-Only one file to edit: `src/adk_fluent/_version.py`. Everything else auto-syncs.
+Only one file to edit: `python/src/adk_fluent/_version.py`. Everything else auto-syncs. (The TypeScript package versions independently via `ts/package.json`.)
 
 ```bash
 just release patch   # or: minor, major
@@ -1759,7 +1865,7 @@ just release-tag     # creates and pushes the git tag
 # → CI auto-publishes to PyPI + rebuilds versioned docs
 ```
 
-The version in `_version.py` is the single source of truth — `pyproject.toml`, `docs/conf.py`, and the announcement banner all read from it automatically.
+The version in `python/src/adk_fluent/_version.py` is the single source of truth for the Python package — `python/pyproject.toml`, `docs/conf.py`, and the announcement banner all read from it automatically.
 
 ## License
 

--- a/docs/decision-guide.md
+++ b/docs/decision-guide.md
@@ -156,17 +156,42 @@ See [Middleware](user-guide/middleware.md).
 
 ### "I want to classify and route"
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
-from adk_fluent import Agent, S, C
-from adk_fluent._routing import Route
+from adk_fluent import Agent, S, C, Route
 
 classifier = Agent("classifier", MODEL).instruct("Classify: a, b, or c").context(C.none()).writes("category")
 pipeline = S.capture("input") >> classifier >> Route("category").eq("a", agent_a).eq("b", agent_b).otherwise(agent_c)
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent, S, C, Route } from "adk-fluent-ts";
+
+const classifier = new Agent("classifier", MODEL)
+  .instruct("Classify: a, b, or c")
+  .context(C.none())
+  .writes("category");
+
+const pipeline = S.capture("input")
+  .then(classifier)
+  .then(new Route("category").eq("a", agentA).eq("b", agentB).otherwise(agentC));
+```
+:::
+::::
 
 See [Cookbook: Customer Support Triage](cookbook/hero-workflows/customer-support-triage.md)
 
 ### "I want parallel search then synthesis"
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from adk_fluent import Agent, C
@@ -177,10 +202,32 @@ results = (
 )
 pipeline = results >> Agent("synth", MODEL).instruct("Synthesize {web} and {papers}.")
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent } from "adk-fluent-ts";
+
+const results = new Agent("web", MODEL)
+  .instruct("Search web.")
+  .writes("web")
+  .parallel(new Agent("papers", MODEL).instruct("Search papers.").writes("papers"));
+
+const pipeline = results.then(
+  new Agent("synth", MODEL).instruct("Synthesize {web} and {papers}."),
+);
+```
+:::
+::::
 
 See [Cookbook: Deep Research](cookbook/hero-workflows/deep-research.md)
 
 ### "I want write-review-revise loop"
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from adk_fluent import Agent
@@ -190,10 +237,29 @@ loop = (
     >> Agent("critic", MODEL).instruct("Score 0-1.").writes("score")
 ).loop_until(lambda s: float(s.get("score", 0)) >= 0.8, max_iterations=3)
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent } from "adk-fluent-ts";
+
+const loop = new Agent("writer", MODEL)
+  .instruct("Write.")
+  .writes("draft")
+  .then(new Agent("critic", MODEL).instruct("Score 0-1.").writes("score"))
+  .timesUntil((s) => Number(s.score ?? 0) >= 0.8, { max: 3 });
+```
+:::
+::::
 
 See [Patterns: review_loop](user-guide/patterns.md)
 
 ### "I want to test without API calls"
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from adk_fluent import Agent
@@ -206,6 +272,21 @@ harness = AgentHarness(
 response = await harness.send("Hi")
 assert response.final_text == "I can help!"
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent } from "adk-fluent-ts";
+
+const helper = new Agent("helper", "gemini-2.5-flash")
+  .instruct("Help.")
+  .mock({ helper: "I can help!" });
+
+const response = await helper.askAsync("Hi");
+```
+:::
+::::
 
 See [Testing](user-guide/testing.md)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,6 +8,15 @@ This page gets you from zero to a working agent in 5 minutes.
 By the end, you'll understand the builder pattern, the expression operators,
 and when to use each.
 
+:::{note} Python and TypeScript
+`adk-fluent` ships as two sibling packages from a single monorepo:
+
+- **`adk-fluent`** (Python 3.11+, [PyPI](https://pypi.org/project/adk-fluent/)) — lives in [`python/`](https://github.com/vamsiramakrishnan/adk-fluent/tree/master/python). This documentation is Python-first.
+- **`adk-fluent-ts`** (TypeScript, not yet published) — lives in [`ts/`](https://github.com/vamsiramakrishnan/adk-fluent/tree/master/ts). Mirrors the same builders and namespaces with method-chained operators (`.then()`, `.parallel()`, `.times()`, `.fallback()`, `.outputAs()`). See [`ts/README.md`](https://github.com/vamsiramakrishnan/adk-fluent/blob/master/ts/README.md) for the TS quick start.
+
+Both packages are regenerated from the same `shared/manifest.json`, so the API surface stays in sync by construction.
+:::
+
 ## Install
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,22 +8,38 @@ This page gets you from zero to a working agent in 5 minutes.
 By the end, you'll understand the builder pattern, the expression operators,
 and when to use each.
 
-:::{note} Python and TypeScript
-`adk-fluent` ships as two sibling packages from a single monorepo:
+:::{note} Python and TypeScript — click a tab once
+Most code samples on this page come with a **Python** / **TypeScript** tab. Click either — every other synced tab across the docs follows your choice, and the preference sticks as you navigate. The conceptual content is the same in both languages; only the operator syntax differs (Python uses `>>` / `|` / `*` / `//` / `@`, TypeScript uses `.then()` / `.parallel()` / `.times()` / `.fallback()` / `.outputAs()`).
 
-- **`adk-fluent`** (Python 3.11+, [PyPI](https://pypi.org/project/adk-fluent/)) — lives in [`python/`](https://github.com/vamsiramakrishnan/adk-fluent/tree/master/python). This documentation is Python-first.
-- **`adk-fluent-ts`** (TypeScript, not yet published) — lives in [`ts/`](https://github.com/vamsiramakrishnan/adk-fluent/tree/master/ts). Mirrors the same builders and namespaces with method-chained operators (`.then()`, `.parallel()`, `.times()`, `.fallback()`, `.outputAs()`). See [`ts/README.md`](https://github.com/vamsiramakrishnan/adk-fluent/blob/master/ts/README.md) for the TS quick start.
-
-Both packages are regenerated from the same `shared/manifest.json`, so the API surface stays in sync by construction.
+If you picked **TypeScript**, also read the {doc}`user-guide/typescript` landing page for install, imports, and the full operator-mapping reference. Both packages are regenerated from the same `shared/manifest.json` in [`shared/`](https://github.com/vamsiramakrishnan/adk-fluent/tree/master/shared), so the API surface stays in sync by construction.
 :::
 
 ## Install
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```bash
 pip install adk-fluent
 ```
 
 Autocomplete works immediately -- the package ships with `.pyi` type stubs for every builder. Type `Agent("name").` and your IDE shows all available methods with type hints.
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```bash
+# adk-fluent-ts lives in the monorepo (not yet on npm)
+git clone https://github.com/vamsiramakrishnan/adk-fluent.git
+cd adk-fluent/ts
+npm install
+npm run build
+```
+
+Autocomplete works out of the box — the package is written in TypeScript, so hover-docs and type inference light up immediately in VS Code, JetBrains, Neovim (with `tsserver`), and any LSP-aware editor. See {doc}`user-guide/typescript` for install, imports, and the operator-mapping reference.
+:::
+::::
 
 ## IDE Setup
 
@@ -67,17 +83,38 @@ In native ADK, `LlmAgent(instuction="...")` silently ignores the misspelled keyw
 
 ## Your First Agent
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 from adk_fluent import Agent
 
 agent = Agent("helper", "gemini-2.5-flash").instruct("You are a helpful assistant.").build()
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
 
-That's it. `agent` is a real `google.adk.agents.llm_agent.LlmAgent` -- use it with `adk web`, `adk run`, or pass it to any ADK API.
+```ts
+import { Agent } from "adk-fluent-ts";
+
+const agent = new Agent("helper", "gemini-2.5-flash")
+  .instruct("You are a helpful assistant.")
+  .build();
+```
+:::
+::::
+
+That's it. `agent` is a real native ADK `LlmAgent` object — use it with `adk web`, `adk run`, or pass it to any ADK API. The TypeScript build returns an `@google/adk` `LlmAgent`; the Python build returns a `google.adk.agents.llm_agent.LlmAgent`. Same semantics, same field names, different runtime.
 
 ## Your First Pipeline
 
-Chain agents sequentially with `.step()` or the `>>` operator:
+Chain agents sequentially with the `Pipeline` builder or the sequential operator — `>>` in Python, `.then()` in TypeScript.
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from adk_fluent import Agent, Pipeline
@@ -96,12 +133,37 @@ pipeline = (
     >> Agent("writer", "gemini-2.5-flash").instruct("Write a summary.")
 ).build()
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
 
-Both produce an identical `SequentialAgent`. The builder style shines when each step needs callbacks, tools, and context engineering. The operator style excels at composing reusable sub-expressions.
+```ts
+import { Agent, Pipeline } from "adk-fluent-ts";
+
+// Builder style -- explicit, great for complex configurations
+const pipeline = new Pipeline("research")
+  .step(new Agent("searcher", "gemini-2.5-flash").instruct("Search for information."))
+  .step(new Agent("writer", "gemini-2.5-flash").instruct("Write a summary."))
+  .build();
+
+// Method-chain style -- concise, great for composing reusable parts
+const pipeline2 = new Agent("searcher", "gemini-2.5-flash")
+  .instruct("Search for information.")
+  .then(new Agent("writer", "gemini-2.5-flash").instruct("Write a summary."))
+  .build();
+```
+:::
+::::
+
+Both produce an identical `SequentialAgent`. The builder style shines when each step needs callbacks, tools, and context engineering. The operator / method-chain style excels at composing reusable sub-expressions.
 
 ## Parallel Execution
 
-Run agents concurrently with `.branch()` or the `|` operator:
+Run agents concurrently with `FanOut` or the parallel operator — `|` in Python, `.parallel()` in TypeScript.
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from adk_fluent import Agent, FanOut
@@ -119,10 +181,34 @@ fanout = (
     | Agent("papers", "gemini-2.5-flash").instruct("Search papers.")
 ).build()
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent, FanOut } from "adk-fluent-ts";
+
+const fanout = new FanOut("parallel_research")
+  .branch(new Agent("web", "gemini-2.5-flash").instruct("Search the web."))
+  .branch(new Agent("papers", "gemini-2.5-flash").instruct("Search papers."))
+  .build();
+
+// Or with the method-chain operator:
+const fanout2 = new Agent("web", "gemini-2.5-flash")
+  .instruct("Search the web.")
+  .parallel(new Agent("papers", "gemini-2.5-flash").instruct("Search papers."))
+  .build();
+```
+:::
+::::
 
 ## Loops
 
-Iterate until a condition is met:
+Iterate a fixed number of times — `* 3` in Python, `.times(3)` in TypeScript. Use `Loop` / `loop_until` / `timesUntil` when you need a predicate-driven exit.
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from adk_fluent import Agent, Loop
@@ -141,28 +227,73 @@ loop = (
     >> Agent("critic", "gemini-2.5-flash").instruct("Critique.")
 ) * 3
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent, Loop } from "adk-fluent-ts";
+
+const loop = new Loop("refine")
+  .step(new Agent("writer", "gemini-2.5-flash").instruct("Write draft."))
+  .step(new Agent("critic", "gemini-2.5-flash").instruct("Critique."))
+  .maxIterations(3)
+  .build();
+
+// Or with the method-chain operator:
+const loop2 = new Agent("writer", "gemini-2.5-flash")
+  .instruct("Write draft.")
+  .then(new Agent("critic", "gemini-2.5-flash").instruct("Critique."))
+  .times(3)
+  .build();
+```
+:::
+::::
 
 ## Two Styles, Same Result
 
 Every workflow can be expressed two ways. Both produce identical ADK objects:
 
 ::::{tab-set}
-:::{tab-item} Builder Style
+:::{tab-item} Python
+:sync: python
+
 ```python
+# Builder style
 pipeline = (
     Pipeline("research")
     .step(Agent("web", "gemini-2.5-flash").instruct("Search web.").writes("web_data"))
     .step(Agent("analyst", "gemini-2.5-flash").instruct("Analyze {web_data}."))
     .build()
 )
-```
-:::
-:::{tab-item} Operator Style
-```python
+
+# Operator style
 pipeline = (
     Agent("web", "gemini-2.5-flash").instruct("Search web.").writes("web_data")
     >> Agent("analyst", "gemini-2.5-flash").instruct("Analyze {web_data}.")
 ).build()
+```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+// Builder style
+const pipeline = new Pipeline("research")
+  .step(
+    new Agent("web", "gemini-2.5-flash")
+      .instruct("Search web.")
+      .writes("web_data"),
+  )
+  .step(new Agent("analyst", "gemini-2.5-flash").instruct("Analyze {web_data}."))
+  .build();
+
+// Method-chain style
+const pipeline2 = new Agent("web", "gemini-2.5-flash")
+  .instruct("Search web.")
+  .writes("web_data")
+  .then(new Agent("analyst", "gemini-2.5-flash").instruct("Analyze {web_data}."))
+  .build();
 ```
 :::
 ::::

--- a/docs/index.md
+++ b/docs/index.md
@@ -105,16 +105,46 @@ hide-toc: true
 ## Before / After
 
 ::::{tab-set}
-:::{tab-item} adk-fluent (5 lines)
+:::{tab-item} adk-fluent — Python
+:sync: python
+
 ```python
-from adk_fluent import Agent, S, C
+from adk_fluent import Agent, C
 
 research = (
     Agent("analyzer", "gemini-2.5-flash").instruct("Decompose the query.").writes("plan")
     >> (Agent("web", "gemini-2.5-flash").instruct("Search web.").context(C.from_state("plan")).writes("web")
         | Agent("papers", "gemini-2.5-flash").instruct("Search papers.").context(C.from_state("plan")).writes("papers"))
     >> Agent("writer", "gemini-2.5-flash").instruct("Synthesize findings from {web} and {papers}.")
-)
+).build()
+```
+:::
+:::{tab-item} adk-fluent — TypeScript
+:sync: ts
+
+```ts
+import { Agent, C } from "adk-fluent-ts";
+
+const research = new Agent("analyzer", "gemini-2.5-flash")
+  .instruct("Decompose the query.")
+  .writes("plan")
+  .then(
+    new Agent("web", "gemini-2.5-flash")
+      .instruct("Search web.")
+      .context(C.fromState("plan"))
+      .writes("web")
+      .parallel(
+        new Agent("papers", "gemini-2.5-flash")
+          .instruct("Search papers.")
+          .context(C.fromState("plan"))
+          .writes("papers"),
+      ),
+  )
+  .then(
+    new Agent("writer", "gemini-2.5-flash")
+      .instruct("Synthesize findings from {web} and {papers}."),
+  )
+  .build();
 ```
 :::
 :::{tab-item} Native ADK (22 lines)
@@ -143,15 +173,15 @@ research = SequentialAgent(
 :::
 ::::
 
-Every `.build()` returns a real ADK object -- fully compatible with `adk web`, `adk run`, and `adk deploy`.
+Every `.build()` returns a real ADK object -- fully compatible with `adk web`, `adk run`, and `adk deploy`. **Click a tab** — your Python/TypeScript choice is remembered across every code sample on this site.
 
 :::{note} Python + TypeScript monorepo
 adk-fluent ships as two sibling packages from a single monorepo:
 
-- **`adk-fluent`** ([PyPI](https://pypi.org/project/adk-fluent/)) — Python 3.11+, under [`python/`](https://github.com/vamsiramakrishnan/adk-fluent/tree/master/python). The reference implementation and the focus of these docs.
-- **`adk-fluent-ts`** (npm, coming soon) — TypeScript, under [`ts/`](https://github.com/vamsiramakrishnan/adk-fluent/tree/master/ts). Mirrors the same builders and namespaces with method-chained operators (`.then()`, `.parallel()`, `.times()`, `.fallback()`, `.outputAs()`). See the [TypeScript README](https://github.com/vamsiramakrishnan/adk-fluent/blob/master/ts/README.md).
+- **`adk-fluent`** ([PyPI](https://pypi.org/project/adk-fluent/)) — Python 3.11+, under [`python/`](https://github.com/vamsiramakrishnan/adk-fluent/tree/master/python). Reference implementation; this site is Python-first.
+- **`adk-fluent-ts`** (npm, coming soon) — TypeScript, under [`ts/`](https://github.com/vamsiramakrishnan/adk-fluent/tree/master/ts). Mirrors the same builders and namespaces with method-chained operators. See the [TypeScript user guide](user-guide/typescript.md) and the [TS README](https://github.com/vamsiramakrishnan/adk-fluent/blob/master/ts/README.md).
 
-Both packages are generated from the same `shared/manifest.json`, so parity is enforced at generation time. Guides on this site apply to both languages; operator differences are called out inline.
+Both packages are generated from the same `shared/manifest.json`, so parity is enforced at generation time. Throughout this site, conceptual guides apply to both languages; code samples with a `Python` / `TypeScript` tab selector stay in sync once you pick one.
 :::
 
 ## What's New in v{{version}}
@@ -356,6 +386,8 @@ Complete reference for all 135 builders.
 
 **"I want my AI coding agent to know adk-fluent"** -- Set up [Editor & AI Agent Setup](editor-setup/index.md) for rules files, skills, and MCP servers.
 
+**"I'm using TypeScript, not Python"** -- Start with the [TypeScript user guide](user-guide/typescript.md). Every conceptual chapter in this site applies to both languages; code samples have a synced `Python` / `TypeScript` tab.
+
 ---
 
 [PyPI](https://pypi.org/project/adk-fluent/) · [GitHub](https://github.com/vamsiramakrishnan/adk-fluent) · [Changelog](changelog.md) · [Contributing](contributing/index.md)
@@ -366,6 +398,7 @@ maxdepth: 2
 caption: Getting Started
 ---
 getting-started
+user-guide/typescript
 editor-setup/index
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -145,6 +145,15 @@ research = SequentialAgent(
 
 Every `.build()` returns a real ADK object -- fully compatible with `adk web`, `adk run`, and `adk deploy`.
 
+:::{note} Python + TypeScript monorepo
+adk-fluent ships as two sibling packages from a single monorepo:
+
+- **`adk-fluent`** ([PyPI](https://pypi.org/project/adk-fluent/)) — Python 3.11+, under [`python/`](https://github.com/vamsiramakrishnan/adk-fluent/tree/master/python). The reference implementation and the focus of these docs.
+- **`adk-fluent-ts`** (npm, coming soon) — TypeScript, under [`ts/`](https://github.com/vamsiramakrishnan/adk-fluent/tree/master/ts). Mirrors the same builders and namespaces with method-chained operators (`.then()`, `.parallel()`, `.times()`, `.fallback()`, `.outputAs()`). See the [TypeScript README](https://github.com/vamsiramakrishnan/adk-fluent/blob/master/ts/README.md).
+
+Both packages are generated from the same `shared/manifest.json`, so parity is enforced at generation time. Guides on this site apply to both languages; operator differences are called out inline.
+:::
+
 ## What's New in v{{version}}
 
 ::::{grid} 1 1 2 3

--- a/docs/llms-ts.txt
+++ b/docs/llms-ts.txt
@@ -58,88 +58,94 @@ Sub-builders passed to workflow builders are auto-built — do not call
     const pipeline2 = writer.then(reviewer).times(3).build();
 ## Namespace modules (S, C, P, A, M, T, E, G)
 
+All namespaces mirror the Python API with TypeScript idioms: camelCase
+method names, method-chained composition via ``.pipe()`` / ``.add()``, and
+options-object arguments instead of keyword arguments.  JavaScript reserved
+words (``default``) use a trailing underscore (``S.default_``, ``C.default_``).
+
 ### S — State transforms
 
-Used with `>>` operator. Compose with `>>` (chain) or `+` (combine).
+Used in pipelines via ``.then()``.  Compose with ``.pipe()`` (chain) or
+``.add()`` (combine).
 
-  S.pick(*keys)                — keep only named keys
-  S.drop(*keys)                — remove named keys
-  S.rename(**mapping)          — rename keys
-  S.merge(*keys, into=)        — combine keys
+  S.pick(...keys)              — keep only named keys
+  S.drop(...keys)              — remove named keys
+  S.rename({old: "new"})       — rename keys
+  S.merge_([keys], "into")     — combine keys (note trailing underscore)
   S.transform(key, fn)         — apply function to value
-  S.compute(**factories)       — derive new keys from state
-  S.set(**kv)                  — set explicit key-value pairs
-  S.default(**kv)              — fill missing keys with defaults
-  S.guard(pred, msg=)          — assert state invariant
+  S.compute({key: fn, ...})    — derive new keys from state
+  S.set({k: v})                — set explicit key-value pairs
+  S.default_({k: v})           — fill missing keys with defaults
+  S.guard(pred, msg?)          — assert state invariant
   S.when(pred, transform)      — conditional transform
-  S.branch(key, **transforms)  — route to different transforms
-  S.capture(*keys)             — capture function args into state
+  S.branch(key, {match: tr})   — route to different transforms
+  S.capture(...keys)           — capture function args into state
   S.identity()                 — pass-through (no-op)
   S.accumulate(key)            — append to list in state
   S.counter(key)               — increment counter in state
   S.history(key)               — maintain history list
-  S.validate(**schemas)        — validate state keys against schemas
-  S.require(*keys)             — assert keys exist
+  S.validate({k: schema})      — validate state keys against schemas
+  S.require(...keys)           — assert keys exist
   S.flatten(key)               — flatten nested dict
-  S.unflatten(key, sep=".")    — unflatten dotted keys
-  S.zip(*keys, into=)          — zip parallel lists
-  S.group_by(key, by=)         — group items by field
-  S.log(*keys)                 — log state keys to stderr
+  S.unflatten(key, {sep})      — unflatten dotted keys
+  S.zip(...keys, "into")       — zip parallel lists
+  S.groupBy(key, {by})         — group items by field
+  S.log(...keys)               — log state keys
 
 ### C — Context engineering
 
-Used with `.context()`. Compose with `+` (union) or `|` (pipe).
+Used with ``.context()``.  Compose with ``.add()`` (union) or ``.pipe()``.
 
   C.none()                     — suppress all history
-  C.default()                  — default ADK behavior
-  C.user_only()                — only user messages
-  C.window(n=5)                — last N turn-pairs
-  C.from_state(*keys)          — inject state keys as context
-  C.from_agents(*names)        — user + named agent outputs
-  C.from_agents_windowed(n=)   — windowed agent output filtering
-  C.exclude_agents(*names)     — exclude named agents
+  C.default_()                 — default ADK behavior
+  C.userOnly()                 — only user messages
+  C.window(n)                  — last N turn-pairs
+  C.fromState(...keys)         — inject state keys as context
+  C.fromAgents(...names)       — user + named agent outputs
+  C.fromAgentsWindowed({n})    — windowed agent output filtering
+  C.excludeAgents(...names)    — exclude named agents
   C.template(text)             — template with {key} placeholders
-  C.select(*agent_names)       — select specific agents
-  C.recent(n=)                 — recent messages only
+  C.select(...agentNames)      — select specific agents
+  C.recent({n})                — recent messages only
   C.compact()                  — remove redundant messages
   C.dedup()                    — remove duplicate messages
-  C.truncate(max_turns=)       — hard limit
-  C.project(*fields)           — project specific fields
-  C.budget(max_tokens=)        — token budget constraint
-  C.priority(*keys)            — prioritize certain context
-  C.fit(max_tokens=)           — fit within token limit
-  C.fresh(max_age=)            — filter by recency
-  C.redact(*patterns)          — redact sensitive content
-  C.summarize(scope=)          — LLM-powered summarization
-  C.relevant(query_key=)       — semantic relevance filtering
-  C.extract(key=)              — extract structured data
+  C.truncate({maxTurns})       — hard limit
+  C.project(...fields)         — project specific fields
+  C.budget({maxTokens})        — token budget constraint
+  C.priority(...keys)          — prioritize certain context
+  C.fit({maxTokens})           — fit within token limit
+  C.fresh({maxAge})            — filter by recency
+  C.redact(...patterns)        — redact sensitive content
+  C.summarize({scope})         — LLM-powered summarization
+  C.relevant({queryKey})       — semantic relevance filtering
+  C.extract({key})             — extract structured data
   C.distill()                  — distill to key points
   C.validate()                 — validate context integrity
   C.notes()                    — attach notes
-  C.write_notes()              — persist notes to state
-  C.rolling(n=)                — rolling window with compaction
+  C.writeNotes()               — persist notes to state
+  C.rolling({n})               — rolling window with compaction
   C.user()                     — user messages only (alias)
-  C.manus_cascade()            — Manus-style cascading context
+  C.manusCascade()             — Manus-style cascading context
   C.when(pred, transform)      — conditional context transform
 
 ### P — Prompt composition
 
-Used with `.instruct()`. Compose with `+` (union) or `|` (pipe).
+Used with ``.instruct()``.  Compose with ``.add()`` (union) or ``.pipe()``.
 Section order: role → context → task → constraint → format → example.
 
   P.role(text)                 — agent persona
   P.context(text)              — background context
   P.task(text)                 — primary objective
-  P.constraint(*rules)         — constraints/rules
+  P.constraint(...rules)       — constraints/rules
   P.format(text)               — output format spec
-  P.example(input=, output=)   — few-shot examples
+  P.example({input, output})   — few-shot examples (options object)
   P.section(name, text)        — custom named section
   P.when(pred, block)          — conditional inclusion
-  P.from_state(*keys)          — dynamic state injection
+  P.fromState(...keys)         — dynamic state injection
   P.template(text)             — {key}, {key?}, {ns:key} placeholders
-  P.reorder(*sections)         — reorder sections
-  P.only(*sections)            — include only named sections
-  P.without(*sections)         — exclude named sections
+  P.reorder(...sections)       — reorder sections
+  P.only(...sections)          — include only named sections
+  P.without(...sections)       — exclude named sections
   P.compress()                 — compress verbose prompts
   P.adapt(fn)                  — transform prompt dynamically
   P.scaffolded(structure)      — structured prompt scaffold
@@ -147,146 +153,162 @@ Section order: role → context → task → constraint → format → example.
 
 ### A — Artifacts
 
-Used with `.artifacts()` or `>>`. Compose with `>>` (chain).
+Used with ``.artifacts()`` or ``.then()``.  Compose with ``.pipe()``.
 
-  A.publish(filename, from_key=) — state → artifact
-  A.snapshot(filename, into_key=) — artifact → state
-  A.save(filename, content=)    — content → artifact
+  A.publish(filename, {fromKey}) — state → artifact
+  A.snapshot(filename, {intoKey}) — artifact → state
+  A.save(filename, {content})   — content → artifact
   A.load(filename)              — artifact → pipeline
   A.list()                      — list available artifacts
   A.version(filename)           — get artifact version
-  A.delete(filename)            — delete artifact
-  A.publish_many(**mapping)     — batch publish multiple artifacts
-  A.snapshot_many(**mapping)    — batch snapshot multiple artifacts
-  A.for_llm()                  — context transform for LLM-aware loading
-  A.when(pred, transform)      — conditional artifact operation
-  A.from_json() / A.from_csv() / A.from_markdown() — content transforms (pre-publish)
-  A.as_json() / A.as_csv() / A.as_text() — content transforms (post-snapshot)
+  A.delete_(filename)           — delete artifact (reserved word)
+  A.publishMany({mapping})      — batch publish multiple artifacts
+  A.snapshotMany({mapping})     — batch snapshot multiple artifacts
+  A.forLlm()                    — context transform for LLM-aware loading
+  A.when(pred, transform)       — conditional artifact operation
+  A.fromJson() / A.fromCsv() / A.fromMarkdown() — content transforms (pre-publish)
+  A.asJson() / A.asCsv() / A.asText() — content transforms (post-snapshot)
 
 ### M — Middleware
 
-Used with `.middleware()`. Compose with `|` (chain).
+Used with ``.middleware()``.  Compose with ``.pipe()`` (chain).
+Most factories take an options object.
 
-  M.retry(max_attempts=)       — retry with exponential backoff
+  M.retry({maxAttempts})       — retry with exponential backoff
   M.log()                      — structured event logging
   M.cost()                     — token usage tracking
   M.latency()                  — per-agent latency tracking
-  M.scope(agents, mw)          — restrict middleware to agents
+  M.scope([agents], mw)        — restrict middleware to agents
   M.when(condition, mw)        — conditional middleware
-  M.circuit_breaker(max_fails=) — circuit breaker pattern
-  M.timeout(seconds)           — per-agent timeout
-  M.cache(ttl=)                — response caching
-  M.fallback_model(model)      — fallback to different model
+  M.circuitBreaker({maxFails}) — circuit breaker pattern
+  M.timeout({seconds})         — per-agent timeout
+  M.cache({ttl})               — response caching
+  M.fallbackModel(model)       — fallback to different model
   M.dedup()                    — deduplicate requests
-  M.sample(rate=)              — probabilistic sampling
+  M.sample({rate})             — probabilistic sampling
   M.trace()                    — distributed tracing
   M.metrics()                  — metrics collection
-  M.before_agent(fn)           — pre-agent hook
-  M.after_agent(fn)            — post-agent hook
-  M.before_model(fn)           — pre-model hook
-  M.after_model(fn)            — post-model hook
-  M.on_loop(fn)                — loop iteration hook
-  M.on_timeout(fn)             — timeout event hook
-  M.on_route(fn)               — routing event hook
-  M.on_fallback(fn)            — fallback event hook
+  M.beforeAgent(fn)            — pre-agent hook
+  M.afterAgent(fn)             — post-agent hook
+  M.beforeModel(fn)            — pre-model hook
+  M.afterModel(fn)             — post-model hook
+  M.onLoop(fn)                 — loop iteration hook
+  M.onTimeout(fn)              — timeout event hook
+  M.onRoute(fn)                — routing event hook
+  M.onFallback(fn)             — fallback event hook
 
 ### T — Tool composition
 
-Used with `.tools()`. Compose with `|` (chain).
+Used with ``.tools()``.  Compose with ``.pipe()`` (chain).
 
   T.fn(callable)               — wrap callable as FunctionTool
   T.agent(agent)               — wrap agent as AgentTool
-  T.google_search()            — built-in Google Search
+  T.googleSearch()             — built-in Google Search
   T.search(registry)           — BM25-indexed dynamic loading
   T.toolset(toolset)           — wrap MCPToolset or similar
   T.schema(schema)             — attach ToolSchema
   T.mock(responses)            — mock tool for testing
-  T.confirm(prompt=)           — human confirmation wrapper
-  T.timeout(seconds)           — tool timeout wrapper
-  T.cache(ttl=)                — tool response caching
+  T.confirm({prompt})          — human confirmation wrapper
+  T.timeout({seconds})         — tool timeout wrapper
+  T.cache({ttl})               — tool response caching
   T.mcp(server)                — MCP server tool
   T.openapi(spec)              — OpenAPI spec tool
   T.transform(fn)              — transform tool output
 
 ### E — Evaluation
 
-Used with `.eval()` and `.eval_suite()`. Build evaluation criteria and test suites.
+Used with ``.eval()`` / ``.evalSuite()``.  Build evaluation criteria and
+test suites.
 
-  E.case(prompt, expect=)      — single evaluation case
+  E.case(prompt, {expect})     — single evaluation case
   E.criterion(name, fn)        — custom evaluation criterion
-  E.persona(name, style=)      — persona for evaluation
+  E.persona(name, {style})     — persona for evaluation
   EvalSuite                    — collection of eval cases
   EvalReport                   — evaluation results
   ComparisonReport             — compare multiple agents/models
 
 ### G — Guards (output validation)
 
-Used with `.guard()`. Guards validate/transform the LLM response (after_model).
-Compose with `|` (chain). Raise GuardViolation on failure.
+Used with ``.guard()``.  Guards validate/transform the LLM response
+(afterModel).  Compose with ``.pipe()`` (chain).  Throws ``GuardViolation``
+on failure.
 
-  G.guard(fn)                  — custom guard function (fn receives llm_response)
-  G.pii(detector=)             — detect and block/redact PII in output
-  G.toxicity(threshold=)       — block toxic content above threshold
-  G.length(max=)               — enforce max response length
-  G.schema(model)              — validate output against Pydantic model
+  G.guard(fn)                  — custom guard function
+  G.pii({action, detector})    — detect and block/redact PII in output
+  G.toxicity({threshold, judge}) — block toxic content above threshold
+  G.length({min, max})         — enforce length bounds
+  G.regex(pattern, {action})   — block or redact pattern matches
+  G.schema(schema)             — validate output against schema
+  G.output(schema)             — post-model schema validation
+  G.input(schema)              — pre-model input schema validation
+  G.budget({maxTokens})        — token budget constraint
+  G.rateLimit({rpm})           — requests-per-minute limit
+  G.maxTurns(n)                — cap conversation turns
+  G.topic({deny})              — block specific topics
+  G.grounded({sourcesKey})     — verify output is grounded in sources
+  G.hallucination({threshold}) — detect hallucinated content
+  G.when(pred, guard)          — conditional guard
+  G.dlp({project, infoTypes, location}) — Google Cloud DLP detector
+  G.regexDetector([patterns])  — lightweight regex-based PII detector
+  G.multi(...detectors)        — union of multiple detectors
   GuardViolation               — raised when a guard check fails
-  PIIDetector                  — PII detection provider
-  ContentJudge                 — content judgment provider
+  PIIDetector                  — PII detection provider type
+  ContentJudge                 — content judgment provider type
 
 ### UI — Agent-to-UI composition (A2UI)
 
-Declarative UI composition for agents. Compose with `|` (Row), `>>` (Column).
-Import: ``from adk_fluent import UI`` or ``from adk_fluent._ui import UI``.
+Declarative UI composition for agents.  Compose with ``.pipe()`` / ``.add()``.
+Import: ``import { UI } from "adk-fluent-ts";``
 
 Component factories:
-  UI.text(content, variant=)   — text content (h1-h5, caption, body)
-  UI.button(label, action=)    — clickable button
-  UI.text_field(label, bind=)  — text input with optional data binding
-  UI.image(src, alt=, fit=)    — display an image
-  UI.row(*children)            — horizontal layout
-  UI.column(*children)         — vertical layout
-  UI.component(kind, **props)  — generic escape hatch
+  UI.text(content, {variant})  — text content (h1-h5, caption, body)
+  UI.button(label, {action})   — clickable button
+  UI.textField(label, {bind})  — text input with optional data binding
+  UI.image(src, {alt, fit})    — display an image
+  UI.row(...children)          — horizontal layout
+  UI.column(...children)       — vertical layout
+  UI.component(kind, props)    — generic escape hatch
 
 Data binding & validation:
   UI.bind(path)                — create data binding to JSON Pointer path
-  UI.required(msg=)            — required field validation
-  UI.email(msg=)               — email format validation
+  UI.required({msg})           — required field validation
+  UI.email({msg})              — email format validation
 
 Surface lifecycle:
-  UI.surface(name, *children)  — create named surface (compilation root)
-  UI.auto(catalog=)            — LLM-guided mode (agent decides UI)
+  UI.surface(name, ...children) — create named surface (compilation root)
+  UI.auto({catalog})           — LLM-guided mode (agent decides UI)
 
 Presets:
-  UI.form(title, fields=)      — form surface from field spec
-  UI.dashboard(title, cards=)  — dashboard with metric cards
-  UI.wizard(title, steps=)     — multi-step wizard
+  UI.form(title, {fields})     — form surface from field spec
+  UI.dashboard(title, {cards}) — dashboard with metric cards
+  UI.wizard(title, {steps})    — multi-step wizard
   UI.confirm(message)          — confirmation dialog
-  UI.table(columns, data_bind=) — data table
+  UI.table({columns, dataBind}) — data table
 
 Agent integration:
   Agent.ui(spec)               — attach UI surface to agent
   T.a2ui()                     — A2UI toolset for LLM-guided mode
-  G.a2ui(max_components=)      — validate LLM-generated UI
-  P.ui_schema()                — inject catalog schema into prompt
-  S.to_ui(*keys, surface=)     — bridge state → A2UI data model
-  S.from_ui(*keys, surface=)   — bridge A2UI data model → state
-  M.a2ui_log(level=)           — log A2UI surface operations
-  C.with_ui(surface_id=)       — include UI state in context
+  G.a2ui({maxComponents})      — validate LLM-generated UI
+  P.uiSchema()                 — inject catalog schema into prompt
+  S.toUi(...keys, {surface})   — bridge state → A2UI data model
+  S.fromUi(...keys, {surface}) — bridge A2UI data model → state
+  M.a2uiLog({level})           — log A2UI surface operations
+  C.withUi({surfaceId})        — include UI state in context
 ## Builder inventory
 
-132 builders across 9 modules.
+135 builders across 9 modules.
 
-### agent module (2 builders)
+### agent module (3 builders)
 
-BaseAgent, Agent
+BaseAgent, Agent, RemoteA2aAgent
 
-### config module (38 builders)
+### config module (39 builders)
 
-AgentConfig, BaseAgentConfig, AgentRefConfig, ArgumentConfig, CodeConfig, ContextCacheConfig, LlmAgentConfig, LoopAgentConfig, ParallelAgentConfig, RunConfig, ToolThreadPoolConfig, SequentialAgentConfig, EventsCompactionConfig, ResumabilityConfig, FeatureConfig, AudioCacheConfig, SimplePromptOptimizerConfig, BigQueryLoggerConfig, RetryConfig, GetSessionConfig, BaseGoogleCredentialsConfig, AgentSimulatorConfig, InjectionConfig, ToolSimulationConfig, AgentToolConfig, BigQueryCredentialsConfig, BigQueryToolConfig, BigtableCredentialsConfig, DataAgentToolConfig, DataAgentCredentialsConfig, ExampleToolConfig, McpToolsetConfig, PubSubToolConfig, PubSubCredentialsConfig, SpannerCredentialsConfig, BaseToolConfig, ToolArgsConfig, ToolConfig
+A2aAgentExecutorConfig, AgentConfig, BaseAgentConfig, AgentRefConfig, ArgumentConfig, CodeConfig, ContextCacheConfig, LlmAgentConfig, LoopAgentConfig, ParallelAgentConfig, RunConfig, ToolThreadPoolConfig, SequentialAgentConfig, EventsCompactionConfig, ResumabilityConfig, FeatureConfig, AudioCacheConfig, SimplePromptOptimizerConfig, BigQueryLoggerConfig, RetryConfig, GetSessionConfig, BaseGoogleCredentialsConfig, AgentSimulatorConfig, InjectionConfig, ToolSimulationConfig, AgentToolConfig, BigQueryCredentialsConfig, BigQueryToolConfig, BigtableCredentialsConfig, DataAgentToolConfig, DataAgentCredentialsConfig, ExampleToolConfig, McpToolsetConfig, PubSubToolConfig, PubSubCredentialsConfig, SpannerCredentialsConfig, BaseToolConfig, ToolArgsConfig, ToolConfig
 
-### executor module (5 builders)
+### executor module (6 builders)
 
-AgentEngineSandboxCodeExecutor, BaseCodeExecutor, BuiltInCodeExecutor, UnsafeLocalCodeExecutor, VertexAiCodeExecutor
+A2aAgentExecutor, AgentEngineSandboxCodeExecutor, BaseCodeExecutor, BuiltInCodeExecutor, UnsafeLocalCodeExecutor, VertexAiCodeExecutor
 
 ### planner module (3 builders)
 
@@ -314,26 +336,27 @@ Loop, FanOut, Pipeline
 ## Best practices
 
 1. Use deterministic routing (Route) over LLM routing when the decision is rule-based
-2. Use `.inject()` for infrastructure deps — never expose DB clients in tool schemas
+2. Use ``.inject()`` for infrastructure deps — never expose DB clients in tool schemas
 3. Use S.transform() or plain functions for data transforms, not custom BaseAgent
 4. Use C.none() to hide conversation history from background/utility agents
 5. Use M.retry() middleware instead of retry logic inside tool functions
-6. Use `.writes()` not deprecated `.output_key()` / `.outputs()`
-7. Use `.returns()` not deprecated `.output_schema()`
-8. Use `.context()` not deprecated `.history()` / `.include_history()`
-9. Use `.agent_tool()` not deprecated `.delegate()`
-10. Use `.guard()` not deprecated `.guardrail()`
-11. Use `.loop_while()` not deprecated `.retry_if()`
-12. Use `.prepend()` not deprecated `.inject_context()`
-13. All operators are immutable — sub-expressions can be safely reused
-14. Every `.build()` returns a real ADK object compatible with adk web/run/deploy
-15. Use `.sub_agent()` for transfer-based delegation (LLM decides routing);
-    use `.agent_tool()` for tool-based invocation (parent stays in control)
-16. Use `.isolate()` on specialist agents by default — it is the most predictable pattern
-17. Always set `.describe()` on sub-agents — the description helps the coordinator LLM
+6. Use ``.writes()`` not deprecated ``.outputKey()`` / ``.outputs()``
+7. Use ``.outputAs()`` not deprecated ``.outputSchema()``
+8. Use ``.context()`` not deprecated ``.history()`` / ``.includeHistory()``
+9. Use ``.agentTool()`` not deprecated ``.delegate()``
+10. Use ``.guard()`` not deprecated ``.guardrail()``
+11. Use ``.loopWhile()`` not deprecated ``.retryIf()``
+12. Use ``.prepend()`` not deprecated ``.injectContext()``
+13. All builders are immutable — sub-expressions can be safely reused
+14. Workflow sub-builders passed to ``.then()`` / ``.parallel()`` / ``.step()``
+    are auto-built; do not call ``.build()`` on individual steps
+15. Use ``.subAgent()`` for transfer-based delegation (LLM decides routing);
+    use ``.agentTool()`` for tool-based invocation (parent stays in control)
+16. Use ``.isolate()`` on specialist agents by default — it is the most predictable pattern
+17. Always set ``.describe()`` on sub-agents — the description helps the coordinator LLM
     pick the right specialist during transfer routing
-18. Use `.ask_async()` and `.map_async()` in async contexts (Jupyter, FastAPI).
-    The sync variants (.ask, .map) raise RuntimeError inside running event loops.
+18. Use ``.askAsync()`` / ``.mapAsync()`` in async code paths;
+    the sync ``.ask()`` / ``.map()`` variants throw inside running event loops
 ## Development commands (TypeScript)
 
     cd ts

--- a/docs/user-guide/builders.md
+++ b/docs/user-guide/builders.md
@@ -3,7 +3,37 @@
 Every adk-fluent builder does one thing: it turns a chain of readable method calls into a native ADK object. No subclassing. No boilerplate. No silent misconfiguration.
 
 ::::{tab-set}
-:::{tab-item} Native ADK (22 lines)
+:::{tab-item} Python
+:sync: python
+
+```python
+from adk_fluent import Agent
+
+agent = (
+    Agent("helper", "gemini-2.5-flash")
+    .instruct("You are a helpful assistant.")
+    .describe("A general-purpose helper")
+    .writes("response")
+    .tool(search_fn)
+    .build()
+)
+```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent } from "adk-fluent-ts";
+
+const agent = new Agent("helper", "gemini-2.5-flash")
+  .instruct("You are a helpful assistant.")
+  .describe("A general-purpose helper")
+  .writes("response")
+  .tool(searchFn)
+  .build();
+```
+:::
+:::{tab-item} Native ADK (Python, 22 lines)
 ```python
 from google.adk.agents import LlmAgent
 from google.adk.tools import FunctionTool
@@ -18,20 +48,6 @@ agent = LlmAgent(
 )
 ```
 :::
-:::{tab-item} adk-fluent (6 lines)
-```python
-from adk_fluent import Agent
-
-agent = (
-    Agent("helper", "gemini-2.5-flash")
-    .instruct("You are a helpful assistant.")
-    .describe("A general-purpose helper")
-    .writes("response")
-    .tool(search_fn)
-    .build()
-)
-```
-:::
 ::::
 
 Both produce the **exact same `LlmAgent`**. The difference: the builder catches typos at definition time, provides IDE autocomplete for every field, and chains naturally.
@@ -40,6 +56,10 @@ Both produce the **exact same `LlmAgent`**. The difference: the builder catches 
 
 Every builder takes a required `name` as the first positional argument. Some builders accept additional optional positional arguments. For example, the `Agent` builder accepts an optional `model` as a second positional argument:
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 from adk_fluent import Agent
 
@@ -47,10 +67,27 @@ from adk_fluent import Agent
 agent = Agent("helper", "gemini-2.5-flash")
 agent = Agent("helper").model("gemini-2.5-flash")
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent } from "adk-fluent-ts";
+
+// These are equivalent:
+const a = new Agent("helper", "gemini-2.5-flash");
+const b = new Agent("helper").model("gemini-2.5-flash");
+```
+:::
+::::
 
 ## Method Chaining (Fluent API)
 
-Every configuration method returns `self`, enabling fluent chaining:
+Every configuration method returns the builder, enabling fluent chaining. Methods can be called in any order:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 agent = (
@@ -62,12 +99,28 @@ agent = (
     .build()
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
 
-Methods can be called in any order. Each call records a configuration value that is applied when `.build()` is invoked.
+```ts
+const agent = new Agent("helper", "gemini-2.5-flash")
+  .instruct("You are a helpful assistant.")
+  .describe("A general-purpose helper agent")
+  .writes("response")
+  .tool(searchFn)
+  .build();
+```
+:::
+::::
 
 ## `.build()` -- Terminal Method
 
 `.build()` resolves the builder into a native ADK object:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from adk_fluent import Agent, Pipeline, FanOut, Loop
@@ -77,6 +130,20 @@ pipe  = Pipeline("p").step(agent).build()                               # -> Seq
 fan   = FanOut("f").branch(agent).build()                               # -> ParallelAgent
 loop  = Loop("l").step(agent).max_iterations(3).build()                 # -> LoopAgent
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent, Pipeline, FanOut, Loop } from "adk-fluent-ts";
+
+const agent = new Agent("x", "gemini-2.5-flash").instruct("Help.").build(); // -> LlmAgent
+const pipe = new Pipeline("p").step(agent).build();                          // -> SequentialAgent
+const fan = new FanOut("f").branch(agent).build();                           // -> ParallelAgent
+const loop = new Loop("l").step(agent).maxIterations(3).build();             // -> LoopAgent
+```
+:::
+::::
 
 Sub-builders passed to workflow builders (Pipeline, FanOut, Loop) are automatically built at `.build()` time, so you do not need to call `.build()` on each step individually.
 
@@ -327,8 +394,12 @@ All workflow builders (Pipeline, FanOut, Loop) accept both built ADK agents and 
 
 ### Pipeline (Sequential)
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
-from adk_fluent import Pipeline, Agent
+from adk_fluent import Pipeline, Agent, C
 
 pipeline = (
     Pipeline("data_processing")
@@ -338,6 +409,33 @@ pipeline = (
     .build()
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Pipeline, Agent, C } from "adk-fluent-ts";
+
+const pipeline = new Pipeline("data_processing")
+  .step(
+    new Agent("extractor", "gemini-2.5-flash")
+      .instruct("Extract entities.")
+      .writes("entities"),
+  )
+  .step(
+    new Agent("enricher", "gemini-2.5-flash")
+      .instruct("Enrich {entities}.")
+      .tool(lookupDb),
+  )
+  .step(
+    new Agent("formatter", "gemini-2.5-flash")
+      .instruct("Format output.")
+      .context(C.none()),
+  )
+  .build();
+```
+:::
+::::
 
 | Method         | Description                                                        |
 | -------------- | ------------------------------------------------------------------ |
@@ -345,6 +443,10 @@ pipeline = (
 | `.build()`     | Resolve into a native ADK `SequentialAgent`                        |
 
 ### FanOut (Parallel)
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from adk_fluent import FanOut, Agent
@@ -356,6 +458,28 @@ fanout = (
     .build()
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { FanOut, Agent } from "adk-fluent-ts";
+
+const fanout = new FanOut("research")
+  .branch(
+    new Agent("web", "gemini-2.5-flash")
+      .instruct("Search the web.")
+      .writes("web_results"),
+  )
+  .branch(
+    new Agent("papers", "gemini-2.5-pro")
+      .instruct("Search academic papers.")
+      .writes("paper_results"),
+  )
+  .build();
+```
+:::
+::::
 
 | Method           | Description                                                   |
 | ---------------- | ------------------------------------------------------------- |
@@ -363,6 +487,10 @@ fanout = (
 | `.build()`       | Resolve into a native ADK `ParallelAgent`                     |
 
 ### Loop
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from adk_fluent import Loop, Agent
@@ -376,6 +504,24 @@ loop = (
     .build()
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Loop, Agent } from "adk-fluent-ts";
+
+const loop = new Loop("quality_loop")
+  .step(
+    new Agent("writer", "gemini-2.5-flash").instruct("Write draft.").writes("quality"),
+  )
+  .step(new Agent("reviewer", "gemini-2.5-flash").instruct("Review and score."))
+  .maxIterations(5)
+  .until((s) => s.quality === "good")
+  .build();
+```
+:::
+::::
 
 | Method               | Description                                            |
 | -------------------- | ------------------------------------------------------ |
@@ -386,7 +532,11 @@ loop = (
 
 ## Combining Builder and Operator Styles
 
-The builder and operator styles mix freely. Use builders for complex individual steps and operators for composition:
+The builder and operator styles mix freely. Use builders for complex individual steps and operators (Python `>>`/`|`/`*` or TypeScript `.then()`/`.parallel()`/`.times()`) for composition:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from adk_fluent import Agent, Pipeline, FanOut, S, until, Prompt
@@ -427,3 +577,42 @@ pipeline = (
     >> (reviewer >> writer) * until(lambda s: int(s.get("quality_score", 0)) >= 8, max=3)
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent, FanOut, S, P } from "adk-fluent-ts";
+
+const researcher = new Agent("researcher", "gemini-2.5-flash")
+  .instruct(
+    P.role("You are a research analyst.").add(P.task("Find relevant information.")),
+  )
+  .tool(searchTool)
+  .beforeModel(logFn)
+  .writes("findings");
+
+const writer = new Agent("writer", "gemini-2.5-pro")
+  .instruct("Write a report about {findings}.")
+  .static("Company style guide: use formal tone, cite sources...")
+  .writes("draft");
+
+const reviewer = new Agent("reviewer", "gemini-2.5-flash")
+  .instruct("Score the draft 1-10 for quality.")
+  .writes("quality_score");
+
+const researchPhase = new FanOut("gather")
+  .branch(researcher.clone("web").tool(webSearch))
+  .branch(researcher.clone("papers").tool(paperSearch));
+
+const pipeline = researchPhase
+  .then(S.merge_(["web", "papers"], "findings"))
+  .then(writer)
+  .then(
+    reviewer
+      .then(writer)
+      .timesUntil((s) => Number(s.quality_score ?? 0) >= 8, { max: 3 }),
+  );
+```
+:::
+::::

--- a/docs/user-guide/callbacks.md
+++ b/docs/user-guide/callbacks.md
@@ -23,6 +23,10 @@ adk-fluent provides a fluent API for attaching callbacks to agents. All callback
 
 Each call appends to the list of handlers for that callback type. This is different from native ADK where setting a callback replaces the previous one:
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 from adk_fluent import Agent
 
@@ -41,10 +45,42 @@ agent = (
     .build()
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent } from "adk-fluent-ts";
+
+const logFn = (ctx: unknown, req: unknown) => {
+  console.log(`Request: ${JSON.stringify(req)}`);
+};
+
+const metricsFn = (ctx: unknown, req: unknown) => {
+  console.log(`Metrics: ${JSON.stringify(req)}`);
+};
+
+// Both handlers run before every LLM call
+const agent = new Agent("service", "gemini-2.5-flash")
+  .instruct("Handle requests.")
+  .beforeModel(logFn)
+  .beforeModel(metricsFn)
+  .build();
+```
+:::
+::::
+
+:::{note} TypeScript naming
+TypeScript uses camelCase for all callback methods: `beforeModel`, `afterModel`, `beforeAgent`, `afterAgent`, `beforeTool`, `afterTool`, `onModelError`, `onToolError`. Semantics and additive behavior are identical to Python.
+:::
 
 ## Conditional Callbacks
 
 Conditional variants append only when the condition is true:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 debug_mode = True
@@ -58,12 +94,32 @@ agent = (
     .build()
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const debugMode = true;
+const auditEnabled = false;
+
+const agent = new Agent("service", "gemini-2.5-flash")
+  .instruct("Handle requests.")
+  .beforeModelIf(debugMode, logFn)        // Added (debugMode is true)
+  .afterModelIf(auditEnabled, auditFn)    // Skipped (auditEnabled is false)
+  .build();
+```
+:::
+::::
 
 This is useful for toggling callbacks based on environment variables or feature flags without cluttering your code with if-else blocks.
 
 ## Guards
 
 `.guard(fn)` is a shorthand that registers the function as both `before_model` and `after_model`:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 def safety_check(ctx, data):
@@ -78,10 +134,33 @@ agent = (
     .build()
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const safetyCheck = (ctx: unknown, data: unknown) => {
+  // Runs both before and after model calls
+  if (JSON.stringify(data).includes("dangerous")) {
+    throw new Error("Safety violation detected");
+  }
+};
+
+const agent = new Agent("service", "gemini-2.5-flash")
+  .instruct("Handle requests.")
+  .guard(safetyCheck)
+  .build();
+```
+:::
+::::
 
 ## Middleware Stacks with `.apply()`
 
 For agents that need multiple layers of callbacks, use Presets to bundle them into reusable middleware stacks:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from adk_fluent.presets import Preset
@@ -99,12 +178,36 @@ agent = (
     .build()
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Preset } from "adk-fluent-ts";
+
+// Define reusable middleware
+const loggingPreset = new Preset({ beforeModel: logFn, afterModel: logResponseFn });
+const securityPreset = new Preset({ beforeModel: safetyCheck, afterModel: auditFn });
+
+// Apply multiple presets
+const agent = new Agent("service", "gemini-2.5-flash")
+  .instruct("Handle requests.")
+  .use(loggingPreset)
+  .use(securityPreset)
+  .build();
+```
+:::
+::::
 
 See [Presets](presets.md) for more on reusable configuration bundles.
 
 ## Error Handling
 
 Error callbacks handle failures in LLM calls and tool executions:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 def handle_model_error(ctx, error):
@@ -123,8 +226,35 @@ agent = (
     .build()
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const handleModelError = (ctx: unknown, error: Error) => {
+  console.log(`Model error: ${error.message}`);
+  // Optionally return a fallback response
+};
+
+const handleToolError = (ctx: unknown, error: Error) => {
+  console.log(`Tool error: ${error.message}`);
+  // Optionally return a fallback result
+};
+
+const agent = new Agent("service", "gemini-2.5-flash")
+  .instruct("Handle requests.")
+  .onModelError(handleModelError)
+  .onToolError(handleToolError)
+  .build();
+```
+:::
+::::
 
 ## Complete Example
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from adk_fluent import Agent
@@ -154,6 +284,38 @@ agent = (
     .build()
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent } from "adk-fluent-ts";
+
+const logRequest = (ctx: { agentName: string }, req: unknown) =>
+  console.log(`[LOG] Model request at ${ctx.agentName}`);
+
+const logResponse = (ctx: { agentName: string }, resp: unknown) =>
+  console.log(`[LOG] Model response at ${ctx.agentName}`);
+
+const validateOutput = (ctx: unknown, resp: unknown) => {
+  if (!resp) throw new Error("Empty response");
+};
+
+const auditTool = (ctx: unknown, result: unknown) =>
+  console.log(`[AUDIT] Tool result: ${JSON.stringify(result)}`);
+
+const agent = new Agent("production_agent", "gemini-2.5-flash")
+  .instruct("You are a production service.")
+  .beforeModel(logRequest)
+  .afterModel(logResponse)
+  .afterModel(validateOutput)
+  .beforeTool((ctx, tool) => console.log(`Calling tool: ${String(tool)}`))
+  .afterTool(auditTool)
+  .onModelError((ctx, e) => console.log(`Error: ${(e as Error).message}`))
+  .build();
+```
+:::
+::::
 
 ## Callbacks vs. Middleware
 
@@ -166,14 +328,36 @@ Callbacks are **per-agent** -- they apply only to the agent they're attached to.
 | Multiplicity | Multiple per agent  | Stack of middleware on pipeline |
 | Compilation  | Stored on IR node   | Stored in ExecutionConfig       |
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
+from adk_fluent import Agent, M
+
 # Per-agent callback: only affects this agent
 agent = Agent("a").before_model(log_fn)
 
 # App-global middleware: affects all agents in the pipeline
-from adk_fluent import RetryMiddleware
-pipeline = (Agent("a") >> Agent("b")).middleware(RetryMiddleware())
+pipeline = (Agent("a") >> Agent("b")).middleware(M.retry(3))
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent, M } from "adk-fluent-ts";
+
+// Per-agent callback: only affects this agent
+const agent = new Agent("a", "gemini-2.5-flash").beforeModel(logFn);
+
+// App-global middleware: affects all agents in the pipeline
+const pipeline = new Agent("a", "gemini-2.5-flash")
+  .then(new Agent("b", "gemini-2.5-flash"))
+  .middleware(M.retry({ maxAttempts: 3 }));
+```
+:::
+::::
 
 See [Middleware](middleware.md) for the full middleware guide.
 
@@ -182,6 +366,10 @@ See [Middleware](middleware.md) for the full middleware guide.
 ### Callbacks + Guards
 
 `.guard(fn)` registers a function as both `before_model` and `after_model`. The G module provides structured guards that compile to callbacks automatically. Prefer G for safety/validation, raw callbacks for custom logic:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from adk_fluent import Agent, G
@@ -192,12 +380,32 @@ agent = Agent("safe").guard(G.pii("redact") | G.length(max=500))
 # Raw callback: custom logic that doesn't fit G
 agent = Agent("custom").before_model(my_custom_check)
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent, G } from "adk-fluent-ts";
+
+// G module: declarative, composable, phase-aware
+const safe = new Agent("safe", "gemini-2.5-flash")
+  .guard(G.pii({ action: "redact" }).pipe(G.length({ max: 500 })));
+
+// Raw callback: custom logic that doesn't fit G
+const custom = new Agent("custom", "gemini-2.5-flash").beforeModel(myCustomCheck);
+```
+:::
+::::
 
 See [Guards](guards.md).
 
 ### Callbacks + Presets
 
 Bundle callbacks into reusable Presets to avoid repetition across agents:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from adk_fluent.presets import Preset
@@ -206,12 +414,29 @@ observability = Preset(before_model=log_fn, after_model=metrics_fn)
 agent_a = Agent("a").use(observability)
 agent_b = Agent("b").use(observability)
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent, Preset } from "adk-fluent-ts";
+
+const observability = new Preset({ beforeModel: logFn, afterModel: metricsFn });
+const agentA = new Agent("a", "gemini-2.5-flash").use(observability);
+const agentB = new Agent("b", "gemini-2.5-flash").use(observability);
+```
+:::
+::::
 
 See [Presets](presets.md).
 
 ### Callbacks + Context Engineering
 
 Callbacks run *after* context engineering. The LLM request that `before_model` receives already has context filtering applied:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from adk_fluent import Agent, C
@@ -222,6 +447,19 @@ agent = (
     .before_model(log_request)    # Sees the filtered request
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent, C } from "adk-fluent-ts";
+
+const agent = new Agent("classifier", "gemini-2.5-flash")
+  .context(C.none())            // Context filtered first
+  .beforeModel(logRequest);     // Sees the filtered request
+```
+:::
+::::
 
 See [Context Engineering](context-engineering.md).
 

--- a/docs/user-guide/context-engineering.md
+++ b/docs/user-guide/context-engineering.md
@@ -38,12 +38,34 @@ flowchart LR
 
 **Composition operators:**
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 C.window(3) + C.from_state("topic")    # union: both applied
 C.window(5) | C.template("{history}")   # pipe: output → input
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+C.window(3).add(C.fromState("topic"));    // union: both applied
+C.window(5).pipe(C.template("{history}")); // pipe: output → input
+```
+:::
+::::
+
+:::{note} TypeScript naming
+TypeScript uses camelCase: `C.fromState`, `C.userOnly`, `C.fromAgents`, `C.excludeAgents`. The `+` operator from Python becomes `.add()` and `|` becomes `.pipe()`.
+:::
 
 ## Quick Start
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from adk_fluent import Agent, C
@@ -59,6 +81,27 @@ focused_agent = (
     .build()
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent, C } from "adk-fluent-ts";
+
+// Suppress all conversation history
+const cleanAgent = new Agent("processor", "gemini-2.5-flash")
+  .context(C.none())
+  .instruct("Process input.")
+  .build();
+
+// Only see last 3 turn-pairs + state keys
+const focusedAgent = new Agent("analyst", "gemini-2.5-flash")
+  .context(C.window(3).add(C.fromState("topic")))
+  .instruct("Analyze {topic}.")
+  .build();
+```
+:::
+::::
 
 ## The Problem
 
@@ -92,30 +135,83 @@ Context engineering solves three problems:
 
 Suppress all conversation history. The agent sees only its instruction:
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 agent = Agent("classifier").context(C.none()).instruct("Classify the input.").build()
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const agent = new Agent("classifier", "gemini-2.5-flash")
+  .context(C.none())
+  .instruct("Classify the input.")
+  .build();
+```
+:::
+::::
 
 ## `C.default()`
 
 Keep the default conversation history. This is the pass-through -- equivalent to not calling `.context()` at all:
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 agent = Agent("assistant").context(C.default()).instruct("Help the user.").build()
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
 
-## `C.user_only()`
+```ts
+// In TypeScript, `default` is reserved — use `default_()`.
+const agent = new Agent("assistant", "gemini-2.5-flash")
+  .context(C.default_())
+  .instruct("Help the user.")
+  .build();
+```
+:::
+::::
+
+## `C.userOnly()` / `C.user_only()`
 
 Include only user messages, filtering out all agent and tool responses:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 # The reviewer sees what the user said, not what other agents produced
 agent = Agent("reviewer").context(C.user_only()).instruct("Review the request.").build()
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
 
-## `C.from_state(*keys)`
+```ts
+const agent = new Agent("reviewer", "gemini-2.5-flash")
+  .context(C.userOnly())
+  .instruct("Review the request.")
+  .build();
+```
+:::
+::::
+
+## `C.fromState()` / `C.from_state()`
 
 Read named keys from session state and inject them as context. This is a **pure data-injection transform** — it injects state values without suppressing conversation history:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 # Inject state AND keep conversation history
@@ -136,14 +232,40 @@ agent = (
 
 # Or use .reads() which suppresses history by default
 agent = Agent("writer").reads("topic", "style").instruct("Write about {topic} in {style} style.").build()
-
-# .reads() with keep_history=True to inject state without suppressing
-agent = Agent("writer").reads("topic", "style", keep_history=True).instruct("Write.").build()
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
 
-## `C.from_agents(*names)`
+```ts
+// Inject state AND keep conversation history
+const a = new Agent("writer", "gemini-2.5-flash")
+  .context(C.fromState("topic", "style"))
+  .instruct("Write about {topic} in {style} style.")
+  .build();
+
+// Inject state, suppress history (common pipeline pattern)
+const b = new Agent("writer", "gemini-2.5-flash")
+  .context(C.none().add(C.fromState("topic", "style")))
+  .instruct("Write about {topic} in {style} style.")
+  .build();
+
+// Or use .reads() which suppresses history by default
+const c = new Agent("writer", "gemini-2.5-flash")
+  .reads("topic", "style")
+  .instruct("Write about {topic} in {style} style.")
+  .build();
+```
+:::
+::::
+
+## `C.fromAgents()` / `C.from_agents()`
 
 Include user messages plus outputs from specific named agents. All other agent outputs are excluded:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 # The editor sees only what the user said and what "writer" produced
@@ -154,10 +276,26 @@ agent = (
     .build()
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
 
-## `C.exclude_agents(*names)`
+```ts
+const agent = new Agent("editor", "gemini-2.5-flash")
+  .context(C.fromAgents("writer"))
+  .instruct("Edit the draft for clarity.")
+  .build();
+```
+:::
+::::
+
+## `C.excludeAgents()` / `C.exclude_agents()`
 
 Include everything except outputs from the named agents:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 # The summarizer sees the full history but ignores the verbose "researcher" output
@@ -168,19 +306,51 @@ agent = (
     .build()
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
 
-## `C.window(n=)`
+```ts
+const agent = new Agent("summarizer", "gemini-2.5-flash")
+  .context(C.excludeAgents("researcher"))
+  .instruct("Summarize the conversation.")
+  .build();
+```
+:::
+::::
+
+## `C.window(n)`
 
 Include only the last N turn-pairs (user message + model response). Useful for long-running conversations where only recent context matters:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 # Only see the last 3 exchanges
 agent = Agent("responder").context(C.window(n=3)).instruct("Continue the conversation.").build()
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const agent = new Agent("responder", "gemini-2.5-flash")
+  .context(C.window(3))
+  .instruct("Continue the conversation.")
+  .build();
+```
+:::
+::::
 
 ## `C.template(str)`
 
 Render a template string using state values. Supports `{key}` (required) and `{key?}` (optional, replaced with empty string if missing):
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 agent = (
@@ -190,10 +360,26 @@ agent = (
     .build()
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const agent = new Agent("reporter", "gemini-2.5-flash")
+  .context(C.template("Topic: {topic}\nNotes: {notes?}"))
+  .instruct("Write a report from the context above.")
+  .build();
+```
+:::
+::::
 
 ## `S.capture(key)`
 
 Capture the most recent user message into a state key. Used as a pipeline step, not inside `.context()`:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from adk_fluent import Agent, C, S
@@ -205,6 +391,21 @@ pipeline = (
         .instruct("Respond to: {user_message}")
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent, C, S } from "adk-fluent-ts";
+
+const pipeline = S.capture("user_message").then(
+  new Agent("handler", "gemini-2.5-flash")
+    .context(C.fromState("user_message"))
+    .instruct("Respond to: {user_message}"),
+);
+```
+:::
+::::
 
 ## `C.budget(max_tokens=)`
 
@@ -236,7 +437,11 @@ agent = (
 
 Primitives compose with two operators:
 
-**`+` (union)** combines transforms. Both are applied to produce the final context:
+**Union** combines transforms. Both are applied to produce the final context:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 # Window + state keys: agent sees last 3 turns AND the topic from state
@@ -244,8 +449,25 @@ ctx = C.window(n=3) + C.from_state("topic", "style")
 
 agent = Agent("analyst").context(ctx).instruct("Analyze {topic}.").build()
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
 
-**`|` (pipe)** feeds the output of one transform into another:
+```ts
+const ctx = C.window(3).add(C.fromState("topic", "style"));
+const agent = new Agent("analyst", "gemini-2.5-flash")
+  .context(ctx)
+  .instruct("Analyze {topic}.")
+  .build();
+```
+:::
+::::
+
+**Pipe** feeds the output of one transform into another:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 # Window output piped through a template
@@ -253,12 +475,38 @@ ctx = C.window(n=5) | C.template("Recent conversation:\n{history}")
 
 agent = Agent("summarizer").context(ctx).instruct("Summarize.").build()
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const ctx = C.window(5).pipe(C.template("Recent conversation:\n{history}"));
+const agent = new Agent("summarizer", "gemini-2.5-flash")
+  .context(ctx)
+  .instruct("Summarize.")
+  .build();
+```
+:::
+::::
 
 You can chain multiple unions:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 ctx = C.window(n=3) + C.from_state("topic") + C.budget(max_tokens=4000)
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const ctx = C.window(3).add(C.fromState("topic")).add(C.budget({ maxTokens: 4000 }));
+```
+:::
+::::
 
 ## Integration with Agent Builder
 
@@ -289,6 +537,10 @@ Context flow through a pipeline:
                                                  + user history
 ```
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 from adk_fluent import Agent, C, S
 
@@ -305,6 +557,28 @@ pipeline = (
         .context(C.from_state("user_message", "intent") + C.user_only())
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent, C, S } from "adk-fluent-ts";
+
+const pipeline = S.capture("user_message")
+  .then(
+    new Agent("classifier", "gemini-2.5-flash")
+      .instruct("Classify the user's intent.")
+      .context(C.none()) // No history needed
+      .writes("intent"),
+  )
+  .then(
+    new Agent("handler", "gemini-2.5-flash")
+      .instruct("Help the user.")
+      .context(C.fromState("user_message", "intent").add(C.userOnly())),
+  );
+```
+:::
+::::
 
 The classifier sees only its instruction -- no history, no prior agent output. The handler sees the original user message and classified intent from state, plus user-only history for conversational continuity. Each agent gets exactly the context it needs.
 

--- a/docs/user-guide/data-flow.md
+++ b/docs/user-guide/data-flow.md
@@ -90,6 +90,10 @@ Every data-flow method in adk-fluent maps to exactly one of **five orthogonal co
 
 ### Recommended builder chain
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 from adk_fluent import Agent
 from pydantic import BaseModel
@@ -111,6 +115,44 @@ classifier = (
     .writes("intent")            # STORAGE: Save to state["intent"]
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent } from "adk-fluent-ts";
+
+const SearchQuerySchema = {
+  type: "object",
+  properties: {
+    query: { type: "string" },
+    max_results: { type: "number" },
+  },
+  required: ["query"],
+} as const;
+
+const IntentSchema = {
+  type: "object",
+  properties: {
+    category: { type: "string" },
+    confidence: { type: "number" },
+  },
+  required: ["category", "confidence"],
+} as const;
+
+const classifier = new Agent("classifier", "gemini-2.0-flash")
+  .instruct("Classify the user query: {query}")
+  .reads("query")              // CONTEXT: I see state["query"]
+  .accepts(SearchQuerySchema)  // INPUT:   Tool-mode validation
+  .outputAs(IntentSchema)      // OUTPUT:  Structured JSON response
+  .writes("intent");           // STORAGE: Save to state["intent"]
+```
+:::
+::::
+
+:::{note} TypeScript naming
+TypeScript uses `.outputAs(schema)` for structured output (Python's `.returns()` / `@` operator). Reads / writes / accepts map one-to-one. All five concerns (Context, Input, Output, Storage, Contract) are available via the same method names.
+:::
 
 Each line maps to exactly one ADK field. Each verb is unambiguous.
 
@@ -163,6 +205,10 @@ All three modules support composition, but with different operators:
 | `\|`     | Pipe (transform) | Pipe (transform) | —                  |
 | `>>`     | —                | —                | Chain (sequential) |
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 # P: compose prompt sections
 prompt = P.role("Expert coder") + P.task("Review code") + P.constraint("Be brief")
@@ -173,6 +219,22 @@ context = C.window(n=3) + C.from_state("topic")
 # S: chain state transforms
 transform = S.pick("a", "b") >> S.rename(a="x") >> S.default(y=1)
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+// P: compose prompt sections (use .add() instead of +)
+const prompt = P.role("Expert coder").add(P.task("Review code")).add(P.constraint("Be brief"));
+
+// C: compose context specs (use .add() instead of +)
+const context = C.window(3).add(C.fromState("topic"));
+
+// S: chain state transforms (use .pipe() instead of >>)
+const transform = S.pick("a", "b").pipe(S.rename({ a: "x" })).pipe(S.default_({ y: 1 }));
+```
+:::
+::::
 
 ______________________________________________________________________
 
@@ -449,6 +511,10 @@ Multiple sections of the same kind are concatenated. Custom sections appear afte
 
 ### Usage
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 from adk_fluent import Agent, P
 
@@ -480,6 +546,28 @@ agent = Agent("reviewer").instruct(
 # Input: x = eval(user_input)
 # Output: - Security: injection risk via eval()
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent, P } from "adk-fluent-ts";
+
+const agent = new Agent("reviewer", "gemini-2.5-flash").instruct(
+  P.role("You are a senior code reviewer.")
+    .add(P.task("Review the provided code for bugs and style issues."))
+    .add(P.constraint("Be concise.", "Focus on correctness."))
+    .add(P.format("Return a bulleted list of findings."))
+    .add(
+      P.example({
+        input: "x = eval(user_input)",
+        output: "- Security: injection risk via eval()",
+      }),
+    ),
+);
+```
+:::
+::::
 
 ______________________________________________________________________
 
@@ -537,9 +625,22 @@ By default, an agent sees the entire conversation history from all agents. No `.
 
 ### `.reads()`: Selective state injection
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 Agent("writer").reads("topic", "tone")
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+new Agent("writer", "gemini-2.5-flash").reads("topic", "tone");
+```
+:::
+::::
 
 This does two things:
 
@@ -548,23 +649,55 @@ This does two things:
 
 ### `.context()`: Advanced context control
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
-from adk_fluent import C
+from adk_fluent import Agent, C
 
 Agent("writer").context(C.window(n=3))      # Last 3 turns only
 Agent("writer").context(C.user_only())       # User messages only
 Agent("writer").context(C.none())            # No context at all
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent, C } from "adk-fluent-ts";
+
+new Agent("writer", "gemini-2.5-flash").context(C.window(3));      // Last 3 turns only
+new Agent("writer", "gemini-2.5-flash").context(C.userOnly());     // User messages only
+new Agent("writer", "gemini-2.5-flash").context(C.none());         // No context at all
+```
+:::
+::::
 
 ### Composing context
 
-`.context()` and `.reads()` compose additively with the `+` operator:
+`.context()` and `.reads()` compose additively with the `+` / `.add()` operator:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 Agent("writer")
     .context(C.window(n=3))   # Include last 3 turns
     .reads("topic")           # AND inject state["topic"]
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+new Agent("writer", "gemini-2.5-flash")
+  .context(C.window(3))       // Include last 3 turns
+  .reads("topic");            // AND inject state["topic"]
+```
+:::
+::::
 
 ______________________________________________________________________
 
@@ -602,7 +735,11 @@ The S module transforms session state between pipeline steps using callable `STr
 
 ### Usage in pipelines
 
-S transforms appear as steps between agents using the `>>` operator:
+S transforms appear as steps between agents using the `>>` / `.then()` operator:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from adk_fluent import Agent, S
@@ -615,6 +752,22 @@ pipeline = (
     >> Agent("writer").reads("input")
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent, S } from "adk-fluent-ts";
+
+const pipeline = new Agent("researcher", "gemini-2.5-flash")
+  .writes("findings")
+  .then(S.pick("findings"))                        // Keep only "findings"
+  .then(S.rename({ findings: "input" }))           // Rename for next agent
+  .then(S.default_({ depth: "comprehensive" }))    // Add default value
+  .then(new Agent("writer", "gemini-2.5-flash").reads("input"));
+```
+:::
+::::
 
 ______________________________________________________________________
 
@@ -622,12 +775,31 @@ ______________________________________________________________________
 
 ### `.accepts(Model)`: Schema validation at tool-call time
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 class SearchQuery(BaseModel):
     query: str
 
 Agent("searcher").accepts(SearchQuery)
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const SearchQuerySchema = {
+  type: "object",
+  properties: { query: { type: "string" } },
+  required: ["query"],
+} as const;
+
+new Agent("searcher", "gemini-2.5-flash").accepts(SearchQuerySchema);
+```
+:::
+::::
 
 When another agent invokes this agent via `AgentTool`, the input is validated against this schema. **This has no effect for top-level agents** — only for agents used as tools.
 
@@ -639,7 +811,11 @@ ______________________________________________________________________
 
 Without `.returns()`, the agent responds in free-form text and **can use tools**.
 
-### `.returns(Model)`: Structured JSON
+### `.returns(Model)` / `.outputAs(schema)`: Structured JSON
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 class Intent(BaseModel):
@@ -650,15 +826,51 @@ Agent("classifier").returns(Intent)
 ```
 
 Forces the LLM to respond with JSON matching the schema. The `@` operator is shorthand: `Agent("classifier") @ Intent`
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const IntentSchema = {
+  type: "object",
+  properties: {
+    category: { type: "string" },
+    confidence: { type: "number" },
+  },
+  required: ["category", "confidence"],
+} as const;
+
+new Agent("classifier", "gemini-2.5-flash").outputAs(IntentSchema);
+```
+
+The `@` operator shorthand is Python-only; in TypeScript, use `.outputAs()` explicitly.
+:::
+::::
 
 **Tool interaction:** When `output_schema` is set, whether tools remain available depends on model capabilities. For models that don't natively support both, ADK injects a `set_model_response` workaround tool so the agent can still reason with tools but must deliver its final answer as structured JSON.
 
 ### Using `.ask()` with structured output
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 result = await Agent("classifier").returns(Intent).ask_async("Classify this query")
 # result is an Intent instance (automatically parsed)
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const result = await new Agent("classifier", "gemini-2.5-flash")
+  .outputAs(IntentSchema)
+  .askAsync("Classify this query");
+// result is a parsed object matching IntentSchema
+```
+:::
+::::
 
 ______________________________________________________________________
 
@@ -666,9 +878,22 @@ ______________________________________________________________________
 
 ### `.writes(key)`: Store raw text in state
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 Agent("researcher").writes("findings")
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+new Agent("researcher", "gemini-2.5-flash").writes("findings");
+```
+:::
+::::
 
 After the agent runs, `state["findings"]` holds the **raw text response** (not a parsed Pydantic model).
 
@@ -676,12 +901,27 @@ After the agent runs, `state["findings"]` holds the **raw text response** (not a
 
 Downstream agents reference stored values with `{key}` placeholders:
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 pipeline = (
     Agent("researcher").writes("findings")
     >> Agent("writer").instruct("Summarize: {findings}")
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const pipeline = new Agent("researcher", "gemini-2.5-flash")
+  .writes("findings")
+  .then(new Agent("writer", "gemini-2.5-flash").instruct("Summarize: {findings}"));
+```
+:::
+::::
 
 ______________________________________________________________________
 
@@ -691,9 +931,24 @@ ______________________________________________________________________
 
 These have **no runtime effect**. They are annotations for the contract checker:
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 Agent("classifier").produces(Intent).consumes(SearchQuery)
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+new Agent("classifier", "gemini-2.5-flash")
+  .produces(IntentSchema)
+  .consumes(SearchQuerySchema);
+```
+:::
+::::
 
 The contract checker uses these to verify data flow between agents at build time.
 
@@ -810,6 +1065,10 @@ ______________________________________________________________________
 
 ### Classify then route
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 pipeline = (
     Agent("classifier")
@@ -822,8 +1081,30 @@ pipeline = (
     .writes("response")
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const pipeline = new Agent("classifier", "gemini-2.5-flash")
+  .instruct("Classify the query.")
+  .outputAs(IntentSchema)
+  .writes("intent")
+  .then(
+    new Agent("handler", "gemini-2.5-flash")
+      .reads("intent")
+      .instruct("Handle the {intent} query.")
+      .writes("response"),
+  );
+```
+:::
+::::
 
 ### Fan-out research with merge
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from adk_fluent import Agent, FanOut, S
@@ -836,8 +1117,27 @@ research = (
     >> Agent("synthesizer").reads("all_results").writes("synthesis")
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent, S } from "adk-fluent-ts";
+
+const research = new Agent("web", "gemini-2.5-flash")
+  .writes("web_results")
+  .parallel(new Agent("docs", "gemini-2.5-flash").writes("doc_results"))
+  .then(S.merge_(["web_results", "doc_results"], "all_results"))
+  .then(new Agent("synthesizer", "gemini-2.5-flash").reads("all_results").writes("synthesis"));
+```
+:::
+::::
 
 ### Review loop
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from adk_fluent.patterns import review_loop
@@ -850,12 +1150,31 @@ pipeline = review_loop(
     max_rounds=3,
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent, reviewLoop } from "adk-fluent-ts";
+
+const pipeline = reviewLoop(
+  new Agent("writer", "gemini-2.5-flash").instruct("Write a draft."),
+  new Agent("reviewer", "gemini-2.5-flash").instruct("Review the draft."),
+  { qualityKey: "review_score", target: 0.8, maxRounds: 3 },
+);
+```
+:::
+::::
 
 ______________________________________________________________________
 
 ## T Module: Tool Composition
 
 The T module provides a compositional namespace for tool construction. Compose with `|` (chain).
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from adk_fluent import Agent, T
@@ -866,6 +1185,19 @@ agent = Agent("assistant").tools(
     | T.agent(specialist_agent)
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent, T } from "adk-fluent-ts";
+
+const agent = new Agent("assistant", "gemini-2.5-flash").tools(
+  T.googleSearch().pipe(T.fn(myFunc)).pipe(T.agent(specialistAgent)),
+);
+```
+:::
+::::
 
 See the [CLAUDE.md T namespace reference](../../CLAUDE.md) for all T factories.
 
@@ -874,6 +1206,10 @@ ______________________________________________________________________
 ## A Module: Artifact Operations
 
 The A module handles artifact publishing, snapshotting, and transformations. Used with `.artifacts()` or `>>`.
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from adk_fluent import Agent, A
@@ -884,5 +1220,18 @@ agent = (
     .artifacts(A.publish("report.md", from_key="report_text"))
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent, A } from "adk-fluent-ts";
+
+const agent = new Agent("generator", "gemini-2.5-flash")
+  .writes("report_text")
+  .artifacts(A.publish("report.md", { fromKey: "report_text" }));
+```
+:::
+::::
 
 See the [CLAUDE.md A namespace reference](../../CLAUDE.md) for all A factories.

--- a/docs/user-guide/expression-language.md
+++ b/docs/user-guide/expression-language.md
@@ -6,6 +6,19 @@ Nine operators compose any agent topology. All operators are **immutable** -- su
 **Visual learner?** Open the [Operator Algebra Interactive Reference](../operator-algebra-reference.html){target="_blank"} for animated SVG flow diagrams, code examples, and composition rules for all 9 operators.
 :::
 
+:::{note} Python uses operators, TypeScript uses method chains
+JavaScript has no operator overloading, so the TypeScript package replaces every operator with an explicit method call. Pick your language with the tabs on each example.
+
+| Python | TypeScript | Returns |
+| --- | --- | --- |
+| `a >> b` | `a.then(b)` | `Pipeline` |
+| `a \| b` | `a.parallel(b)` | `FanOut` |
+| `a * 3` | `a.times(3)` | `Loop` |
+| `a * until(pred, max=5)` | `a.timesUntil(pred, { max: 5 })` | `Loop` |
+| `a // b` | `a.fallback(b)` | `Fallback` |
+| `a @ Schema` | `a.outputAs(schema)` | `Agent` |
+:::
+
 ```{raw} html
 <div class="arch-diagram-wrapper">
   <svg viewBox="0 0 740 340" fill="none" xmlns="http://www.w3.org/2000/svg" class="arch-diagram" aria-label="Operator visual reference showing all 9 operators">
@@ -143,15 +156,34 @@ Nine operators compose any agent topology. All operators are **immutable** -- su
 
 All operators produce new expression objects. Sub-expressions can be safely reused:
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 review = agent_a >> agent_b
 pipeline_1 = review >> agent_c  # Independent
 pipeline_2 = review >> agent_d  # Independent
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const review = agentA.then(agentB);
+const pipeline1 = review.then(agentC); // Independent
+const pipeline2 = review.then(agentD); // Independent
+```
+:::
+::::
 
 ## `>>` -- Pipeline (Sequential)
 
-The `>>` operator chains agents into a sequential pipeline. Each agent runs after the previous one completes:
+The `>>` operator (Python) / `.then()` method (TypeScript) chains agents into a sequential pipeline. Each agent runs after the previous one completes:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from adk_fluent import Agent
@@ -162,12 +194,32 @@ pipeline = (
     >> Agent("formatter", "gemini-2.5-flash").instruct("Format output.")
 ).build()
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent } from "adk-fluent-ts";
+
+const pipeline = new Agent("extractor", "gemini-2.5-flash")
+  .instruct("Extract entities.")
+  .writes("entities")
+  .then(new Agent("enricher", "gemini-2.5-flash").instruct("Enrich {entities}."))
+  .then(new Agent("formatter", "gemini-2.5-flash").instruct("Format output."))
+  .build();
+```
+:::
+::::
 
 This produces the same `SequentialAgent` as the builder-style `Pipeline("name").step(...).step(...).build()`.
 
-## `>> fn` -- Function Steps
+## Function Steps
 
-Plain Python functions compose with `>>` as zero-cost workflow nodes (no LLM call):
+Plain functions compose as zero-cost workflow nodes (no LLM call):
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 def merge_research(state):
@@ -175,12 +227,31 @@ def merge_research(state):
 
 pipeline = web_agent >> merge_research >> writer_agent
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
 
-Functions receive the session state dict and return a dict of state updates. They are useful for data transformations between agent steps.
+```ts
+import { tap } from "adk-fluent-ts";
 
-## `|` -- Parallel (Fan-Out)
+const mergeResearch = tap((state) => {
+  state.research = `${state.web}\n${state.papers}`;
+});
 
-The `|` operator runs agents in parallel:
+const pipeline = webAgent.then(mergeResearch).then(writerAgent);
+```
+:::
+::::
+
+Function steps receive the session state and can mutate it (TypeScript) or return a dict of updates (Python). They are useful for data transformations between agent steps.
+
+## `|` / `.parallel()` -- Parallel (Fan-Out)
+
+Run agents concurrently:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from adk_fluent import Agent
@@ -191,14 +262,40 @@ fanout = (
     | Agent("internal", "gemini-2.5-flash").instruct("Search internal docs.").writes("internal_results")
 ).build()
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent } from "adk-fluent-ts";
+
+const fanout = new Agent("web", "gemini-2.5-flash")
+  .instruct("Search web.")
+  .writes("web_results")
+  .parallel(
+    new Agent("papers", "gemini-2.5-pro").instruct("Search papers.").writes("paper_results"),
+  )
+  .parallel(
+    new Agent("internal", "gemini-2.5-flash")
+      .instruct("Search internal docs.")
+      .writes("internal_results"),
+  )
+  .build();
+```
+:::
+::::
 
 This produces the same `ParallelAgent` as the builder-style `FanOut("name").branch(...).branch(...).build()`.
 
-## `*` -- Loop
+## `*` / `.times()` -- Loop
 
 ### Fixed Count
 
-Multiply an expression by an integer to loop a fixed number of times:
+Repeat an expression a fixed number of times:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 loop = (
@@ -206,10 +303,26 @@ loop = (
     >> Agent("reviewer", "gemini-2.5-flash").instruct("Review.")
 ) * 3
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const loop = new Agent("writer", "gemini-2.5-flash")
+  .instruct("Write draft.")
+  .then(new Agent("reviewer", "gemini-2.5-flash").instruct("Review."))
+  .times(3);
+```
+:::
+::::
 
 ### Conditional Loop with `until()`
 
-`* until(pred)` loops until a predicate on session state is satisfied:
+Loop until a predicate on session state is satisfied:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from adk_fluent import until
@@ -219,12 +332,29 @@ loop = (
     >> Agent("reviewer").model("gemini-2.5-flash").instruct("Review.")
 ) * until(lambda s: s.get("quality") == "good", max=5)
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const loop = new Agent("writer", "gemini-2.5-flash")
+  .instruct("Write.")
+  .writes("quality")
+  .then(new Agent("reviewer", "gemini-2.5-flash").instruct("Review."))
+  .timesUntil((s) => s.quality === "good", { max: 5 });
+```
+:::
+::::
 
 The `max` parameter sets a safety limit on the number of iterations.
 
-## `@` -- Typed Output
+## `@` / `.outputAs()` -- Typed Output
 
-`@` binds a Pydantic schema as the agent's output contract:
+Bind a structured-output schema as the agent's response contract:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from pydantic import BaseModel
@@ -235,12 +365,37 @@ class Report(BaseModel):
 
 agent = Agent("writer").model("gemini-2.5-flash").instruct("Write.") @ Report
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+// Use any opaque schema descriptor — Zod, JSON Schema, or a plain object.
+const ReportSchema = {
+  type: "object",
+  properties: {
+    title: { type: "string" },
+    body: { type: "string" },
+  },
+  required: ["title", "body"],
+} as const;
+
+const agent = new Agent("writer", "gemini-2.5-flash")
+  .instruct("Write.")
+  .outputAs(ReportSchema);
+```
+:::
+::::
 
 The agent's output is validated against the schema, ensuring structured, typed responses.
 
-## `//` -- Fallback Chain
+## `//` / `.fallback()` -- Fallback Chain
 
-`//` tries each agent in order. The first agent to succeed wins:
+Try each agent in order. The first agent to succeed wins:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 answer = (
@@ -248,6 +403,17 @@ answer = (
     // Agent("thorough").model("gemini-2.5-pro").instruct("Detailed answer.")
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const answer = new Agent("fast", "gemini-2.0-flash")
+  .instruct("Quick answer.")
+  .fallback(new Agent("thorough", "gemini-2.5-pro").instruct("Detailed answer."));
+```
+:::
+::::
 
 This is useful for cost optimization: try a cheaper, faster model first and fall back to a more capable model only if needed.
 
@@ -255,9 +421,12 @@ This is useful for cost optimization: try a cheaper, faster model first and fall
 
 Route on session state without LLM calls:
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
-from adk_fluent import Agent
-from adk_fluent._routing import Route
+from adk_fluent import Agent, Route
 
 classifier = Agent("classify").model("gemini-2.5-flash").instruct("Classify intent.").writes("intent")
 booker = Agent("booker").model("gemini-2.5-flash").instruct("Book flights.")
@@ -269,12 +438,33 @@ pipeline = classifier >> Route("intent").eq("booking", booker).eq("info", info)
 # Dict shorthand
 pipeline = classifier >> {"booking": booker, "info": info}
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
 
-The dict shorthand `>> {"key": agent}` is equivalent to `Route` with `.eq()` for each key-value pair.
+```ts
+import { Agent, Route } from "adk-fluent-ts";
+
+const classifier = new Agent("classify", "gemini-2.5-flash")
+  .instruct("Classify intent.")
+  .writes("intent");
+const booker = new Agent("booker", "gemini-2.5-flash").instruct("Book flights.");
+const info = new Agent("info", "gemini-2.5-flash").instruct("Provide info.");
+
+const pipeline = classifier.then(
+  new Route("intent").eq("booking", booker).eq("info", info),
+);
+```
+:::
+::::
 
 ## Conditional Gating
 
-`.proceed_if()` gates an agent's execution based on a state predicate:
+`.proceedIf()` / `.proceed_if()` gates an agent's execution based on a state predicate:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 enricher = (
@@ -284,6 +474,20 @@ enricher = (
     .proceed_if(lambda s: s.get("valid") == "yes")
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent, gate } from "adk-fluent-ts";
+
+const enricher = gate(
+  (s) => s.valid === "yes",
+  new Agent("enricher", "gemini-2.5-flash").instruct("Enrich the data."),
+);
+```
+:::
+::::
 
 The agent only runs if the predicate returns a truthy value.
 
@@ -304,6 +508,10 @@ Full composition topology:
   ┌──► critic ──► reviser ──┐
   └── until(confidence≥0.85) ┘  (*)
 ```
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from pydantic import BaseModel
@@ -327,6 +535,45 @@ pipeline = (
     ) * until(lambda s: s.get("confidence", 0) >= 0.85, max=4)
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent, S } from "adk-fluent-ts";
+
+const ReportSchema = {
+  type: "object",
+  properties: {
+    title: { type: "string" },
+    body: { type: "string" },
+    confidence: { type: "number" },
+  },
+  required: ["title", "body", "confidence"],
+} as const;
+
+const pipeline = new Agent("web", "gemini-2.5-flash")
+  .instruct("Search web.")
+  .parallel(new Agent("scholar", "gemini-2.5-flash").instruct("Search papers."))
+  .then(S.merge_(["web", "scholar"], "research"))
+  .then(
+    new Agent("writer", "gemini-2.5-flash")
+      .instruct("Write.")
+      .outputAs(ReportSchema)
+      .fallback(
+        new Agent("writer_b", "gemini-2.5-pro").instruct("Write.").outputAs(ReportSchema),
+      ),
+  )
+  .then(
+    new Agent("critic", "gemini-2.5-flash")
+      .instruct("Score.")
+      .writes("confidence")
+      .then(new Agent("reviser", "gemini-2.5-flash").instruct("Improve."))
+      .timesUntil((s) => Number(s.confidence ?? 0) >= 0.85, { max: 4 }),
+  );
+```
+:::
+::::
 
 This expression combines parallel fan-out (`|`), state transforms (`S.merge`), typed output (`@ Report`), fallback (`//`), and conditional loops (`* until`).
 

--- a/docs/user-guide/guards.md
+++ b/docs/user-guide/guards.md
@@ -4,6 +4,10 @@ The G module provides a declarative composition surface for safety, validation, 
 
 ## Quick Start
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 from adk_fluent import Agent, G
 
@@ -14,6 +18,24 @@ agent = (
     .build()
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent, G } from "adk-fluent-ts";
+
+const agent = new Agent("safe_agent", "gemini-2.5-flash")
+  .instruct("Answer user questions helpfully.")
+  .guard(G.json().pipe(G.length({ max: 500 })).pipe(G.pii({ action: "redact" })))
+  .build();
+```
+:::
+::::
+
+:::{note} TypeScript naming
+TypeScript uses camelCase: `G.rateLimit`, `G.maxTurns`, `G.regexDetector`. Composition uses `.pipe()` instead of Python's `|` operator. Most factories take an options object: `G.length({ max: 500 })`, `G.pii({ action: "redact" })`, `G.toxicity({ threshold: 0.8 })`.
+:::
 
 ## Design Principle
 
@@ -62,12 +84,28 @@ Each guard answers: **"What must this agent *never* do?"** If you remove the gua
 
 ## Composition
 
-Guards compose with the `|` operator:
+Guards compose with the `|` operator (Python) or `.pipe()` method (TypeScript):
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 safety = G.pii("redact") | G.toxicity(threshold=0.8) | G.budget(max_tokens=5000)
 agent.guard(safety)
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const safety = G.pii({ action: "redact" })
+  .pipe(G.toxicity({ threshold: 0.8 }))
+  .pipe(G.budget({ maxTokens: 5000 }));
+agent.guard(safety);
+```
+:::
+::::
 
 Each guard in the chain runs independently. The first violation aborts.
 
@@ -76,6 +114,10 @@ Each guard in the chain runs independently. The first violation aborts.
 Guards that perform detection or judgment delegate to pluggable providers.
 
 ### PIIDetector
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from adk_fluent._guards import PIIDetector, PIIFinding
@@ -87,15 +129,36 @@ class MyDetector:
 
 agent.guard(G.pii("redact", detector=MyDetector()))
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { G, type PIIDetector, type PIIFinding } from "adk-fluent-ts";
+
+const myDetector: PIIDetector = {
+  async detect(text: string): Promise<PIIFinding[]> {
+    return [{ kind: "EMAIL", start: 0, end: 10, confidence: 0.95, text: "..." }];
+  },
+};
+
+agent.guard(G.pii({ action: "redact", detector: myDetector }));
+```
+:::
+::::
 
 Built-in detector factories:
 
-- `G.regex_detector(patterns)` — Lightweight regex (dev/test)
-- `G.dlp(project)` — Google Cloud DLP (production, requires `google-cloud-dlp`)
-- `G.multi(*detectors)` — Union of findings from multiple detectors
+- `G.regex_detector(patterns)` / `G.regexDetector(patterns)` — Lightweight regex (dev/test)
+- `G.dlp(project)` / `G.dlp({ project, infoTypes, location })` — Google Cloud DLP (production)
+- `G.multi(*detectors)` / `G.multi(...detectors)` — Union of findings from multiple detectors
 - `G.custom(async_fn)` — Wrap any async callable
 
 ### ContentJudge
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from adk_fluent._guards import ContentJudge, JudgmentResult
@@ -106,6 +169,23 @@ class MyJudge:
 
 agent.guard(G.toxicity(threshold=0.8, judge=MyJudge()))
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { G, type ContentJudge, type JudgmentResult } from "adk-fluent-ts";
+
+const myJudge: ContentJudge = {
+  async judge(text: string, context?: Record<string, unknown>): Promise<JudgmentResult> {
+    return { passed: true, score: 0.1, reason: "Clean" };
+  },
+};
+
+agent.guard(G.toxicity({ threshold: 0.8, judge: myJudge }));
+```
+:::
+::::
 
 Built-in judge factories:
 
@@ -116,6 +196,10 @@ Built-in judge factories:
 
 The legacy callable guard pattern still works:
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 def my_guard(callback_context, llm_request):
     # Legacy guard function
@@ -123,6 +207,20 @@ def my_guard(callback_context, llm_request):
 
 agent.guard(my_guard)  # Registers as both before_model and after_model callback
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const myGuard = (ctx: unknown, llmRequest: unknown) => {
+  // Legacy guard function
+  return null;
+};
+
+agent.guard(myGuard); // Registers as both beforeModel and afterModel callback
+```
+:::
+::::
 
 ## How Guards Compile
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -4,6 +4,14 @@ Write agents in 1-3 lines. Get native ADK objects. Keep full control.
 
 This guide takes you from "I know how to build a simple agent" to "I can design production multi-agent systems with data contracts, context engineering, middleware, and evaluation." Read sequentially for the full journey, or jump to the topic you need.
 
+:::{admonition} Python or TypeScript?
+:class: note
+
+This user guide is **Python-first**, but every concept applies to both `adk-fluent` (Python) and `adk-fluent-ts` (TypeScript). Code samples with a synced `Python` / `TypeScript` tab stay in sync once you pick one — click TypeScript on any block and the rest of the site follows.
+
+If you're using TypeScript, read the {doc}`typescript` landing page first. It covers install, imports, and the full operator → method-chain mapping (`>>` → `.then()`, `|` → `.parallel()`, `*` → `.times()`, `//` → `.fallback()`, `@` → `.outputAs()`).
+:::
+
 :::{admonition} Quick taste — every concept in 8 lines
 :class: tip
 
@@ -150,6 +158,7 @@ maxdepth: 2
 hidden: true
 ---
 architecture-and-concepts
+typescript
 best-practices
 comparison
 builders

--- a/docs/user-guide/middleware.md
+++ b/docs/user-guide/middleware.md
@@ -17,9 +17,12 @@ Middleware provides app-global cross-cutting behavior. Unlike [callbacks](callba
 
 Use `.middleware()` on any builder, then `.to_app()` to compile:
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
-from adk_fluent import Agent
-from adk_fluent._middleware import M
+from adk_fluent import Agent, M
 
 pipeline = (
     Agent("a") >> Agent("b")
@@ -27,20 +30,62 @@ pipeline = (
 
 app = pipeline.to_app()
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
 
-Multiple `.middleware()` calls accumulate. When combined with `>>` or `|`, middleware from all operands is merged.
+```ts
+import { Agent, M } from "adk-fluent-ts";
+
+const pipeline = new Agent("a", "gemini-2.5-flash")
+  .then(new Agent("b", "gemini-2.5-flash"))
+  .middleware(M.retry({ maxAttempts: 3 }).pipe(M.log()));
+
+const app = pipeline.toApp();
+```
+:::
+::::
+
+Multiple `.middleware()` calls accumulate. When combined with `>>` / `.then()` or `|` / `.parallel()`, middleware from all operands is merged.
+
+:::{note} TypeScript naming
+TypeScript uses camelCase and options objects: `M.retry({ maxAttempts: 3 })`, `M.circuitBreaker({ maxFails: 5 })`, `M.fallbackModel("gemini-2.5-pro")`. Composition uses `.pipe()` instead of Python's `|`.
+:::
 
 ## The M Module
 
-The M module provides composable middleware factories. Compose with `|` (chain):
+The M module provides composable middleware factories. Compose with `|` / `.pipe()` (chain):
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
-from adk_fluent._middleware import M
+from adk_fluent import Agent, M
 
 # Compose a middleware stack
 stack = M.retry(3) | M.log() | M.latency() | M.cost()
 pipeline = (Agent("a") >> Agent("b")).middleware(stack)
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent, M } from "adk-fluent-ts";
+
+// Compose a middleware stack
+const stack = M.retry({ maxAttempts: 3 })
+  .pipe(M.log())
+  .pipe(M.latency())
+  .pipe(M.cost());
+
+const pipeline = new Agent("a", "gemini-2.5-flash")
+  .then(new Agent("b", "gemini-2.5-flash"))
+  .middleware(stack);
+```
+:::
+::::
 
 ### Built-in Middleware
 
@@ -66,7 +111,7 @@ pipeline = (Agent("a") >> Agent("b")).middleware(stack)
 Middleware runs in the order you compose it. For non-void hooks (`before_model`, `before_tool`), the first middleware to return a non-None value short-circuits the rest:
 
 ```python
-# Retry wraps logging wraps cost tracking
+# Retry wraps logging wraps cost tracking (Python: |, TypeScript: .pipe())
 stack = M.retry(3) | M.log() | M.cost()
 
 # Execution order for before_model:
@@ -89,15 +134,36 @@ Put **retry** first (outermost), **logging** next, then specific concerns (cost,
 
 Apply middleware to specific agents only:
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 # Only retry the LLM-calling agents, not the state transforms
 stack = M.scope(["classifier", "resolver"], M.retry(3)) | M.log()
 pipeline = (Agent("classifier") >> Agent("resolver")).middleware(stack)
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+// Only retry the LLM-calling agents, not the state transforms
+const stack = M.scope(["classifier", "resolver"], M.retry({ maxAttempts: 3 })).pipe(M.log());
+const pipeline = new Agent("classifier", "gemini-2.5-flash")
+  .then(new Agent("resolver", "gemini-2.5-flash"))
+  .middleware(stack);
+```
+:::
+::::
 
 ### Conditional Middleware
 
 Apply middleware based on runtime conditions:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 import os
@@ -105,6 +171,16 @@ import os
 # Only enable cost tracking in production
 stack = M.log() | M.when(os.getenv("ENV") == "production", M.cost())
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+// Only enable cost tracking in production
+const stack = M.log().pipe(M.when(process.env.ENV === "production", M.cost()));
+```
+:::
+::::
 
 ## Middleware Protocol
 
@@ -138,6 +214,10 @@ All methods are optional. Implement only what you need.
 
 ## Writing Custom Middleware
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 import time
 
@@ -154,6 +234,26 @@ class TimingMiddleware:
         elapsed = time.time() - context.state.get("_start", time.time())
         self.timings[agent.name] = elapsed
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+class TimingMiddleware {
+  timings: Record<string, number> = {};
+
+  async beforeAgent({ agent, context }: { agent: { name: string }; context: { state: Record<string, unknown> } }) {
+    context.state._start = Date.now();
+  }
+
+  async afterAgent({ agent, context }: { agent: { name: string }; context: { state: Record<string, unknown> } }) {
+    const start = (context.state._start as number) ?? Date.now();
+    this.timings[agent.name] = Date.now() - start;
+  }
+}
+```
+:::
+::::
 
 ## How Middleware Works
 
@@ -191,15 +291,37 @@ Middleware Lifecycle (execution order):
 
 Guards are per-agent safety checks. Middleware is pipeline-wide infrastructure. Use both:
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
-from adk_fluent import Agent, G
-from adk_fluent._middleware import M
+from adk_fluent import Agent, G, M
 
 agent = Agent("service").instruct("Help.").guard(G.pii("redact") | G.length(max=500))
 pipeline = (agent >> Agent("auditor")).middleware(M.retry(3) | M.log())
 # Guards: PII redaction on the service agent only
 # Middleware: retry + logging on the entire pipeline
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent, G, M } from "adk-fluent-ts";
+
+const agent = new Agent("service", "gemini-2.5-flash")
+  .instruct("Help.")
+  .guard(G.pii({ action: "redact" }).pipe(G.length({ max: 500 })));
+
+const pipeline = agent
+  .then(new Agent("auditor", "gemini-2.5-flash"))
+  .middleware(M.retry({ maxAttempts: 3 }).pipe(M.log()));
+// Guards: PII redaction on the service agent only
+// Middleware: retry + logging on the entire pipeline
+```
+:::
+::::
 
 See [Guards](guards.md).
 
@@ -221,9 +343,12 @@ See [Visibility](visibility.md).
 
 Middleware and context engineering don't interact directly, but they complement each other. Context engineering controls what the LLM sees; middleware controls how the pipeline behaves:
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
-from adk_fluent import Agent, C
-from adk_fluent._middleware import M
+from adk_fluent import Agent, C, M
 
 pipeline = (
     Agent("classifier").context(C.none()).writes("intent")
@@ -232,19 +357,56 @@ pipeline = (
 # Context: each agent sees only what it needs
 # Middleware: retry, logging, cost tracking across all agents
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent, C, M } from "adk-fluent-ts";
+
+const pipeline = new Agent("classifier", "gemini-2.5-flash")
+  .context(C.none())
+  .writes("intent")
+  .then(new Agent("resolver", "gemini-2.5-flash").context(C.fromState("intent")))
+  .middleware(M.retry({ maxAttempts: 3 }).pipe(M.log()).pipe(M.cost()));
+// Context: each agent sees only what it needs
+// Middleware: retry, logging, cost tracking across all agents
+```
+:::
+::::
 
 ### Middleware + Testing
 
 Use `M.log()` in tests to capture events for assertions:
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
-from adk_fluent._middleware import M
+from adk_fluent import Agent, M
 
 logger = M.log()
 pipeline = (Agent("a") >> Agent("b")).middleware(logger)
 app = pipeline.to_app()
 # After execution: inspect logger.events for assertions
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent, M } from "adk-fluent-ts";
+
+const logger = M.log();
+const pipeline = new Agent("a", "gemini-2.5-flash")
+  .then(new Agent("b", "gemini-2.5-flash"))
+  .middleware(logger);
+const app = pipeline.toApp();
+// After execution: inspect logger events for assertions
+```
+:::
+::::
 
 See [Testing](testing.md).
 

--- a/docs/user-guide/patterns.md
+++ b/docs/user-guide/patterns.md
@@ -1,10 +1,39 @@
 # Composition Patterns
 
-Higher-order constructors from `adk_fluent.patterns` that compose agents into common architectures. Each pattern is a function that returns a ready-to-use builder.
+Higher-order constructors that compose agents into common architectures. Each pattern is a function that returns a ready-to-use builder. Both packages ship the same pattern set with parallel naming (snake_case in Python, camelCase in TypeScript).
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
-from adk_fluent.patterns import review_loop, cascade, fan_out_merge, chain, conditional, supervised, map_reduce
+from adk_fluent.patterns import (
+    review_loop,
+    cascade,
+    fan_out_merge,
+    chain,
+    conditional,
+    supervised,
+    map_reduce,
+)
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import {
+  reviewLoop,
+  cascade,
+  fanOutMerge,
+  chain,
+  conditional,
+  supervised,
+  mapReduce,
+} from "adk-fluent-ts";
+```
+:::
+::::
 
 ```
 Pattern Quick Reference:
@@ -27,6 +56,10 @@ ______________________________________________________________________
 
 A worker produces output, a reviewer scores it, and the loop repeats until quality meets the target.
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 pipeline = review_loop(
     worker=Agent("writer").instruct("Write a blog post about {topic}."),
@@ -36,6 +69,19 @@ pipeline = review_loop(
     max_rounds=3,
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const pipeline = reviewLoop(
+  new Agent("writer", "gemini-2.5-flash").instruct("Write a blog post about {topic}."),
+  new Agent("reviewer", "gemini-2.5-flash").instruct("Score the draft 0-1 for quality."),
+  { qualityKey: "review_score", target: 0.8, maxRounds: 3 },
+);
+```
+:::
+::::
 
 ```
     ┌──────────────────────────────────────────────┐
@@ -62,6 +108,10 @@ ______________________________________________________________________
 
 Tries each agent in order. First successful response wins.
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 pipeline = cascade(
     Agent("fast").model("gemini-2.0-flash"),
@@ -69,6 +119,19 @@ pipeline = cascade(
     Agent("fallback").model("gemini-2.0-flash").instruct("Provide a safe default."),
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const pipeline = cascade(
+  new Agent("fast", "gemini-2.0-flash"),
+  new Agent("smart", "gemini-2.5-pro"),
+  new Agent("fallback", "gemini-2.0-flash").instruct("Provide a safe default."),
+);
+```
+:::
+::::
 
 ```
     fast ──► success? ─── yes ──► done
@@ -86,6 +149,10 @@ ______________________________________________________________________
 
 Run multiple agents in parallel, then merge their outputs.
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 pipeline = fan_out_merge(
     Agent("web_search").writes("web"),
@@ -95,6 +162,22 @@ pipeline = fan_out_merge(
     merge_fn=lambda results: "\n\n".join(results.values()),
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const pipeline = fanOutMerge(
+  [
+    new Agent("web_search", "gemini-2.5-flash").writes("web"),
+    new Agent("doc_search", "gemini-2.5-flash").writes("docs"),
+    new Agent("expert", "gemini-2.5-flash").writes("expert"),
+  ],
+  { mergeKey: "combined" },
+);
+```
+:::
+::::
 
 ```
     ┌─ web_search ──► state["web"]  ─┐
@@ -114,6 +197,10 @@ ______________________________________________________________________
 
 Compose a list of steps into a Pipeline.
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 pipeline = chain(
     Agent("researcher").writes("findings"),
@@ -121,6 +208,19 @@ pipeline = chain(
     Agent("editor").reads("draft").writes("final"),
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const pipeline = chain(
+  new Agent("researcher", "gemini-2.5-flash").writes("findings"),
+  new Agent("writer", "gemini-2.5-flash").reads("findings").writes("draft"),
+  new Agent("editor", "gemini-2.5-flash").reads("draft").writes("final"),
+);
+```
+:::
+::::
 
 **Data flow:** Each agent runs in sequence. State propagates between steps via `.writes()` and `.reads()`.
 
@@ -130,6 +230,10 @@ ______________________________________________________________________
 
 Route to different agents based on a predicate.
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 pipeline = conditional(
     predicate=lambda state: state.get("category") == "technical",
@@ -137,6 +241,19 @@ pipeline = conditional(
     if_false=Agent("general_support").instruct("Handle general inquiry."),
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const pipeline = conditional(
+  (state) => state.category === "technical",
+  new Agent("tech_support", "gemini-2.5-flash").instruct("Handle technical issue."),
+  new Agent("general_support", "gemini-2.5-flash").instruct("Handle general inquiry."),
+);
+```
+:::
+::::
 
 ```
                     ┌─ yes ──► tech_support
@@ -152,6 +269,10 @@ ______________________________________________________________________
 
 A worker produces output, a supervisor approves or requests revisions.
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 pipeline = supervised(
     worker=Agent("drafter").instruct("Draft the contract."),
@@ -160,6 +281,19 @@ pipeline = supervised(
     max_revisions=2,
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const pipeline = supervised(
+  new Agent("drafter", "gemini-2.5-flash").instruct("Draft the contract."),
+  new Agent("lawyer", "gemini-2.5-flash").instruct("Review for legal compliance."),
+  { approvedKey: "approved", maxRounds: 2 },
+);
+```
+:::
+::::
 
 **Data flow:** Similar to `review_loop` but with approval semantics. The supervisor marks `state[approval_key]` as approved or requests changes.
 
@@ -169,6 +303,10 @@ ______________________________________________________________________
 
 Apply a mapper agent to each item, then reduce results.
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 pipeline = map_reduce(
     mapper=Agent("analyzer").instruct("Analyze this item: {item}"),
@@ -176,6 +314,19 @@ pipeline = map_reduce(
     items_key="items",
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const pipeline = mapReduce(
+  new Agent("analyzer", "gemini-2.5-flash").instruct("Analyze this item: {item}"),
+  new Agent("synthesizer", "gemini-2.5-flash").instruct("Synthesize all analyses."),
+  { itemsKey: "items", resultKey: "report" },
+);
+```
+:::
+::::
 
 ```
     state["items"] ──┬─ mapper("item_0") ─┐

--- a/docs/user-guide/prompts.md
+++ b/docs/user-guide/prompts.md
@@ -8,6 +8,10 @@ The `P` namespace provides structured, composable prompt construction using froz
 
 ## Basic Usage
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 from adk_fluent import Agent, P
 
@@ -23,8 +27,31 @@ prompt = (
 
 agent = Agent("reviewer").model("gemini-2.5-flash").instruct(prompt).build()
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
 
-Each `P.xxx()` call returns an immutable `PTransform` dataclass. Transforms compose via `+` (union) and `|` (pipe).
+```ts
+import { Agent, P } from "adk-fluent-ts";
+
+const prompt = P.role("You are a senior code reviewer.")
+  .add(P.context("The codebase uses Python 3.11 with type hints."))
+  .add(P.task("Review the code for bugs and security issues."))
+  .add(P.constraint("Be concise. Max 5 bullet points."))
+  .add(P.constraint("No false positives."))
+  .add(P.format("Return markdown with ## sections."))
+  .add(P.example({ input: "x=eval(input())", output: "Critical: eval() on user input" }));
+
+const agent = new Agent("reviewer", "gemini-2.5-flash").instruct(prompt).build();
+```
+:::
+::::
+
+Each `P.xxx()` call returns an immutable `PTransform`. Transforms compose via `+` / `.add()` (union) and `|` / `.pipe()` (pipe).
+
+:::{note} TypeScript naming
+TypeScript uses camelCase: `P.fromState`, `P.uiSchema`. The `+` operator from Python becomes `.add()` and `|` becomes `.pipe()`. `P.example(input=..., output=...)` becomes `P.example({ input, output })`.
+:::
 
 ## Core Sections
 
@@ -110,9 +137,13 @@ Adds a custom named section:
 P.section("Audience", "C-level executives with limited technical background.")
 ```
 
-## Composability with `+`
+## Composability
 
-Prompts compose and reuse via the `+` operator:
+Prompts compose and reuse:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 base = P.role("You are a senior engineer.") + P.constraint("Be precise.")
@@ -120,12 +151,32 @@ base = P.role("You are a senior engineer.") + P.constraint("Be precise.")
 reviewer = Agent("reviewer").instruct(base + P.task("Review code."))
 writer   = Agent("writer").instruct(base + P.task("Write documentation."))
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const base = P.role("You are a senior engineer.").add(P.constraint("Be precise."));
+
+const reviewer = new Agent("reviewer", "gemini-2.5-flash").instruct(
+  base.add(P.task("Review code.")),
+);
+const writer = new Agent("writer", "gemini-2.5-flash").instruct(
+  base.add(P.task("Write documentation.")),
+);
+```
+:::
+::::
 
 This allows you to define common persona, constraints, and context once, then specialize with task-specific sections.
 
 ## Building and Inspection
 
-Every `PTransform` supports `.build()`, `str()`, and `.fingerprint()`:
+Every prompt transform can be rendered to a string with state values resolved:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 prompt = P.role("Helper.") + P.task("Answer questions.")
@@ -140,12 +191,31 @@ text = prompt.build(state={"topic": "Python"})
 # SHA-256 fingerprint for caching/versioning
 fp = prompt.fingerprint()  # e.g. "a1b2c3d4e5f6"
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const prompt = P.role("Helper.").add(P.task("Answer questions."));
+
+// Compile to instruction string
+const text1 = prompt.render();
+
+// Compile with state variables resolved
+const text2 = prompt.render({ topic: "Python" });
+```
+:::
+::::
 
 ## Conditional and Dynamic Sections
 
 ### `P.when(predicate, block)`
 
 Include a section only when a condition is met at runtime:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 # String predicate — checks if state key is truthy
@@ -160,10 +230,25 @@ prompt = (
     + P.when(lambda s: s.get("tier") == "premium", P.context("Premium features enabled."))
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
 
-### `P.from_state(*keys)`
+```ts
+const prompt = P.role("Helper").add(
+  P.when((s) => s.tier === "premium", P.context("Premium features enabled.")),
+);
+```
+:::
+::::
+
+### `P.fromState()` / `P.from_state()`
 
 Read named keys from session state and render as context:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 prompt = P.role("Support agent") + P.from_state("customer_name", "plan")
@@ -171,15 +256,37 @@ prompt = P.role("Support agent") + P.from_state("customer_name", "plan")
 #   customer_name: Alice
 #   plan: pro
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const prompt = P.role("Support agent").add(P.fromState("customer_name", "plan"));
+```
+:::
+::::
 
 ### `P.template(text)`
 
 Template string with `{key}`, `{key?}` (optional), and `{ns:key}` (namespaced) placeholders:
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 prompt = P.template("Help the user with {topic} in a {style} tone. Note: {extra?}")
 # {topic} and {style} are required; {extra?} resolves to empty string if missing
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const prompt = P.template("Help the user with {topic} in a {style} tone. Note: {extra?}");
+```
+:::
+::::
 
 ## Structural Transforms
 
@@ -291,6 +398,10 @@ Optional variables use `?` suffix (`{maybe_key?}` returns empty string if missin
 
 Split prompts into cacheable and dynamic parts:
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 agent = (
     Agent("analyst")
@@ -300,12 +411,28 @@ agent = (
     .build()
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const agent = new Agent("analyst", "gemini-2.5-flash")
+  .static("You are a financial analyst. Here is the 50-page annual report: ...")
+  .instruct("Answer the user's question about the report.")
+  .build();
+```
+:::
+::::
 
 When `.static()` is set, the static content goes as a system instruction (eligible for context caching), while `.instruct()` content goes as user content. This avoids re-processing large static contexts on every turn.
 
 ## Dynamic Context Injection
 
 Prepend runtime context to every LLM call:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 agent = (
@@ -316,5 +443,17 @@ agent = (
     .prepend(lambda ctx: f"Plan: {ctx.state.get('plan', 'free')}")
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const agent = new Agent("support", "gemini-2.5-flash")
+  .instruct("Help the customer.")
+  .prepend((ctx) => `Customer: ${ctx.state.customer_name ?? "unknown"}`)
+  .prepend((ctx) => `Plan: ${ctx.state.plan ?? "free"}`);
+```
+:::
+::::
 
 Each `.prepend()` call accumulates. The function receives the callback context and returns a string that gets prepended as content before the LLM processes the request.

--- a/docs/user-guide/state-transforms.md
+++ b/docs/user-guide/state-transforms.md
@@ -23,12 +23,34 @@ flowchart TB
 
 **Composition operators:**
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 S.drop() >> S.merge()         # chain: run in sequence
 S.default() + S.rename()      # combine: apply to same state
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+S.drop().pipe(S.merge_(["a", "b"], "c"));     // chain: run in sequence
+S.default_({ k: 1 }).add(S.rename({ a: "b" })); // combine: apply to same state
+```
+:::
+::::
+
+:::{note} TypeScript naming
+JavaScript reserves the `default` keyword, so `S.default` becomes `S.default_` and `S.merge` becomes `S.merge_` in TypeScript. The signature also flips: `S.merge_(["a","b"], "into")` takes the keys as an array and the destination as a positional argument.
+:::
 
 ## Basic Usage
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from adk_fluent import S
@@ -41,6 +63,22 @@ pipeline = (
     >> writer_agent
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { S } from "adk-fluent-ts";
+
+const pipeline = webAgent
+  .parallel(scholarAgent)
+  .then(S.merge_(["web", "scholar"], "research"))
+  .then(S.default_({ confidence: 0.0 }))
+  .then(S.rename({ research: "input" }))
+  .then(writerAgent);
+```
+:::
+::::
 
 ## Transform Reference
 
@@ -60,41 +98,97 @@ pipeline = (
 
 Keep only the specified keys in state, dropping everything else:
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 # After this, state only contains "name" and "email"
 pipeline = agent >> S.pick("name", "email") >> next_agent
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const pipeline = agent.then(S.pick("name", "email")).then(nextAgent);
+```
+:::
+::::
 
 ## `S.drop(*keys)`
 
 Remove the specified keys from state:
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 # Remove temporary/internal keys before the next step
 pipeline = agent >> S.drop("_internal", "_debug") >> next_agent
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
 
-## `S.rename(**kw)`
+```ts
+const pipeline = agent.then(S.drop("_internal", "_debug")).then(nextAgent);
+```
+:::
+::::
 
-Rename keys in state. The keyword argument maps old names to new names:
+## `S.rename(...)`
+
+Rename keys in state, mapping old names to new names:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 # Rename "research" to "input" for the next agent
 pipeline = researcher >> S.rename(research="input") >> writer
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
 
-## `S.default(**kw)`
+```ts
+const pipeline = researcher.then(S.rename({ research: "input" })).then(writer);
+```
+:::
+::::
+
+## `S.default(...)`
 
 Fill in missing keys with default values. Existing keys are not overwritten:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 # Ensure "confidence" exists with a default of 0.0
 pipeline = agent >> S.default(confidence=0.0) >> evaluator
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
 
-## `S.merge(*keys, into=)`
+```ts
+const pipeline = agent.then(S.default_({ confidence: 0.0 })).then(evaluator);
+```
+:::
+::::
+
+## `S.merge(...)`
 
 Combine multiple keys into a single key:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 # Merge "web" and "scholar" results into "research"
@@ -104,19 +198,50 @@ pipeline = (
     >> writer
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const pipeline = webAgent
+  .parallel(scholarAgent)
+  .then(S.merge_(["web", "scholar"], "research"))
+  .then(writer);
+```
+:::
+::::
 
 ## `S.transform(key, fn)`
 
 Apply a function to transform a single value in state:
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 # Uppercase the "title" value
 pipeline = agent >> S.transform("title", str.upper) >> next_agent
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
 
-## `S.compute(**fns)`
+```ts
+const pipeline = agent
+  .then(S.transform("title", (v) => String(v).toUpperCase()))
+  .then(nextAgent);
+```
+:::
+::::
+
+## `S.compute(...)`
 
 Derive new keys by applying functions to the state:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 # Compute a new "summary_length" key from the existing state
@@ -125,19 +250,54 @@ pipeline = agent >> S.compute(
     has_citations=lambda s: "cite" in s.get("text", "").lower()
 ) >> evaluator
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const pipeline = agent
+  .then(
+    S.compute({
+      summary_length: (s) => String(s.summary ?? "").length,
+      has_citations: (s) => String(s.text ?? "").toLowerCase().includes("cite"),
+    }),
+  )
+  .then(evaluator);
+```
+:::
+::::
 
 ## `S.guard(pred)`
 
 Assert an invariant on the state. Raises an error if the predicate fails:
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 # Ensure "data" key is present before proceeding
 pipeline = agent >> S.guard(lambda s: "data" in s) >> processor
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const pipeline = agent
+  .then(S.guard((s) => "data" in s, "missing data key"))
+  .then(processor);
+```
+:::
+::::
 
 ## `S.log(*keys)`
 
 Debug-print specified keys from state. Useful during development:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 # Print "web" and "scholar" values for debugging
@@ -148,35 +308,89 @@ pipeline = (
     >> writer
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const pipeline = webAgent
+  .parallel(scholarAgent)
+  .then(S.log("web", "scholar"))
+  .then(S.merge_(["web", "scholar"], "research"))
+  .then(writer);
+```
+:::
+::::
 
 ## STransform Composition
 
 All `S.xxx()` methods return `STransform` objects that support two composition operators:
 
-### `>>` — Chain (sequential)
+### Chain (sequential)
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 # Clean state then merge — runs in order
 cleanup = S.drop("_internal") >> S.merge("web", "scholar", into="research")
 pipeline = agent >> cleanup >> writer
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
 
-### `+` — Combine (parallel)
+```ts
+const cleanup = S.drop("_internal").pipe(S.merge_(["web", "scholar"], "research"));
+const pipeline = agent.then(cleanup).then(writer);
+```
+:::
+::::
+
+### Combine (parallel)
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 # Apply multiple transforms to the same state at once
 setup = S.default(confidence=0.0) + S.rename(research="input")
 pipeline = agent >> setup >> writer
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const setup = S.default_({ confidence: 0.0 }).add(S.rename({ research: "input" }));
+const pipeline = agent.then(setup).then(writer);
+```
+:::
+::::
 
 ### Composing with agents
 
 STransform objects work seamlessly in pipelines:
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 # STransform >> Agent works directly
 pipeline = S.capture("user_message") >> classifier >> handler
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const pipeline = S.capture("user_message").then(classifier).then(handler);
+```
+:::
+::::
 
 ### Key tracking
 
@@ -208,6 +422,10 @@ Complete transform flow:
   S.guard(confidence > 0)  ── fail? ──► raise
 ```
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 from pydantic import BaseModel
 from adk_fluent import Agent, S, until
@@ -229,3 +447,32 @@ pipeline = (
     >> S.guard(lambda s: s.get("confidence", 0) > 0)    # Assert
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent, S } from "adk-fluent-ts";
+
+const ReportSchema = {
+  type: "object",
+  properties: {
+    title: { type: "string" },
+    body: { type: "string" },
+    confidence: { type: "number" },
+  },
+  required: ["title", "body", "confidence"],
+} as const;
+
+const pipeline = new Agent("web", "gemini-2.5-flash")
+  .instruct("Search web.")
+  .parallel(new Agent("scholar", "gemini-2.5-flash").instruct("Search papers."))
+  .then(S.log("web", "scholar"))                                    // Debug
+  .then(S.merge_(["web", "scholar"], "research"))                   // Combine
+  .then(S.default_({ confidence: 0.0 }))                            // Default
+  .then(S.rename({ research: "input" }))                            // Rename
+  .then(new Agent("writer", "gemini-2.5-flash").instruct("Write.").outputAs(ReportSchema))
+  .then(S.guard((s) => Number(s.confidence ?? 0) > 0, "confidence must be > 0")); // Assert
+```
+:::
+::::

--- a/docs/user-guide/structured-data.md
+++ b/docs/user-guide/structured-data.md
@@ -8,6 +8,10 @@ Agents that return free-form text are fine for chat, but production pipelines ne
 
 ### Basic usage
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 from adk_fluent import Agent
 
@@ -17,6 +21,19 @@ classifier = (
     .writes("category")
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent } from "adk-fluent-ts";
+
+const classifier = new Agent("classifier", "gemini-2.5-flash")
+  .instruct("Classify the customer inquiry as one of: billing, technical, account, general.")
+  .writes("category");
+```
+:::
+::::
 
 After `classifier` runs, `state["category"]` holds the response text (e.g., `"billing"`).
 
@@ -24,16 +41,34 @@ After `classifier` runs, `state["category"]` holds the response text (e.g., `"bi
 
 Downstream agents reference state keys with `{key}` placeholders. ADK resolves these at runtime:
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
 handler = (
     Agent("handler", "gemini-2.5-flash")
     .instruct("The customer's issue is categorized as: {category}. Resolve it.")
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const handler = new Agent("handler", "gemini-2.5-flash")
+  .instruct("The customer's issue is categorized as: {category}. Resolve it.");
+```
+:::
+::::
 
 When `handler` runs, `{category}` is replaced by whatever `classifier` stored.
 
 ### Pipeline example: classify then route
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from adk_fluent import Agent
@@ -52,6 +87,31 @@ pipeline = (
     .instruct("Summarize the resolution for the customer: {resolution}")
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent } from "adk-fluent-ts";
+
+const pipeline = new Agent("classifier", "gemini-2.5-flash")
+  .instruct("Classify the support ticket as: billing, technical, or account.")
+  .writes("category")
+  .then(
+    new Agent("resolver", "gemini-2.5-flash")
+      .instruct(
+        "You handle {category} issues. " +
+        "Investigate the customer's problem and provide a resolution.",
+      )
+      .writes("resolution"),
+  )
+  .then(
+    new Agent("summarizer", "gemini-2.5-flash")
+      .instruct("Summarize the resolution for the customer: {resolution}"),
+  );
+```
+:::
+::::
 
 Each agent writes to a distinct key. The pipeline reads like a data flow: `category` feeds `resolver`, whose `resolution` feeds `summarizer`.
 
@@ -100,7 +160,11 @@ When you need the LLM to return structured JSON rather than free text, use `.ret
 When `output_schema` is set, the agent **cannot use tools**. ADK enforces this because structured output mode changes how the model generates responses. If you need both tool use and structured output, split them into separate agents in a pipeline.
 ```
 
-### Defining a Pydantic model
+### Defining a schema
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from pydantic import BaseModel, Field
@@ -111,10 +175,46 @@ class Invoice(BaseModel):
     due_date: str = Field(description="Due date in YYYY-MM-DD format")
     line_items: list[str] = Field(description="List of items or services billed")
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+// Option 1: Plain JSON Schema (as const)
+const InvoiceSchema = {
+  type: "object",
+  properties: {
+    vendor: { type: "string", description: "Company or person who issued the invoice" },
+    amount: { type: "number", description: "Total amount in USD" },
+    due_date: { type: "string", description: "Due date in YYYY-MM-DD format" },
+    line_items: {
+      type: "array",
+      items: { type: "string" },
+      description: "List of items or services billed",
+    },
+  },
+  required: ["vendor", "amount", "due_date", "line_items"],
+} as const;
+
+// Option 2: Zod (if you prefer runtime validation)
+// import { z } from "zod";
+// const Invoice = z.object({
+//   vendor: z.string().describe("Company or person who issued the invoice"),
+//   amount: z.number().describe("Total amount in USD"),
+//   due_date: z.string().describe("Due date in YYYY-MM-DD format"),
+//   line_items: z.array(z.string()),
+// });
+```
+:::
+::::
 
 Field descriptions are passed to the LLM as part of the schema, helping it fill fields accurately.
 
-### Builder style: `.returns()`
+### Builder style: `.returns()` / `.outputAs()`
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 extractor = (
@@ -124,6 +224,22 @@ extractor = (
     .writes("invoice_data")
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const extractor = new Agent("invoice_extractor", "gemini-2.5-flash")
+  .instruct("Extract invoice details from the provided document text.")
+  .outputAs(InvoiceSchema)
+  .writes("invoice_data");
+```
+:::
+::::
+
+:::{note} TypeScript naming
+TypeScript uses `.outputAs(schema)` where Python uses `.returns(Model)`. It accepts any JSON schema descriptor (plain `as const` objects, Zod schemas, or native JSON schema). The `@` operator shorthand is Python-only.
+:::
 
 The agent will respond with a JSON object like:
 
@@ -152,7 +268,11 @@ Both forms produce identical results. Use `@` in operator expressions where brev
 
 ### Combining with `.writes(key)`
 
-When both `.returns()` and `.writes(key)` are set, the structured JSON response is stored in session state under the given key. This is the recommended pattern for structured pipelines:
+When both `.returns()` / `.outputAs()` and `.writes(key)` are set, the structured JSON response is stored in session state under the given key. This is the recommended pattern for structured pipelines:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from pydantic import BaseModel, Field
@@ -170,6 +290,30 @@ analyzer = (
     .writes("sentiment")
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent } from "adk-fluent-ts";
+
+const SentimentResultSchema = {
+  type: "object",
+  properties: {
+    sentiment: { type: "string", description: "positive, negative, or neutral" },
+    confidence: { type: "number", description: "Confidence score between 0.0 and 1.0" },
+    reasoning: { type: "string", description: "Brief explanation of the classification" },
+  },
+  required: ["sentiment", "confidence", "reasoning"],
+} as const;
+
+const analyzer = new Agent("sentiment_analyzer", "gemini-2.5-flash")
+  .instruct("Analyze the sentiment of the provided customer review.")
+  .outputAs(SentimentResultSchema)
+  .writes("sentiment");
+```
+:::
+::::
 
 After this agent runs, `state["sentiment"]` contains the JSON string. Downstream agents can reference `{sentiment}` in their instructions.
 
@@ -190,6 +334,10 @@ extractor = LlmAgent(
 ## Input Schema: `.accepts()`
 
 `.accepts()` defines the expected input structure when an agent is invoked as a tool by another agent. This is less commonly used than `returns`, but it matters in coordinator/agent_tool patterns where one agent calls another as a tool.
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from pydantic import BaseModel, Field
@@ -212,6 +360,40 @@ lookup_agent = (
     .returns(CompanyInfo)
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent } from "adk-fluent-ts";
+
+const LookupRequestSchema = {
+  type: "object",
+  properties: {
+    company_name: { type: "string", description: "Name of the company to look up" },
+    fields: { type: "array", items: { type: "string" } },
+  },
+  required: ["company_name", "fields"],
+} as const;
+
+const CompanyInfoSchema = {
+  type: "object",
+  properties: {
+    name: { type: "string" },
+    industry: { type: "string" },
+    revenue: { type: "string" },
+    employee_count: { type: "number" },
+  },
+  required: ["name", "industry", "revenue", "employee_count"],
+} as const;
+
+const lookupAgent = new Agent("company_lookup", "gemini-2.5-flash")
+  .instruct("Look up the requested company information and return structured data.")
+  .accepts(LookupRequestSchema)
+  .outputAs(CompanyInfoSchema);
+```
+:::
+::::
 
 When a coordinator agent invokes `lookup_agent` as an agent_tool, it knows what arguments to provide (`LookupRequest`) and what structured response to expect (`CompanyInfo`).
 
@@ -220,6 +402,10 @@ When a coordinator agent invokes `lookup_agent` as an agent_tool, it knows what 
 ### Reading structured data in instructions
 
 The simplest pattern is `{key}` substitution. The entire value stored at that key is interpolated into the instruction string:
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 pipeline = (
@@ -231,6 +417,22 @@ pipeline = (
     .instruct("Process this order for fulfillment: {order}")
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+const pipeline = new Agent("extractor", "gemini-2.5-flash")
+  .instruct("Extract the order details.")
+  .outputAs(OrderDetailsSchema)
+  .writes("order")
+  .then(
+    new Agent("fulfillment", "gemini-2.5-flash")
+      .instruct("Process this order for fulfillment: {order}"),
+  );
+```
+:::
+::::
 
 The fulfillment agent receives the full JSON string in its instruction, which it can reason about.
 
@@ -280,9 +482,12 @@ fulfillment = (
 
 A common architecture pairs `.writes()` with deterministic routing. The classifier stores its result, and a `Route` (or dict shorthand) branches without any additional LLM call:
 
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
 ```python
-from adk_fluent import Agent
-from adk_fluent._routing import Route
+from adk_fluent import Agent, Route
 
 classifier = (
     Agent("classifier", "gemini-2.5-flash")
@@ -310,12 +515,41 @@ pipeline = classifier >> {
     "inquiry": inquiry_agent,
 }
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent, Route } from "adk-fluent-ts";
+
+const classifier = new Agent("classifier", "gemini-2.5-flash")
+  .instruct("Classify the request as: refund, exchange, or inquiry.")
+  .writes("request_type");
+
+const refundAgent = new Agent("refund", "gemini-2.5-flash").instruct("Process the refund request.");
+const exchangeAgent = new Agent("exchange", "gemini-2.5-flash").instruct("Process the exchange request.");
+const inquiryAgent = new Agent("inquiry", "gemini-2.5-flash").instruct("Answer the customer inquiry.");
+
+// Route on exact match -- zero LLM calls for routing
+const pipeline = classifier.then(
+  new Route("request_type")
+    .eq("refund", refundAgent)
+    .eq("exchange", exchangeAgent)
+    .eq("inquiry", inquiryAgent),
+);
+```
+:::
+::::
 
 ## Complete Example
 
 This example demonstrates a realistic document processing pipeline that combines all three mechanisms. An extractor agent parses contract documents into structured data. A risk assessor reads that data and produces a risk evaluation. A final agent summarizes everything for a human reviewer.
 
 ### Fluent version
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
 
 ```python
 from pydantic import BaseModel, Field
@@ -369,6 +603,70 @@ pipeline = (
     )
 )
 ```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent } from "adk-fluent-ts";
+
+// --- Schemas ---
+
+const ContractDetailsSchema = {
+  type: "object",
+  properties: {
+    parties: { type: "array", items: { type: "string" }, description: "Names of all contracting parties" },
+    effective_date: { type: "string", description: "Contract start date, YYYY-MM-DD" },
+    termination_date: { type: "string", description: "Contract end date, YYYY-MM-DD" },
+    total_value: { type: "number", description: "Total contract value in USD" },
+    key_obligations: { type: "array", items: { type: "string" } },
+    governing_law: { type: "string", description: "Jurisdiction governing the contract" },
+  },
+  required: ["parties", "effective_date", "termination_date", "total_value", "key_obligations", "governing_law"],
+} as const;
+
+const RiskAssessmentSchema = {
+  type: "object",
+  properties: {
+    risk_level: { type: "string", description: "low, medium, or high" },
+    risk_factors: { type: "array", items: { type: "string" } },
+    recommendation: { type: "string", description: "Action recommendation for legal review" },
+  },
+  required: ["risk_level", "risk_factors", "recommendation"],
+} as const;
+
+// --- Pipeline ---
+
+const pipeline = new Agent("extractor", "gemini-2.5-flash")
+  .instruct(
+    "Extract the key details from the provided contract document. " +
+    "Identify all parties, dates, financial terms, obligations, and jurisdiction.",
+  )
+  .outputAs(ContractDetailsSchema)
+  .writes("contract")
+  .then(
+    new Agent("risk_assessor", "gemini-2.5-flash")
+      .instruct(
+        "Review the following contract details and assess the risk level.\n\n" +
+        "Contract: {contract}\n\n" +
+        "Consider: value concentration, termination clauses, jurisdiction risks, " +
+        "and obligation imbalances.",
+      )
+      .outputAs(RiskAssessmentSchema)
+      .writes("risk"),
+  )
+  .then(
+    new Agent("summarizer", "gemini-2.5-flash")
+      .instruct(
+        "Write a concise executive summary for the legal team.\n\n" +
+        "Contract details: {contract}\n" +
+        "Risk assessment: {risk}\n\n" +
+        "Include the risk level, key concerns, and recommended next steps.",
+      ),
+  );
+```
+:::
+::::
 
 ### Native ADK equivalent
 

--- a/docs/user-guide/typescript.md
+++ b/docs/user-guide/typescript.md
@@ -1,0 +1,186 @@
+# TypeScript (adk-fluent-ts)
+
+:::{note} Python is the reference implementation
+These docs are **Python-first**. Conceptual chapters (context engineering, patterns, prompts, guards, evaluation, deployment, architecture) describe the shared model, and almost every code sample is available as a synced **Python / TypeScript** tab. Pick "TypeScript" on any tab and the rest of the site remembers the choice.
+
+This page is the home base for TS developers: install, the operator → method-chain mapping, imports, and where to find TS-specific assets.
+:::
+
+## Install
+
+`adk-fluent-ts` lives in [`ts/`](https://github.com/vamsiramakrishnan/adk-fluent/tree/master/ts) in the monorepo. It is not yet published to npm; during beta, consume it from the repo.
+
+```bash
+cd ts
+npm install
+npm run build
+```
+
+`adk-fluent-ts` peer-depends on [`@google/adk`](https://www.npmjs.com/package/@google/adk) — the JavaScript port of Google ADK. Install it in your consumer project alongside `adk-fluent-ts`.
+
+## Imports
+
+```ts
+import { Agent, Pipeline, FanOut, Loop, Fallback } from "adk-fluent-ts";
+import { S, C, P, T, G, M, A, E, UI } from "adk-fluent-ts";
+import { tap, expect, gate, race, dispatch, join, Route } from "adk-fluent-ts";
+import { reviewLoop, mapReduce, cascade, chain, conditional } from "adk-fluent-ts";
+import { RemoteAgent, A2AServer, AgentRegistry } from "adk-fluent-ts";
+```
+
+All nine namespaces (`S`, `C`, `P`, `T`, `G`, `M`, `A`, `E`, `UI`) plus the `H` harness namespace are available. The surface is regenerated from the same `shared/manifest.json` that drives the Python package, so parity is enforced at generation time.
+
+## Operators → method chains
+
+JavaScript has no operator overloading, so `adk-fluent-ts` uses method calls. This is the single most important mapping to internalize when reading the rest of these docs:
+
+| Python           | TypeScript                        | Returns    |
+| ---------------- | --------------------------------- | ---------- |
+| `a >> b`         | `a.then(b)`                       | `Pipeline` |
+| `a \| b`         | `a.parallel(b)`                   | `FanOut`   |
+| `a * 3`          | `a.times(3)`                      | `Loop`     |
+| `a * until(...)` | `a.timesUntil(pred, { max })`     | `Loop`     |
+| `a // b`         | `a.fallback(b)`                   | `Fallback` |
+| `a @ Schema`     | `a.outputAs(Schema)`              | `Agent`    |
+| `S.pick("k")`    | `S.pick("k")`                     | `STransform` |
+| `C.window(5)`    | `C.window(5)`                     | `CTransform` |
+
+Sub-builders passed into workflow builders are **auto-built** in both languages — do not call `.build()` on individual steps.
+
+Also:
+
+- TypeScript uses **camelCase** builder methods where Python uses snake_case: `.maxIterations(3)` vs `.max_iterations(3)`, `.beforeModel(fn)` vs `.before_model(fn)`, `.agentTool(agent)` vs `.agent_tool(agent)`.
+- `new` is required when constructing builders in TS: `new Agent("name", "gemini-2.5-flash")`.
+- Generic type parameters on `.outputAs<Schema>()` replace Python's `@ Schema` decorator-style typing.
+
+## Quick start
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
+```python
+from adk_fluent import Agent, Pipeline
+
+pipeline = (
+    Pipeline("research")
+    .step(Agent("searcher", "gemini-2.5-flash").instruct("Search for information."))
+    .step(Agent("writer", "gemini-2.5-flash").instruct("Write a summary."))
+    .build()
+)
+```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent, Pipeline } from "adk-fluent-ts";
+
+const pipeline = new Pipeline("research")
+  .step(new Agent("searcher", "gemini-2.5-flash").instruct("Search for information."))
+  .step(new Agent("writer", "gemini-2.5-flash").instruct("Write a summary."))
+  .build();
+```
+:::
+::::
+
+::::{tab-set}
+:::{tab-item} Python
+:sync: python
+
+```python
+from adk_fluent import Agent
+
+pipeline = (
+    Agent("web", "gemini-2.5-flash").instruct("Search web.").writes("web_data")
+    >> Agent("analyst", "gemini-2.5-flash").instruct("Analyze {web_data}.")
+).build()
+```
+:::
+:::{tab-item} TypeScript
+:sync: ts
+
+```ts
+import { Agent } from "adk-fluent-ts";
+
+const pipeline = new Agent("web", "gemini-2.5-flash")
+  .instruct("Search web.")
+  .writes("web_data")
+  .then(
+    new Agent("analyst", "gemini-2.5-flash").instruct("Analyze {web_data}."),
+  )
+  .build();
+```
+:::
+::::
+
+## Running examples
+
+Runnable recipes live in [`ts/examples/cookbook/`](https://github.com/vamsiramakrishnan/adk-fluent/tree/master/ts/examples/cookbook). Highlights:
+
+| File | What it shows |
+| ---- | ------------- |
+| `01_simple_agent.ts`         | Minimal agent, `.build()` returns a native `@google/adk` LlmAgent |
+| `04_sequential_pipeline.ts`  | `Pipeline` + `.then()` — sequential composition |
+| `05_parallel_fanout.ts`      | `FanOut` + `.parallel()` — concurrent branches |
+| `06_loop_agent.ts`           | `Loop` + `.times()` — bounded iteration |
+| `08_operator_composition.ts` | The full method-chain operator algebra on one page |
+| `12_guards.ts`               | `G.pii()`, `G.length()`, `G.schema()` — output validation |
+| `17_primitives.ts`           | `tap`, `expect`, `gate`, `race`, `dispatch`, `join` |
+| `18_review_loop_pattern.ts`  | `reviewLoop()` higher-order pattern |
+| `20_cascade_fallback.ts`     | `cascade()` — model fallback chains |
+
+Run any example with:
+
+```bash
+cd ts
+npx tsx examples/cookbook/01_simple_agent.ts
+```
+
+## TypeScript API reference
+
+The Python API reference under [`generated/api/`](../generated/api/index.md) is auto-generated from Python introspection. For a symbol-level TypeScript reference, build the typedoc output from inside the `ts/` package:
+
+```bash
+cd ts
+npm run docs     # writes HTML into ts/docs/api/
+```
+
+`typedoc` reads the TypeScript source directly and produces a fully-linked reference for all exported builders, namespaces, and types. We plan to stitch this into the Sphinx site once the TS package surface stabilizes; until then, treat `ts/docs/api/` as the authoritative symbol reference and the Sphinx site as the authoritative conceptual guide.
+
+The shared `CLAUDE.md` files are also useful as a flat API reference:
+
+- [`ts/CLAUDE.md`](https://github.com/vamsiramakrishnan/adk-fluent/blob/master/ts/CLAUDE.md) — TypeScript LLM context, operator mapping, namespace-level API summary.
+- [`CLAUDE.md`](https://github.com/vamsiramakrishnan/adk-fluent/blob/master/CLAUDE.md) — top-level shared API reference, regenerated from `shared/manifest.json`.
+
+## Feature parity
+
+Both packages are regenerated from the same manifest, so builder coverage is identical by construction. Namespace coverage is close to parity but evolving — if you hit a feature that exists in Python but not yet in TypeScript, open an issue. Known areas where the TypeScript package is still catching up:
+
+- The A2A server (`A2AServer` + middleware) is usable but less battle-tested than the Python implementation.
+- The evaluation (`E`) namespace does not yet include a TS-native LLM judge — use `E.case` and `E.criterion` with custom predicates.
+- Some cookbook recipes (70+, A2UI-heavy) do not yet have TypeScript equivalents.
+
+## Development
+
+From the monorepo root, drive the TS package with the `just ts-*` recipes:
+
+```bash
+just ts-setup        # npm install inside ts/
+just ts-generate     # Regenerate TS builders from shared/manifest.json + seeds
+just ts-build        # tsc build
+just ts-typecheck    # tsc --noEmit
+just ts-lint         # eslint
+just ts-test         # vitest run
+just test-all        # Python + TypeScript test suites together
+just generate-all    # Regenerate Python and TypeScript builders from one manifest
+```
+
+Generated TS files (`ts/src/builders/*.ts`) are owned by `just ts-generate`. Hand-written code lives in `ts/src/core/`, `ts/src/namespaces/`, `ts/src/patterns/`, `ts/src/primitives/`, `ts/src/routing/`, and `ts/src/a2a/`. Formatters and lint only touch hand-written files.
+
+## Where to next
+
+- **New to adk-fluent?** Start with {doc}`../getting-started` — every code sample is available as a Python / TypeScript tab.
+- **Want the full operator reference?** Read {doc}`expression-language` with the TypeScript tab active.
+- **Building production systems?** Walk {doc}`patterns`, {doc}`context-engineering`, {doc}`guards`, and {doc}`middleware` — all shared conceptually between languages.
+- **Deploying an agent?** {doc}`execution-backends` and {doc}`execution` cover the shared execution model. Deployment is Python-first today; the TS equivalent is tracked in [ts/README.md](https://github.com/vamsiramakrishnan/adk-fluent/blob/master/ts/README.md).

--- a/python/README.md
+++ b/python/README.md
@@ -14,8 +14,11 @@ Fluent builder API for Google's [Agent Development Kit (ADK)](https://google.git
 [![Coverage](https://codecov.io/gh/vamsiramakrishnan/adk-fluent/branch/master/graph/badge.svg)](https://codecov.io/gh/vamsiramakrishnan/adk-fluent)
 [![Status](https://img.shields.io/badge/status-beta-yellow)](https://github.com/vamsiramakrishnan/adk-fluent)
 
+> **Monorepo:** This repository is a dual-language monorepo. The Python package (`adk-fluent`) lives in [`python/`](python/) and the TypeScript package (`adk-fluent-ts`) lives in [`ts/`](ts/). Shared generation tooling, manifests, and seeds live in [`shared/`](shared/). Both packages are generated from the same manifest and expose the same surface area.
+
 ## Table of Contents
 
+- [Packages](#packages)
 - [Install](#install)
 - [Quick Start](#quick-start)
 - [Three Pathways](#three-pathways)
@@ -36,13 +39,63 @@ Fluent builder API for Google's [Agent Development Kit (ADK)](https://google.git
 - [AI Coding Skills](#ai-coding-skills)
 - [Development](#development)
 
+## Packages
+
+adk-fluent is released as two sibling packages driven by a single shared manifest. Pick the language you ship in — both expose the same builders, operators, and namespaces.
+
+| Package              | Language   | Source      | Registry                                                      | Entry README                              |
+| -------------------- | ---------- | ----------- | ------------------------------------------------------------- | ----------------------------------------- |
+| `adk-fluent`         | Python 3.11+ | [`python/`](python/) | [PyPI](https://pypi.org/project/adk-fluent/)                  | [`python/README.md`](python/README.md)    |
+| `adk-fluent-ts`      | TypeScript | [`ts/`](ts/) | npm (coming soon)                                             | [`ts/README.md`](ts/README.md)            |
+
+Shared generator scripts, ADK scan manifests, and seed files live in [`shared/`](shared/). The Python and TypeScript builders are both regenerated from `shared/manifest.json` + `shared/seeds/seed.toml`, so API parity is enforced at generation time.
+
+```text
+adk-fluent/
+├── python/      # adk-fluent (PyPI) — builders, namespaces, tests, docs fixtures
+├── ts/          # adk-fluent-ts (npm) — TypeScript port with method-chained operators
+├── shared/      # manifest.json, seeds, scripts/ (scanner, generator, doc gen)
+├── docs/        # Sphinx docs site (Python-first, TS guide embedded)
+├── skills/      # AI coding agent skills
+└── justfile     # Monorepo-aware commands (`just test`, `just ts-test`, `just test-all`)
+```
+
 ## Install
+
+### Python (`adk-fluent`)
 
 ```bash
 pip install adk-fluent
 ```
 
 Autocomplete works immediately -- the package ships with `.pyi` type stubs for every builder. Type `Agent("name").` and your IDE shows all available methods with type hints.
+
+### TypeScript (`adk-fluent-ts`)
+
+The TypeScript port mirrors the Python API surface with method-chained operators (`.then()`, `.parallel()`, `.times()`, `.fallback()`, `.outputAs()`).
+
+```bash
+# From the monorepo (until the package is published to npm)
+cd ts
+npm install
+npm run build
+```
+
+```ts
+import { Agent, Pipeline } from "adk-fluent-ts";
+
+const pipeline = new Agent("writer", "gemini-2.5-flash")
+  .instruct("Write a draft about {topic}.")
+  .writes("draft")
+  .then(
+    new Agent("reviewer", "gemini-2.5-flash")
+      .instruct("Review the draft: {draft}")
+      .writes("feedback"),
+  )
+  .build();
+```
+
+See [`ts/README.md`](ts/README.md) for the full TypeScript API, the [operator → method-chain mapping](ts/CLAUDE.md), and [`ts/examples/`](ts/examples) for runnable recipes. The rest of this README focuses on the Python package.
 
 > **Full walkthrough:** [Getting Started guide](https://vamsiramakrishnan.github.io/adk-fluent/getting-started/) covers install, credentials, first agent, and IDE setup.
 
@@ -1551,20 +1604,20 @@ A custom web frontend for interactively running and debugging all cookbook agent
 ### Quick Start (from scratch)
 
 ```bash
-# 1. Clone and install
+# 1. Clone and install the Python package
 git clone https://github.com/vamsiramakrishnan/adk-fluent.git
 cd adk-fluent
-pip install -e ".[a2a,yaml,rich]"      # or: uv sync --all-extras
+cd python && uv sync --all-extras && cd ..    # or: pip install -e "./python[a2a,yaml,rich]"
 
 # 2. Configure credentials
-cp visual/.env.example visual/.env
-# Edit visual/.env — add your Gemini API key or Vertex AI credentials
+cp python/visual/.env.example python/visual/.env
+# Edit python/visual/.env — add your Gemini API key or Vertex AI credentials
 
 # 3. Generate agent folders from cookbooks (one-time)
-just agents                             # or: uv run python scripts/cookbook_to_agents.py --force
+just agents                             # or: uv run --project python python -m shared.scripts.cookbook_to_agents --force
 
 # 4. Launch the visual runner
-just visual                             # or: uv run uvicorn visual.server:app --port 8099 --reload
+just visual                             # or: cd python && uv run uvicorn visual.server:app --port 8099 --reload
 ```
 
 Opens at **http://localhost:8099** with:
@@ -1585,11 +1638,12 @@ This exports surfaces from cookbooks 70-74 and opens a static gallery in your br
 ### Visual Regression Tests
 
 ```bash
+cd python
 uv run pytest tests/visual/ -v                      # run tests (no API key needed)
 uv run pytest tests/visual/ -v --update-golden       # update golden snapshots
 ```
 
-See [`visual/README.md`](visual/README.md) for full architecture details.
+See [`python/visual/README.md`](python/visual/README.md) for full architecture details.
 
 ## Performance
 
@@ -1600,7 +1654,7 @@ adk-fluent is a **build-time layer**. Calling `.build()` produces a native ADK o
 Verify yourself:
 
 ```bash
-python scripts/benchmark.py
+uv run --project python python shared/scripts/benchmark.py
 ```
 
 ## ADK Compatibility
@@ -1633,25 +1687,38 @@ A [weekly sync workflow](.github/workflows/sync-adk.yml) scans for new ADK relea
 
 > **Deep dive:** [Architecture & Concepts](https://vamsiramakrishnan.github.io/adk-fluent/user-guide/architecture-and-concepts/) · [IR & Backends](https://vamsiramakrishnan.github.io/adk-fluent/user-guide/ir-and-backends/)
 
-adk-fluent is **auto-generated** from the installed ADK package:
+adk-fluent is **auto-generated** from the installed ADK package. A single shared pipeline produces both the Python and TypeScript builders:
 
 ```
-scanner.py ──> manifest.json ──> seed_generator.py ──> seed.toml ──> generator.py ──> Python code
-                                      ^
-                              seed.manual.toml
-                              (hand-crafted extras)
+shared/scripts/scanner.py ─> shared/manifest.json
+                                        │
+                                        ▼
+                             shared/scripts/seed_generator.py
+                                        │
+                                        ▼
+                               shared/seeds/seed.toml  ◄── shared/seeds/seed.manual.toml
+                                        │
+                         ┌──────────────┴──────────────┐
+                         ▼                             ▼
+               shared/scripts/generator.py   shared/scripts/generator.py
+                 --target python               --target typescript
+                         │                             │
+                         ▼                             ▼
+               python/src/adk_fluent/         ts/src/builders/
+                 (builders + .pyi stubs)        (TypeScript classes)
 ```
 
-1. **Scanner** introspects all ADK modules and produces `manifest.json`
-1. **Seed Generator** classifies classes and produces `seed.toml` (merged with manual extras)
-1. **Code Generator** emits fluent builders, `.pyi` type stubs, and test scaffolds
+1. **Scanner** introspects all ADK modules and produces `shared/manifest.json`
+1. **Seed Generator** classifies classes and produces `shared/seeds/seed.toml` (merged with manual extras)
+1. **Code Generator** emits fluent builders for both Python (`python/src/adk_fluent/`) and TypeScript (`ts/src/builders/`)
 
 This means adk-fluent automatically stays in sync with ADK updates:
 
 ```bash
 pip install --upgrade google-adk
-just all   # Regenerate everything
-just test  # Verify
+just all              # Regenerate Python (scan → seed → generate → docs)
+just ts-generate      # Regenerate TypeScript from the same manifest
+just test-all         # Verify both languages
 ```
 
 ## API Reference
@@ -1728,26 +1795,65 @@ Works with Gemini CLI, Claude Code, Cursor, GitHub Copilot, Amp, and more.
 
 ## Development
 
-**Requires:** Python 3.11+, [just](https://github.com/casey/just#installation), [uv](https://docs.astral.sh/uv/)
+**Requires:** Python 3.11+, Node.js 20+, [just](https://github.com/casey/just#installation), [uv](https://docs.astral.sh/uv/)
 
 **Container:** Open in VS Code or GitHub Codespaces with the included Dev Container for a pre-configured environment.
 
-```bash
-# Setup
-uv venv .venv && source .venv/bin/activate
-uv pip install -e ".[dev]"
+### Monorepo layout
 
-# Full pipeline: scan -> seed -> generate -> docs
+```text
+adk-fluent/
+├── python/      # adk-fluent — uv-managed Python package (PyPI)
+├── ts/          # adk-fluent-ts — npm-managed TypeScript package
+├── shared/      # Manifests, seeds, generator/scanner/doc-gen scripts
+├── docs/        # Sphinx docs (built from python/ + shared/)
+├── skills/      # AI coding agent skills (auto-regenerated)
+└── justfile     # Monorepo-aware task runner
+```
+
+Generated files (`agent.py`, `config.py`, `.pyi` stubs, `ts/src/builders/*.ts`) are owned by `just generate` / `just ts-generate`. Hand-written files are owned by developers. Formatters and pre-commit hooks only touch hand-written files — see [`.gitattributes`](.gitattributes) for the full generated-file list.
+
+### First-time setup
+
+```bash
+just setup    # uv sync (python/) + npm install (ts/) + pre-commit hooks
+```
+
+### Python workflow
+
+```bash
+# Full pipeline: scan -> seed -> generate -> docs (Python)
 just all
 
-# Run tests (780+ tests)
+# Run the Python test suite (780+ tests)
 just test
 
-# Type check hand-written code
+# Type check hand-written Python code
 just typecheck-core
 
-# Local CI (lint + check-gen + test)
+# Local CI (preflight + check-gen + test)
 just ci
+```
+
+All Python commands run against `python/` under the hood — e.g. `just test` is equivalent to `cd python && uv run pytest tests/`.
+
+### TypeScript workflow
+
+```bash
+just ts-setup        # npm install inside ts/
+just ts-generate     # Regenerate TS builders from shared/manifest.json
+just ts-build        # tsc build
+just ts-typecheck    # tsc --noEmit
+just ts-lint         # eslint
+just ts-test         # vitest run
+```
+
+### Monorepo commands
+
+```bash
+just generate-all    # Regenerate Python AND TypeScript builders
+just build-all       # Generate + build both packages
+just test-all        # Run Python + TypeScript test suites
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) and the [Contributing guide](https://vamsiramakrishnan.github.io/adk-fluent/contributing/) for the full development guide.
@@ -1764,7 +1870,7 @@ See [CHANGELOG.md](CHANGELOG.md) for the full release history, or browse it on t
 
 ## Releases
 
-Only one file to edit: `src/adk_fluent/_version.py`. Everything else auto-syncs.
+Only one file to edit: `python/src/adk_fluent/_version.py`. Everything else auto-syncs. (The TypeScript package versions independently via `ts/package.json`.)
 
 ```bash
 just release patch   # or: minor, major
@@ -1775,7 +1881,7 @@ just release-tag     # creates and pushes the git tag
 # → CI auto-publishes to PyPI + rebuilds versioned docs
 ```
 
-The version in `_version.py` is the single source of truth — `pyproject.toml`, `docs/conf.py`, and the announcement banner all read from it automatically.
+The version in `python/src/adk_fluent/_version.py` is the single source of truth for the Python package — `python/pyproject.toml`, `docs/conf.py`, and the announcement banner all read from it automatically.
 
 ## License
 

--- a/shared/scripts/llms_generator.py
+++ b/shared/scripts/llms_generator.py
@@ -915,6 +915,282 @@ _TS_COMMANDS = """\
     just ts-test                             # run tests via just
 """
 
+# TypeScript-flavored namespace reference.  The TS package mirrors the Python
+# API but uses camelCase identifiers (e.g. ``C.fromState`` not
+# ``C.from_state``) and method-chain composition (``.pipe()`` / ``.add()``)
+# instead of the Python ``|`` / ``+`` operators.  JS reserved words like
+# ``default`` require a trailing underscore (``S.default_``, ``C.default_``).
+_TS_NAMESPACE_MODULES = """
+## Namespace modules (S, C, P, A, M, T, E, G)
+
+All namespaces mirror the Python API with TypeScript idioms: camelCase
+method names, method-chained composition via ``.pipe()`` / ``.add()``, and
+options-object arguments instead of keyword arguments.  JavaScript reserved
+words (``default``) use a trailing underscore (``S.default_``, ``C.default_``).
+
+### S — State transforms
+
+Used in pipelines via ``.then()``.  Compose with ``.pipe()`` (chain) or
+``.add()`` (combine).
+
+  S.pick(...keys)              — keep only named keys
+  S.drop(...keys)              — remove named keys
+  S.rename({old: "new"})       — rename keys
+  S.merge_([keys], "into")     — combine keys (note trailing underscore)
+  S.transform(key, fn)         — apply function to value
+  S.compute({key: fn, ...})    — derive new keys from state
+  S.set({k: v})                — set explicit key-value pairs
+  S.default_({k: v})           — fill missing keys with defaults
+  S.guard(pred, msg?)          — assert state invariant
+  S.when(pred, transform)      — conditional transform
+  S.branch(key, {match: tr})   — route to different transforms
+  S.capture(...keys)           — capture function args into state
+  S.identity()                 — pass-through (no-op)
+  S.accumulate(key)            — append to list in state
+  S.counter(key)               — increment counter in state
+  S.history(key)               — maintain history list
+  S.validate({k: schema})      — validate state keys against schemas
+  S.require(...keys)           — assert keys exist
+  S.flatten(key)               — flatten nested dict
+  S.unflatten(key, {sep})      — unflatten dotted keys
+  S.zip(...keys, "into")       — zip parallel lists
+  S.groupBy(key, {by})         — group items by field
+  S.log(...keys)               — log state keys
+
+### C — Context engineering
+
+Used with ``.context()``.  Compose with ``.add()`` (union) or ``.pipe()``.
+
+  C.none()                     — suppress all history
+  C.default_()                 — default ADK behavior
+  C.userOnly()                 — only user messages
+  C.window(n)                  — last N turn-pairs
+  C.fromState(...keys)         — inject state keys as context
+  C.fromAgents(...names)       — user + named agent outputs
+  C.fromAgentsWindowed({n})    — windowed agent output filtering
+  C.excludeAgents(...names)    — exclude named agents
+  C.template(text)             — template with {key} placeholders
+  C.select(...agentNames)      — select specific agents
+  C.recent({n})                — recent messages only
+  C.compact()                  — remove redundant messages
+  C.dedup()                    — remove duplicate messages
+  C.truncate({maxTurns})       — hard limit
+  C.project(...fields)         — project specific fields
+  C.budget({maxTokens})        — token budget constraint
+  C.priority(...keys)          — prioritize certain context
+  C.fit({maxTokens})           — fit within token limit
+  C.fresh({maxAge})            — filter by recency
+  C.redact(...patterns)        — redact sensitive content
+  C.summarize({scope})         — LLM-powered summarization
+  C.relevant({queryKey})       — semantic relevance filtering
+  C.extract({key})             — extract structured data
+  C.distill()                  — distill to key points
+  C.validate()                 — validate context integrity
+  C.notes()                    — attach notes
+  C.writeNotes()               — persist notes to state
+  C.rolling({n})               — rolling window with compaction
+  C.user()                     — user messages only (alias)
+  C.manusCascade()             — Manus-style cascading context
+  C.when(pred, transform)      — conditional context transform
+
+### P — Prompt composition
+
+Used with ``.instruct()``.  Compose with ``.add()`` (union) or ``.pipe()``.
+Section order: role → context → task → constraint → format → example.
+
+  P.role(text)                 — agent persona
+  P.context(text)              — background context
+  P.task(text)                 — primary objective
+  P.constraint(...rules)       — constraints/rules
+  P.format(text)               — output format spec
+  P.example({input, output})   — few-shot examples (options object)
+  P.section(name, text)        — custom named section
+  P.when(pred, block)          — conditional inclusion
+  P.fromState(...keys)         — dynamic state injection
+  P.template(text)             — {key}, {key?}, {ns:key} placeholders
+  P.reorder(...sections)       — reorder sections
+  P.only(...sections)          — include only named sections
+  P.without(...sections)       — exclude named sections
+  P.compress()                 — compress verbose prompts
+  P.adapt(fn)                  — transform prompt dynamically
+  P.scaffolded(structure)      — structured prompt scaffold
+  P.versioned(v, text)         — versioned prompt variants
+
+### A — Artifacts
+
+Used with ``.artifacts()`` or ``.then()``.  Compose with ``.pipe()``.
+
+  A.publish(filename, {fromKey}) — state → artifact
+  A.snapshot(filename, {intoKey}) — artifact → state
+  A.save(filename, {content})   — content → artifact
+  A.load(filename)              — artifact → pipeline
+  A.list()                      — list available artifacts
+  A.version(filename)           — get artifact version
+  A.delete_(filename)           — delete artifact (reserved word)
+  A.publishMany({mapping})      — batch publish multiple artifacts
+  A.snapshotMany({mapping})     — batch snapshot multiple artifacts
+  A.forLlm()                    — context transform for LLM-aware loading
+  A.when(pred, transform)       — conditional artifact operation
+  A.fromJson() / A.fromCsv() / A.fromMarkdown() — content transforms (pre-publish)
+  A.asJson() / A.asCsv() / A.asText() — content transforms (post-snapshot)
+
+### M — Middleware
+
+Used with ``.middleware()``.  Compose with ``.pipe()`` (chain).
+Most factories take an options object.
+
+  M.retry({maxAttempts})       — retry with exponential backoff
+  M.log()                      — structured event logging
+  M.cost()                     — token usage tracking
+  M.latency()                  — per-agent latency tracking
+  M.scope([agents], mw)        — restrict middleware to agents
+  M.when(condition, mw)        — conditional middleware
+  M.circuitBreaker({maxFails}) — circuit breaker pattern
+  M.timeout({seconds})         — per-agent timeout
+  M.cache({ttl})               — response caching
+  M.fallbackModel(model)       — fallback to different model
+  M.dedup()                    — deduplicate requests
+  M.sample({rate})             — probabilistic sampling
+  M.trace()                    — distributed tracing
+  M.metrics()                  — metrics collection
+  M.beforeAgent(fn)            — pre-agent hook
+  M.afterAgent(fn)             — post-agent hook
+  M.beforeModel(fn)            — pre-model hook
+  M.afterModel(fn)             — post-model hook
+  M.onLoop(fn)                 — loop iteration hook
+  M.onTimeout(fn)              — timeout event hook
+  M.onRoute(fn)                — routing event hook
+  M.onFallback(fn)             — fallback event hook
+
+### T — Tool composition
+
+Used with ``.tools()``.  Compose with ``.pipe()`` (chain).
+
+  T.fn(callable)               — wrap callable as FunctionTool
+  T.agent(agent)               — wrap agent as AgentTool
+  T.googleSearch()             — built-in Google Search
+  T.search(registry)           — BM25-indexed dynamic loading
+  T.toolset(toolset)           — wrap MCPToolset or similar
+  T.schema(schema)             — attach ToolSchema
+  T.mock(responses)            — mock tool for testing
+  T.confirm({prompt})          — human confirmation wrapper
+  T.timeout({seconds})         — tool timeout wrapper
+  T.cache({ttl})               — tool response caching
+  T.mcp(server)                — MCP server tool
+  T.openapi(spec)              — OpenAPI spec tool
+  T.transform(fn)              — transform tool output
+
+### E — Evaluation
+
+Used with ``.eval()`` / ``.evalSuite()``.  Build evaluation criteria and
+test suites.
+
+  E.case(prompt, {expect})     — single evaluation case
+  E.criterion(name, fn)        — custom evaluation criterion
+  E.persona(name, {style})     — persona for evaluation
+  EvalSuite                    — collection of eval cases
+  EvalReport                   — evaluation results
+  ComparisonReport             — compare multiple agents/models
+
+### G — Guards (output validation)
+
+Used with ``.guard()``.  Guards validate/transform the LLM response
+(afterModel).  Compose with ``.pipe()`` (chain).  Throws ``GuardViolation``
+on failure.
+
+  G.guard(fn)                  — custom guard function
+  G.pii({action, detector})    — detect and block/redact PII in output
+  G.toxicity({threshold, judge}) — block toxic content above threshold
+  G.length({min, max})         — enforce length bounds
+  G.regex(pattern, {action})   — block or redact pattern matches
+  G.schema(schema)             — validate output against schema
+  G.output(schema)             — post-model schema validation
+  G.input(schema)              — pre-model input schema validation
+  G.budget({maxTokens})        — token budget constraint
+  G.rateLimit({rpm})           — requests-per-minute limit
+  G.maxTurns(n)                — cap conversation turns
+  G.topic({deny})              — block specific topics
+  G.grounded({sourcesKey})     — verify output is grounded in sources
+  G.hallucination({threshold}) — detect hallucinated content
+  G.when(pred, guard)          — conditional guard
+  G.dlp({project, infoTypes, location}) — Google Cloud DLP detector
+  G.regexDetector([patterns])  — lightweight regex-based PII detector
+  G.multi(...detectors)        — union of multiple detectors
+  GuardViolation               — raised when a guard check fails
+  PIIDetector                  — PII detection provider type
+  ContentJudge                 — content judgment provider type
+
+### UI — Agent-to-UI composition (A2UI)
+
+Declarative UI composition for agents.  Compose with ``.pipe()`` / ``.add()``.
+Import: ``import { UI } from "adk-fluent-ts";``
+
+Component factories:
+  UI.text(content, {variant})  — text content (h1-h5, caption, body)
+  UI.button(label, {action})   — clickable button
+  UI.textField(label, {bind})  — text input with optional data binding
+  UI.image(src, {alt, fit})    — display an image
+  UI.row(...children)          — horizontal layout
+  UI.column(...children)       — vertical layout
+  UI.component(kind, props)    — generic escape hatch
+
+Data binding & validation:
+  UI.bind(path)                — create data binding to JSON Pointer path
+  UI.required({msg})           — required field validation
+  UI.email({msg})              — email format validation
+
+Surface lifecycle:
+  UI.surface(name, ...children) — create named surface (compilation root)
+  UI.auto({catalog})           — LLM-guided mode (agent decides UI)
+
+Presets:
+  UI.form(title, {fields})     — form surface from field spec
+  UI.dashboard(title, {cards}) — dashboard with metric cards
+  UI.wizard(title, {steps})    — multi-step wizard
+  UI.confirm(message)          — confirmation dialog
+  UI.table({columns, dataBind}) — data table
+
+Agent integration:
+  Agent.ui(spec)               — attach UI surface to agent
+  T.a2ui()                     — A2UI toolset for LLM-guided mode
+  G.a2ui({maxComponents})      — validate LLM-generated UI
+  P.uiSchema()                 — inject catalog schema into prompt
+  S.toUi(...keys, {surface})   — bridge state → A2UI data model
+  S.fromUi(...keys, {surface}) — bridge A2UI data model → state
+  M.a2uiLog({level})           — log A2UI surface operations
+  C.withUi({surfaceId})        — include UI state in context
+"""
+
+# TypeScript-flavored best practices.  Mirrors ``_BEST_PRACTICES`` but uses
+# camelCase method names where they differ from Python (e.g. ``subAgent``,
+# ``agentTool``, ``loopWhile``, ``askAsync``/``mapAsync``).
+_TS_BEST_PRACTICES = """
+## Best practices
+
+1. Use deterministic routing (Route) over LLM routing when the decision is rule-based
+2. Use ``.inject()`` for infrastructure deps — never expose DB clients in tool schemas
+3. Use S.transform() or plain functions for data transforms, not custom BaseAgent
+4. Use C.none() to hide conversation history from background/utility agents
+5. Use M.retry() middleware instead of retry logic inside tool functions
+6. Use ``.writes()`` not deprecated ``.outputKey()`` / ``.outputs()``
+7. Use ``.outputAs()`` not deprecated ``.outputSchema()``
+8. Use ``.context()`` not deprecated ``.history()`` / ``.includeHistory()``
+9. Use ``.agentTool()`` not deprecated ``.delegate()``
+10. Use ``.guard()`` not deprecated ``.guardrail()``
+11. Use ``.loopWhile()`` not deprecated ``.retryIf()``
+12. Use ``.prepend()`` not deprecated ``.injectContext()``
+13. All builders are immutable — sub-expressions can be safely reused
+14. Workflow sub-builders passed to ``.then()`` / ``.parallel()`` / ``.step()``
+    are auto-built; do not call ``.build()`` on individual steps
+15. Use ``.subAgent()`` for transfer-based delegation (LLM decides routing);
+    use ``.agentTool()`` for tool-based invocation (parent stays in control)
+16. Use ``.isolate()`` on specialist agents by default — it is the most predictable pattern
+17. Always set ``.describe()`` on sub-agents — the description helps the coordinator LLM
+    pick the right specialist during transfer routing
+18. Use ``.askAsync()`` / ``.mapAsync()`` in async code paths;
+    the sync ``.ask()`` / ``.map()`` variants throw inside running event loops
+"""
+
 
 def generate_llms_txt_ts(specs: list[BuilderSpec]) -> str:
     """Generate the TypeScript-flavored llms.txt content."""
@@ -926,9 +1202,9 @@ def generate_llms_txt_ts(specs: list[BuilderSpec]) -> str:
         _TS_IMPORTS,
         _TS_OPERATORS,
         _TS_EXAMPLE,
-        _NAMESPACE_MODULES,  # namespaces are identical apart from import path
+        _TS_NAMESPACE_MODULES,
         _format_builder_section(groups),
-        _BEST_PRACTICES,
+        _TS_BEST_PRACTICES,
         _TS_COMMANDS,
     ]
     return "\n".join(s.strip() for s in sections) + "\n"

--- a/ts/CLAUDE.md
+++ b/ts/CLAUDE.md
@@ -63,88 +63,94 @@ Sub-builders passed to workflow builders are auto-built — do not call
     const pipeline2 = writer.then(reviewer).times(3).build();
 ## Namespace modules (S, C, P, A, M, T, E, G)
 
+All namespaces mirror the Python API with TypeScript idioms: camelCase
+method names, method-chained composition via ``.pipe()`` / ``.add()``, and
+options-object arguments instead of keyword arguments.  JavaScript reserved
+words (``default``) use a trailing underscore (``S.default_``, ``C.default_``).
+
 ### S — State transforms
 
-Used with `>>` operator. Compose with `>>` (chain) or `+` (combine).
+Used in pipelines via ``.then()``.  Compose with ``.pipe()`` (chain) or
+``.add()`` (combine).
 
-  S.pick(*keys)                — keep only named keys
-  S.drop(*keys)                — remove named keys
-  S.rename(**mapping)          — rename keys
-  S.merge(*keys, into=)        — combine keys
+  S.pick(...keys)              — keep only named keys
+  S.drop(...keys)              — remove named keys
+  S.rename({old: "new"})       — rename keys
+  S.merge_([keys], "into")     — combine keys (note trailing underscore)
   S.transform(key, fn)         — apply function to value
-  S.compute(**factories)       — derive new keys from state
-  S.set(**kv)                  — set explicit key-value pairs
-  S.default(**kv)              — fill missing keys with defaults
-  S.guard(pred, msg=)          — assert state invariant
+  S.compute({key: fn, ...})    — derive new keys from state
+  S.set({k: v})                — set explicit key-value pairs
+  S.default_({k: v})           — fill missing keys with defaults
+  S.guard(pred, msg?)          — assert state invariant
   S.when(pred, transform)      — conditional transform
-  S.branch(key, **transforms)  — route to different transforms
-  S.capture(*keys)             — capture function args into state
+  S.branch(key, {match: tr})   — route to different transforms
+  S.capture(...keys)           — capture function args into state
   S.identity()                 — pass-through (no-op)
   S.accumulate(key)            — append to list in state
   S.counter(key)               — increment counter in state
   S.history(key)               — maintain history list
-  S.validate(**schemas)        — validate state keys against schemas
-  S.require(*keys)             — assert keys exist
+  S.validate({k: schema})      — validate state keys against schemas
+  S.require(...keys)           — assert keys exist
   S.flatten(key)               — flatten nested dict
-  S.unflatten(key, sep=".")    — unflatten dotted keys
-  S.zip(*keys, into=)          — zip parallel lists
-  S.group_by(key, by=)         — group items by field
-  S.log(*keys)                 — log state keys to stderr
+  S.unflatten(key, {sep})      — unflatten dotted keys
+  S.zip(...keys, "into")       — zip parallel lists
+  S.groupBy(key, {by})         — group items by field
+  S.log(...keys)               — log state keys
 
 ### C — Context engineering
 
-Used with `.context()`. Compose with `+` (union) or `|` (pipe).
+Used with ``.context()``.  Compose with ``.add()`` (union) or ``.pipe()``.
 
   C.none()                     — suppress all history
-  C.default()                  — default ADK behavior
-  C.user_only()                — only user messages
-  C.window(n=5)                — last N turn-pairs
-  C.from_state(*keys)          — inject state keys as context
-  C.from_agents(*names)        — user + named agent outputs
-  C.from_agents_windowed(n=)   — windowed agent output filtering
-  C.exclude_agents(*names)     — exclude named agents
+  C.default_()                 — default ADK behavior
+  C.userOnly()                 — only user messages
+  C.window(n)                  — last N turn-pairs
+  C.fromState(...keys)         — inject state keys as context
+  C.fromAgents(...names)       — user + named agent outputs
+  C.fromAgentsWindowed({n})    — windowed agent output filtering
+  C.excludeAgents(...names)    — exclude named agents
   C.template(text)             — template with {key} placeholders
-  C.select(*agent_names)       — select specific agents
-  C.recent(n=)                 — recent messages only
+  C.select(...agentNames)      — select specific agents
+  C.recent({n})                — recent messages only
   C.compact()                  — remove redundant messages
   C.dedup()                    — remove duplicate messages
-  C.truncate(max_turns=)       — hard limit
-  C.project(*fields)           — project specific fields
-  C.budget(max_tokens=)        — token budget constraint
-  C.priority(*keys)            — prioritize certain context
-  C.fit(max_tokens=)           — fit within token limit
-  C.fresh(max_age=)            — filter by recency
-  C.redact(*patterns)          — redact sensitive content
-  C.summarize(scope=)          — LLM-powered summarization
-  C.relevant(query_key=)       — semantic relevance filtering
-  C.extract(key=)              — extract structured data
+  C.truncate({maxTurns})       — hard limit
+  C.project(...fields)         — project specific fields
+  C.budget({maxTokens})        — token budget constraint
+  C.priority(...keys)          — prioritize certain context
+  C.fit({maxTokens})           — fit within token limit
+  C.fresh({maxAge})            — filter by recency
+  C.redact(...patterns)        — redact sensitive content
+  C.summarize({scope})         — LLM-powered summarization
+  C.relevant({queryKey})       — semantic relevance filtering
+  C.extract({key})             — extract structured data
   C.distill()                  — distill to key points
   C.validate()                 — validate context integrity
   C.notes()                    — attach notes
-  C.write_notes()              — persist notes to state
-  C.rolling(n=)                — rolling window with compaction
+  C.writeNotes()               — persist notes to state
+  C.rolling({n})               — rolling window with compaction
   C.user()                     — user messages only (alias)
-  C.manus_cascade()            — Manus-style cascading context
+  C.manusCascade()             — Manus-style cascading context
   C.when(pred, transform)      — conditional context transform
 
 ### P — Prompt composition
 
-Used with `.instruct()`. Compose with `+` (union) or `|` (pipe).
+Used with ``.instruct()``.  Compose with ``.add()`` (union) or ``.pipe()``.
 Section order: role → context → task → constraint → format → example.
 
   P.role(text)                 — agent persona
   P.context(text)              — background context
   P.task(text)                 — primary objective
-  P.constraint(*rules)         — constraints/rules
+  P.constraint(...rules)       — constraints/rules
   P.format(text)               — output format spec
-  P.example(input=, output=)   — few-shot examples
+  P.example({input, output})   — few-shot examples (options object)
   P.section(name, text)        — custom named section
   P.when(pred, block)          — conditional inclusion
-  P.from_state(*keys)          — dynamic state injection
+  P.fromState(...keys)         — dynamic state injection
   P.template(text)             — {key}, {key?}, {ns:key} placeholders
-  P.reorder(*sections)         — reorder sections
-  P.only(*sections)            — include only named sections
-  P.without(*sections)         — exclude named sections
+  P.reorder(...sections)       — reorder sections
+  P.only(...sections)          — include only named sections
+  P.without(...sections)       — exclude named sections
   P.compress()                 — compress verbose prompts
   P.adapt(fn)                  — transform prompt dynamically
   P.scaffolded(structure)      — structured prompt scaffold
@@ -152,146 +158,162 @@ Section order: role → context → task → constraint → format → example.
 
 ### A — Artifacts
 
-Used with `.artifacts()` or `>>`. Compose with `>>` (chain).
+Used with ``.artifacts()`` or ``.then()``.  Compose with ``.pipe()``.
 
-  A.publish(filename, from_key=) — state → artifact
-  A.snapshot(filename, into_key=) — artifact → state
-  A.save(filename, content=)    — content → artifact
+  A.publish(filename, {fromKey}) — state → artifact
+  A.snapshot(filename, {intoKey}) — artifact → state
+  A.save(filename, {content})   — content → artifact
   A.load(filename)              — artifact → pipeline
   A.list()                      — list available artifacts
   A.version(filename)           — get artifact version
-  A.delete(filename)            — delete artifact
-  A.publish_many(**mapping)     — batch publish multiple artifacts
-  A.snapshot_many(**mapping)    — batch snapshot multiple artifacts
-  A.for_llm()                  — context transform for LLM-aware loading
-  A.when(pred, transform)      — conditional artifact operation
-  A.from_json() / A.from_csv() / A.from_markdown() — content transforms (pre-publish)
-  A.as_json() / A.as_csv() / A.as_text() — content transforms (post-snapshot)
+  A.delete_(filename)           — delete artifact (reserved word)
+  A.publishMany({mapping})      — batch publish multiple artifacts
+  A.snapshotMany({mapping})     — batch snapshot multiple artifacts
+  A.forLlm()                    — context transform for LLM-aware loading
+  A.when(pred, transform)       — conditional artifact operation
+  A.fromJson() / A.fromCsv() / A.fromMarkdown() — content transforms (pre-publish)
+  A.asJson() / A.asCsv() / A.asText() — content transforms (post-snapshot)
 
 ### M — Middleware
 
-Used with `.middleware()`. Compose with `|` (chain).
+Used with ``.middleware()``.  Compose with ``.pipe()`` (chain).
+Most factories take an options object.
 
-  M.retry(max_attempts=)       — retry with exponential backoff
+  M.retry({maxAttempts})       — retry with exponential backoff
   M.log()                      — structured event logging
   M.cost()                     — token usage tracking
   M.latency()                  — per-agent latency tracking
-  M.scope(agents, mw)          — restrict middleware to agents
+  M.scope([agents], mw)        — restrict middleware to agents
   M.when(condition, mw)        — conditional middleware
-  M.circuit_breaker(max_fails=) — circuit breaker pattern
-  M.timeout(seconds)           — per-agent timeout
-  M.cache(ttl=)                — response caching
-  M.fallback_model(model)      — fallback to different model
+  M.circuitBreaker({maxFails}) — circuit breaker pattern
+  M.timeout({seconds})         — per-agent timeout
+  M.cache({ttl})               — response caching
+  M.fallbackModel(model)       — fallback to different model
   M.dedup()                    — deduplicate requests
-  M.sample(rate=)              — probabilistic sampling
+  M.sample({rate})             — probabilistic sampling
   M.trace()                    — distributed tracing
   M.metrics()                  — metrics collection
-  M.before_agent(fn)           — pre-agent hook
-  M.after_agent(fn)            — post-agent hook
-  M.before_model(fn)           — pre-model hook
-  M.after_model(fn)            — post-model hook
-  M.on_loop(fn)                — loop iteration hook
-  M.on_timeout(fn)             — timeout event hook
-  M.on_route(fn)               — routing event hook
-  M.on_fallback(fn)            — fallback event hook
+  M.beforeAgent(fn)            — pre-agent hook
+  M.afterAgent(fn)             — post-agent hook
+  M.beforeModel(fn)            — pre-model hook
+  M.afterModel(fn)             — post-model hook
+  M.onLoop(fn)                 — loop iteration hook
+  M.onTimeout(fn)              — timeout event hook
+  M.onRoute(fn)                — routing event hook
+  M.onFallback(fn)             — fallback event hook
 
 ### T — Tool composition
 
-Used with `.tools()`. Compose with `|` (chain).
+Used with ``.tools()``.  Compose with ``.pipe()`` (chain).
 
   T.fn(callable)               — wrap callable as FunctionTool
   T.agent(agent)               — wrap agent as AgentTool
-  T.google_search()            — built-in Google Search
+  T.googleSearch()             — built-in Google Search
   T.search(registry)           — BM25-indexed dynamic loading
   T.toolset(toolset)           — wrap MCPToolset or similar
   T.schema(schema)             — attach ToolSchema
   T.mock(responses)            — mock tool for testing
-  T.confirm(prompt=)           — human confirmation wrapper
-  T.timeout(seconds)           — tool timeout wrapper
-  T.cache(ttl=)                — tool response caching
+  T.confirm({prompt})          — human confirmation wrapper
+  T.timeout({seconds})         — tool timeout wrapper
+  T.cache({ttl})               — tool response caching
   T.mcp(server)                — MCP server tool
   T.openapi(spec)              — OpenAPI spec tool
   T.transform(fn)              — transform tool output
 
 ### E — Evaluation
 
-Used with `.eval()` and `.eval_suite()`. Build evaluation criteria and test suites.
+Used with ``.eval()`` / ``.evalSuite()``.  Build evaluation criteria and
+test suites.
 
-  E.case(prompt, expect=)      — single evaluation case
+  E.case(prompt, {expect})     — single evaluation case
   E.criterion(name, fn)        — custom evaluation criterion
-  E.persona(name, style=)      — persona for evaluation
+  E.persona(name, {style})     — persona for evaluation
   EvalSuite                    — collection of eval cases
   EvalReport                   — evaluation results
   ComparisonReport             — compare multiple agents/models
 
 ### G — Guards (output validation)
 
-Used with `.guard()`. Guards validate/transform the LLM response (after_model).
-Compose with `|` (chain). Raise GuardViolation on failure.
+Used with ``.guard()``.  Guards validate/transform the LLM response
+(afterModel).  Compose with ``.pipe()`` (chain).  Throws ``GuardViolation``
+on failure.
 
-  G.guard(fn)                  — custom guard function (fn receives llm_response)
-  G.pii(detector=)             — detect and block/redact PII in output
-  G.toxicity(threshold=)       — block toxic content above threshold
-  G.length(max=)               — enforce max response length
-  G.schema(model)              — validate output against Pydantic model
+  G.guard(fn)                  — custom guard function
+  G.pii({action, detector})    — detect and block/redact PII in output
+  G.toxicity({threshold, judge}) — block toxic content above threshold
+  G.length({min, max})         — enforce length bounds
+  G.regex(pattern, {action})   — block or redact pattern matches
+  G.schema(schema)             — validate output against schema
+  G.output(schema)             — post-model schema validation
+  G.input(schema)              — pre-model input schema validation
+  G.budget({maxTokens})        — token budget constraint
+  G.rateLimit({rpm})           — requests-per-minute limit
+  G.maxTurns(n)                — cap conversation turns
+  G.topic({deny})              — block specific topics
+  G.grounded({sourcesKey})     — verify output is grounded in sources
+  G.hallucination({threshold}) — detect hallucinated content
+  G.when(pred, guard)          — conditional guard
+  G.dlp({project, infoTypes, location}) — Google Cloud DLP detector
+  G.regexDetector([patterns])  — lightweight regex-based PII detector
+  G.multi(...detectors)        — union of multiple detectors
   GuardViolation               — raised when a guard check fails
-  PIIDetector                  — PII detection provider
-  ContentJudge                 — content judgment provider
+  PIIDetector                  — PII detection provider type
+  ContentJudge                 — content judgment provider type
 
 ### UI — Agent-to-UI composition (A2UI)
 
-Declarative UI composition for agents. Compose with `|` (Row), `>>` (Column).
-Import: ``from adk_fluent import UI`` or ``from adk_fluent._ui import UI``.
+Declarative UI composition for agents.  Compose with ``.pipe()`` / ``.add()``.
+Import: ``import { UI } from "adk-fluent-ts";``
 
 Component factories:
-  UI.text(content, variant=)   — text content (h1-h5, caption, body)
-  UI.button(label, action=)    — clickable button
-  UI.text_field(label, bind=)  — text input with optional data binding
-  UI.image(src, alt=, fit=)    — display an image
-  UI.row(*children)            — horizontal layout
-  UI.column(*children)         — vertical layout
-  UI.component(kind, **props)  — generic escape hatch
+  UI.text(content, {variant})  — text content (h1-h5, caption, body)
+  UI.button(label, {action})   — clickable button
+  UI.textField(label, {bind})  — text input with optional data binding
+  UI.image(src, {alt, fit})    — display an image
+  UI.row(...children)          — horizontal layout
+  UI.column(...children)       — vertical layout
+  UI.component(kind, props)    — generic escape hatch
 
 Data binding & validation:
   UI.bind(path)                — create data binding to JSON Pointer path
-  UI.required(msg=)            — required field validation
-  UI.email(msg=)               — email format validation
+  UI.required({msg})           — required field validation
+  UI.email({msg})              — email format validation
 
 Surface lifecycle:
-  UI.surface(name, *children)  — create named surface (compilation root)
-  UI.auto(catalog=)            — LLM-guided mode (agent decides UI)
+  UI.surface(name, ...children) — create named surface (compilation root)
+  UI.auto({catalog})           — LLM-guided mode (agent decides UI)
 
 Presets:
-  UI.form(title, fields=)      — form surface from field spec
-  UI.dashboard(title, cards=)  — dashboard with metric cards
-  UI.wizard(title, steps=)     — multi-step wizard
+  UI.form(title, {fields})     — form surface from field spec
+  UI.dashboard(title, {cards}) — dashboard with metric cards
+  UI.wizard(title, {steps})    — multi-step wizard
   UI.confirm(message)          — confirmation dialog
-  UI.table(columns, data_bind=) — data table
+  UI.table({columns, dataBind}) — data table
 
 Agent integration:
   Agent.ui(spec)               — attach UI surface to agent
   T.a2ui()                     — A2UI toolset for LLM-guided mode
-  G.a2ui(max_components=)      — validate LLM-generated UI
-  P.ui_schema()                — inject catalog schema into prompt
-  S.to_ui(*keys, surface=)     — bridge state → A2UI data model
-  S.from_ui(*keys, surface=)   — bridge A2UI data model → state
-  M.a2ui_log(level=)           — log A2UI surface operations
-  C.with_ui(surface_id=)       — include UI state in context
+  G.a2ui({maxComponents})      — validate LLM-generated UI
+  P.uiSchema()                 — inject catalog schema into prompt
+  S.toUi(...keys, {surface})   — bridge state → A2UI data model
+  S.fromUi(...keys, {surface}) — bridge A2UI data model → state
+  M.a2uiLog({level})           — log A2UI surface operations
+  C.withUi({surfaceId})        — include UI state in context
 ## Builder inventory
 
-132 builders across 9 modules.
+135 builders across 9 modules.
 
-### agent module (2 builders)
+### agent module (3 builders)
 
-BaseAgent, Agent
+BaseAgent, Agent, RemoteA2aAgent
 
-### config module (38 builders)
+### config module (39 builders)
 
-AgentConfig, BaseAgentConfig, AgentRefConfig, ArgumentConfig, CodeConfig, ContextCacheConfig, LlmAgentConfig, LoopAgentConfig, ParallelAgentConfig, RunConfig, ToolThreadPoolConfig, SequentialAgentConfig, EventsCompactionConfig, ResumabilityConfig, FeatureConfig, AudioCacheConfig, SimplePromptOptimizerConfig, BigQueryLoggerConfig, RetryConfig, GetSessionConfig, BaseGoogleCredentialsConfig, AgentSimulatorConfig, InjectionConfig, ToolSimulationConfig, AgentToolConfig, BigQueryCredentialsConfig, BigQueryToolConfig, BigtableCredentialsConfig, DataAgentToolConfig, DataAgentCredentialsConfig, ExampleToolConfig, McpToolsetConfig, PubSubToolConfig, PubSubCredentialsConfig, SpannerCredentialsConfig, BaseToolConfig, ToolArgsConfig, ToolConfig
+A2aAgentExecutorConfig, AgentConfig, BaseAgentConfig, AgentRefConfig, ArgumentConfig, CodeConfig, ContextCacheConfig, LlmAgentConfig, LoopAgentConfig, ParallelAgentConfig, RunConfig, ToolThreadPoolConfig, SequentialAgentConfig, EventsCompactionConfig, ResumabilityConfig, FeatureConfig, AudioCacheConfig, SimplePromptOptimizerConfig, BigQueryLoggerConfig, RetryConfig, GetSessionConfig, BaseGoogleCredentialsConfig, AgentSimulatorConfig, InjectionConfig, ToolSimulationConfig, AgentToolConfig, BigQueryCredentialsConfig, BigQueryToolConfig, BigtableCredentialsConfig, DataAgentToolConfig, DataAgentCredentialsConfig, ExampleToolConfig, McpToolsetConfig, PubSubToolConfig, PubSubCredentialsConfig, SpannerCredentialsConfig, BaseToolConfig, ToolArgsConfig, ToolConfig
 
-### executor module (5 builders)
+### executor module (6 builders)
 
-AgentEngineSandboxCodeExecutor, BaseCodeExecutor, BuiltInCodeExecutor, UnsafeLocalCodeExecutor, VertexAiCodeExecutor
+A2aAgentExecutor, AgentEngineSandboxCodeExecutor, BaseCodeExecutor, BuiltInCodeExecutor, UnsafeLocalCodeExecutor, VertexAiCodeExecutor
 
 ### planner module (3 builders)
 
@@ -319,26 +341,27 @@ Loop, FanOut, Pipeline
 ## Best practices
 
 1. Use deterministic routing (Route) over LLM routing when the decision is rule-based
-2. Use `.inject()` for infrastructure deps — never expose DB clients in tool schemas
+2. Use ``.inject()`` for infrastructure deps — never expose DB clients in tool schemas
 3. Use S.transform() or plain functions for data transforms, not custom BaseAgent
 4. Use C.none() to hide conversation history from background/utility agents
 5. Use M.retry() middleware instead of retry logic inside tool functions
-6. Use `.writes()` not deprecated `.output_key()` / `.outputs()`
-7. Use `.returns()` not deprecated `.output_schema()`
-8. Use `.context()` not deprecated `.history()` / `.include_history()`
-9. Use `.agent_tool()` not deprecated `.delegate()`
-10. Use `.guard()` not deprecated `.guardrail()`
-11. Use `.loop_while()` not deprecated `.retry_if()`
-12. Use `.prepend()` not deprecated `.inject_context()`
-13. All operators are immutable — sub-expressions can be safely reused
-14. Every `.build()` returns a real ADK object compatible with adk web/run/deploy
-15. Use `.sub_agent()` for transfer-based delegation (LLM decides routing);
-    use `.agent_tool()` for tool-based invocation (parent stays in control)
-16. Use `.isolate()` on specialist agents by default — it is the most predictable pattern
-17. Always set `.describe()` on sub-agents — the description helps the coordinator LLM
+6. Use ``.writes()`` not deprecated ``.outputKey()`` / ``.outputs()``
+7. Use ``.outputAs()`` not deprecated ``.outputSchema()``
+8. Use ``.context()`` not deprecated ``.history()`` / ``.includeHistory()``
+9. Use ``.agentTool()`` not deprecated ``.delegate()``
+10. Use ``.guard()`` not deprecated ``.guardrail()``
+11. Use ``.loopWhile()`` not deprecated ``.retryIf()``
+12. Use ``.prepend()`` not deprecated ``.injectContext()``
+13. All builders are immutable — sub-expressions can be safely reused
+14. Workflow sub-builders passed to ``.then()`` / ``.parallel()`` / ``.step()``
+    are auto-built; do not call ``.build()`` on individual steps
+15. Use ``.subAgent()`` for transfer-based delegation (LLM decides routing);
+    use ``.agentTool()`` for tool-based invocation (parent stays in control)
+16. Use ``.isolate()`` on specialist agents by default — it is the most predictable pattern
+17. Always set ``.describe()`` on sub-agents — the description helps the coordinator LLM
     pick the right specialist during transfer routing
-18. Use `.ask_async()` and `.map_async()` in async contexts (Jupyter, FastAPI).
-    The sync variants (.ask, .map) raise RuntimeError inside running event loops.
+18. Use ``.askAsync()`` / ``.mapAsync()`` in async code paths;
+    the sync ``.ask()`` / ``.map()`` variants throw inside running event loops
 ## Development commands (TypeScript)
 
     cd ts

--- a/ts/README.md
+++ b/ts/README.md
@@ -33,7 +33,11 @@ import { Agent, Pipeline, FanOut, Loop } from "adk-fluent-ts";
 
 // Sequential
 const pipeline = new Pipeline("research")
-  .step(new Agent("searcher", "gemini-2.5-flash").instruct("Search for information."))
+  .step(
+    new Agent("searcher", "gemini-2.5-flash").instruct(
+      "Search for information.",
+    ),
+  )
   .step(new Agent("writer", "gemini-2.5-flash").instruct("Write a summary."))
   .build();
 
@@ -55,14 +59,14 @@ const loop = new Loop("refine")
 
 JavaScript has no operator overloading, so `adk-fluent-ts` uses method calls. The mapping from the Python operator algebra is:
 
-| Python       | TypeScript                     | Returns    |
-| ------------ | ------------------------------ | ---------- |
-| `a >> b`     | `a.then(b)`                    | `Pipeline` |
-| `a \| b`     | `a.parallel(b)`                | `FanOut`   |
-| `a * 3`      | `a.times(3)`                   | `Loop`     |
-| `a * until`  | `a.timesUntil(pred, { max })`  | `Loop`     |
-| `a // b`     | `a.fallback(b)`                | `Fallback` |
-| `a @ Schema` | `a.outputAs(Schema)`           | `Agent`    |
+| Python       | TypeScript                    | Returns    |
+| ------------ | ----------------------------- | ---------- |
+| `a >> b`     | `a.then(b)`                   | `Pipeline` |
+| `a \| b`     | `a.parallel(b)`               | `FanOut`   |
+| `a * 3`      | `a.times(3)`                  | `Loop`     |
+| `a * until`  | `a.timesUntil(pred, { max })` | `Loop`     |
+| `a // b`     | `a.fallback(b)`               | `Fallback` |
+| `a @ Schema` | `a.outputAs(Schema)`          | `Agent`    |
 
 Sub-builders passed into workflow builders are auto-built — do **not** call `.build()` on individual steps.
 
@@ -89,7 +93,13 @@ All nine namespaces from the Python API are available with TypeScript idioms —
 ```ts
 import { S, C, P, T, G, M, A, E, UI } from "adk-fluent-ts";
 import { tap, expect, gate, race, dispatch, join, Route } from "adk-fluent-ts";
-import { reviewLoop, mapReduce, cascade, chain, conditional } from "adk-fluent-ts";
+import {
+  reviewLoop,
+  mapReduce,
+  cascade,
+  chain,
+  conditional,
+} from "adk-fluent-ts";
 import { RemoteAgent, A2AServer, AgentRegistry } from "adk-fluent-ts";
 ```
 

--- a/ts/README.md
+++ b/ts/README.md
@@ -2,22 +2,19 @@
 
 TypeScript fluent builder API for Google's [Agent Development Kit (ADK)](https://github.com/google/adk). Mirrors the Python [`adk-fluent`](https://pypi.org/project/adk-fluent/) API surface with TypeScript idioms — immutable clones, method-chained operators, and camelCase.
 
-> **Monorepo:** This is the TypeScript package in the [`adk-fluent` monorepo](../README.md). The Python package (the current reference implementation) lives in [`python/`](../python/). Shared manifests, seeds, and code generators live in [`shared/`](../shared/). Both packages are regenerated from the same ADK scan.
+Every `.build()` returns a real [`@google/adk`](https://www.npmjs.com/package/@google/adk) object, so anything built with `adk-fluent-ts` is fully compatible with ADK's runtime, deployment, and tooling.
 
 ## Status
 
-Beta. The TypeScript port tracks the Python API surface feature-by-feature and is regenerated from `shared/manifest.json` via `just ts-generate`. The package is not yet published to npm — consume it from the monorepo during beta.
+Beta. The TypeScript port tracks the Python API surface feature-by-feature and is regenerated from a shared manifest via `just ts-generate`. The API surface is stable enough to build real agents, but minor breakages may still land before `1.0`.
 
 ## Install
 
 ```bash
-# From inside the monorepo
-cd ts
-npm install
-npm run build
+npm install adk-fluent-ts @google/adk
 ```
 
-`adk-fluent-ts` peer-depends on [`@google/adk`](https://www.npmjs.com/package/@google/adk) (the JavaScript port of Google ADK). Install it alongside `adk-fluent-ts` in your consumer project.
+`adk-fluent-ts` declares [`@google/adk`](https://www.npmjs.com/package/@google/adk) as a peer dependency — install it alongside in your consumer project.
 
 ## Quick Start
 
@@ -28,8 +25,6 @@ const agent = new Agent("helper", "gemini-2.5-flash")
   .instruct("You are a helpful assistant.")
   .build();
 ```
-
-Every `.build()` returns a real `@google/adk` object — fully compatible with ADK's runtime, deployment, and tooling.
 
 ### Pipeline, FanOut, Loop
 
@@ -60,19 +55,19 @@ const loop = new Loop("refine")
 
 JavaScript has no operator overloading, so `adk-fluent-ts` uses method calls. The mapping from the Python operator algebra is:
 
-| Python      | TypeScript                            | Returns    |
-| ----------- | ------------------------------------- | ---------- |
-| `a >> b`    | `a.then(b)`                           | `Pipeline` |
-| `a \| b`    | `a.parallel(b)`                       | `FanOut`   |
-| `a * 3`    | `a.times(3)`                          | `Loop`     |
-| `a * until` | `a.timesUntil(pred, { max })`         | `Loop`     |
-| `a // b`    | `a.fallback(b)`                       | `Fallback` |
-| `a @ Schema`| `a.outputAs(Schema)`                  | `Agent`    |
+| Python       | TypeScript                     | Returns    |
+| ------------ | ------------------------------ | ---------- |
+| `a >> b`     | `a.then(b)`                    | `Pipeline` |
+| `a \| b`     | `a.parallel(b)`                | `FanOut`   |
+| `a * 3`      | `a.times(3)`                   | `Loop`     |
+| `a * until`  | `a.timesUntil(pred, { max })`  | `Loop`     |
+| `a // b`     | `a.fallback(b)`                | `Fallback` |
+| `a @ Schema` | `a.outputAs(Schema)`           | `Agent`    |
 
 Sub-builders passed into workflow builders are auto-built — do **not** call `.build()` on individual steps.
 
 ```ts
-import { Agent } from "adk-fluent-ts";
+import { Agent, Pipeline } from "adk-fluent-ts";
 
 const writer = new Agent("writer", "gemini-2.5-flash")
   .instruct("Write a draft about {topic}.")
@@ -89,7 +84,7 @@ const pipeline2 = writer.then(reviewer).build();
 
 ## Namespaces
 
-All nine Python namespaces are available:
+All nine namespaces from the Python API are available with TypeScript idioms — camelCase method names, method-chained composition (`.pipe()` / `.add()`), and options-object arguments:
 
 ```ts
 import { S, C, P, T, G, M, A, E, UI } from "adk-fluent-ts";
@@ -109,52 +104,33 @@ import { RemoteAgent, A2AServer, AgentRegistry } from "adk-fluent-ts";
 | `A`       | Artifacts (`A.publish`, `A.snapshot`, ...)                |
 | `E`       | Evaluation (`E.case`, `E.criterion`, `E.persona`, ...)    |
 | `UI`      | A2UI — declarative agent UI composition                   |
-| `H`       | Harness — build-your-own coding agent runtime             |
 
-See [`CLAUDE.md`](CLAUDE.md) for the TypeScript-specific LLM context (operator mapping, namespace reference) and the [root `CLAUDE.md`](../CLAUDE.md) for the shared API reference — both are regenerated from the same manifest as the code.
+JavaScript reserved words use a trailing underscore — `S.default_`, `C.default_`, `A.delete_`. See [`CLAUDE.md`](https://github.com/vamsiramakrishnan/adk-fluent/blob/main/ts/CLAUDE.md) for the full TypeScript namespace reference.
 
 ## Examples
 
-Runnable recipes live in [`examples/cookbook/`](examples/cookbook). Highlights:
+Runnable recipes live in [`ts/examples/cookbook/`](https://github.com/vamsiramakrishnan/adk-fluent/tree/main/ts/examples/cookbook). Highlights:
 
-- [`01_simple_agent.ts`](examples/cookbook/01_simple_agent.ts) — minimal agent
-- [`04_sequential_pipeline.ts`](examples/cookbook/04_sequential_pipeline.ts) — `Pipeline` + `.then()`
-- [`05_parallel_fanout.ts`](examples/cookbook/05_parallel_fanout.ts) — `FanOut` + `.parallel()`
-- [`08_operator_composition.ts`](examples/cookbook/08_operator_composition.ts) — method-chain operator algebra
-- [`12_guards.ts`](examples/cookbook/12_guards.ts) — `G.pii()`, `G.length()`, `G.schema()`
-- [`18_review_loop_pattern.ts`](examples/cookbook/18_review_loop_pattern.ts) — `reviewLoop()` higher-order pattern
+- [`01_simple_agent.ts`](https://github.com/vamsiramakrishnan/adk-fluent/blob/main/ts/examples/cookbook/01_simple_agent.ts) — minimal agent
+- [`04_sequential_pipeline.ts`](https://github.com/vamsiramakrishnan/adk-fluent/blob/main/ts/examples/cookbook/04_sequential_pipeline.ts) — `Pipeline` + `.then()`
+- [`05_parallel_fanout.ts`](https://github.com/vamsiramakrishnan/adk-fluent/blob/main/ts/examples/cookbook/05_parallel_fanout.ts) — `FanOut` + `.parallel()`
+- [`08_operator_composition.ts`](https://github.com/vamsiramakrishnan/adk-fluent/blob/main/ts/examples/cookbook/08_operator_composition.ts) — method-chain operator algebra
+- [`12_guards.ts`](https://github.com/vamsiramakrishnan/adk-fluent/blob/main/ts/examples/cookbook/12_guards.ts) — `G.pii()`, `G.length()`, `G.schema()`
+- [`18_review_loop_pattern.ts`](https://github.com/vamsiramakrishnan/adk-fluent/blob/main/ts/examples/cookbook/18_review_loop_pattern.ts) — `reviewLoop()` higher-order pattern
 
-Run any example with `npx tsx examples/cookbook/01_simple_agent.ts`.
+Clone the repo and run any example with `npx tsx ts/examples/cookbook/01_simple_agent.ts`.
 
-## Development
+## Documentation
 
-From the monorepo root, use the `just` recipes:
+The canonical docs site covers both Python and TypeScript — every guide has synchronized `:::{tab-item} :sync: python` / `:sync: ts` code blocks, so switching language once persists across the whole site.
 
-```bash
-just ts-setup        # npm install inside ts/
-just ts-generate     # Regenerate TS builders from shared/manifest.json + seeds
-just ts-build        # tsc build
-just ts-typecheck    # tsc --noEmit
-just ts-lint         # eslint
-just ts-test         # vitest run
-```
-
-Or work inside `ts/` directly:
-
-```bash
-cd ts
-npm run build
-npm run test
-npm run lint
-npm run typecheck
-npm run docs        # typedoc → docs/api
-```
-
-Generated files (`ts/src/builders/*.ts`) are owned by `just ts-generate` and should not be hand-edited — changes there will be overwritten on the next regeneration. Hand-written code lives under `ts/src/core/`, `ts/src/namespaces/`, `ts/src/patterns/`, `ts/src/primitives/`, `ts/src/routing/`, and `ts/src/a2a/`.
+- **Docs site:** <https://vamsiramakrishnan.github.io/adk-fluent/>
+- **Getting started (TS):** <https://vamsiramakrishnan.github.io/adk-fluent/typescript.html>
+- **LLM context (camelCase reference):** [`ts/CLAUDE.md`](https://github.com/vamsiramakrishnan/adk-fluent/blob/main/ts/CLAUDE.md)
 
 ## How It Works
 
-`adk-fluent-ts` is **auto-generated** from the installed Google ADK via the shared generator:
+`adk-fluent-ts` is **auto-generated** from the installed Google ADK via a shared scanner. The same manifest drives the Python builders — API parity between languages is enforced by construction, not by hand.
 
 ```
 shared/scripts/scanner.py  ─►  shared/manifest.json
@@ -166,15 +142,27 @@ shared/scripts/scanner.py  ─►  shared/manifest.json
                                ts/src/builders/*.ts
 ```
 
-The same manifest drives the Python builders — API parity between languages is enforced by construction.
+## Contributing
+
+Contributions are welcome. The repo is a monorepo with Python (`python/`), TypeScript (`ts/`), and the shared codegen (`shared/`). To hack on the TS package:
+
+```bash
+git clone https://github.com/vamsiramakrishnan/adk-fluent
+cd adk-fluent/ts
+npm install
+npm run build
+npm test
+```
+
+Generated files (`ts/src/builders/*.ts`) are owned by `just ts-generate` and should not be hand-edited. Hand-written code lives under `ts/src/core/`, `ts/src/namespaces/`, `ts/src/patterns/`, `ts/src/primitives/`, `ts/src/routing/`, and `ts/src/a2a/`. See [`CONTRIBUTING.md`](https://github.com/vamsiramakrishnan/adk-fluent/blob/main/CONTRIBUTING.md) for the full workflow.
 
 ## Links
 
-- Monorepo README: [`../README.md`](../README.md)
-- Python package: [`../python/README.md`](../python/README.md) — reference implementation
-- LLM context (shared API reference): [`../CLAUDE.md`](../CLAUDE.md)
-- Python docs site (most guides apply to both languages): <https://vamsiramakrishnan.github.io/adk-fluent/>
-- Changelog: [`../CHANGELOG.md`](../CHANGELOG.md)
+- **Repository:** <https://github.com/vamsiramakrishnan/adk-fluent>
+- **Docs site:** <https://vamsiramakrishnan.github.io/adk-fluent/>
+- **Python package (reference implementation):** [`adk-fluent` on PyPI](https://pypi.org/project/adk-fluent/)
+- **Changelog:** <https://github.com/vamsiramakrishnan/adk-fluent/blob/main/CHANGELOG.md>
+- **Issues:** <https://github.com/vamsiramakrishnan/adk-fluent/issues>
 
 ## License
 

--- a/ts/README.md
+++ b/ts/README.md
@@ -1,0 +1,181 @@
+# adk-fluent-ts
+
+TypeScript fluent builder API for Google's [Agent Development Kit (ADK)](https://github.com/google/adk). Mirrors the Python [`adk-fluent`](https://pypi.org/project/adk-fluent/) API surface with TypeScript idioms — immutable clones, method-chained operators, and camelCase.
+
+> **Monorepo:** This is the TypeScript package in the [`adk-fluent` monorepo](../README.md). The Python package (the current reference implementation) lives in [`python/`](../python/). Shared manifests, seeds, and code generators live in [`shared/`](../shared/). Both packages are regenerated from the same ADK scan.
+
+## Status
+
+Beta. The TypeScript port tracks the Python API surface feature-by-feature and is regenerated from `shared/manifest.json` via `just ts-generate`. The package is not yet published to npm — consume it from the monorepo during beta.
+
+## Install
+
+```bash
+# From inside the monorepo
+cd ts
+npm install
+npm run build
+```
+
+`adk-fluent-ts` peer-depends on [`@google/adk`](https://www.npmjs.com/package/@google/adk) (the JavaScript port of Google ADK). Install it alongside `adk-fluent-ts` in your consumer project.
+
+## Quick Start
+
+```ts
+import { Agent } from "adk-fluent-ts";
+
+const agent = new Agent("helper", "gemini-2.5-flash")
+  .instruct("You are a helpful assistant.")
+  .build();
+```
+
+Every `.build()` returns a real `@google/adk` object — fully compatible with ADK's runtime, deployment, and tooling.
+
+### Pipeline, FanOut, Loop
+
+```ts
+import { Agent, Pipeline, FanOut, Loop } from "adk-fluent-ts";
+
+// Sequential
+const pipeline = new Pipeline("research")
+  .step(new Agent("searcher", "gemini-2.5-flash").instruct("Search for information."))
+  .step(new Agent("writer", "gemini-2.5-flash").instruct("Write a summary."))
+  .build();
+
+// Parallel
+const fanout = new FanOut("parallel_research")
+  .branch(new Agent("web", "gemini-2.5-flash").instruct("Search the web."))
+  .branch(new Agent("papers", "gemini-2.5-flash").instruct("Search papers."))
+  .build();
+
+// Iterative refinement
+const loop = new Loop("refine")
+  .step(new Agent("writer", "gemini-2.5-flash").instruct("Write draft."))
+  .step(new Agent("critic", "gemini-2.5-flash").instruct("Critique."))
+  .maxIterations(3)
+  .build();
+```
+
+## Operators → Method Chains
+
+JavaScript has no operator overloading, so `adk-fluent-ts` uses method calls. The mapping from the Python operator algebra is:
+
+| Python      | TypeScript                            | Returns    |
+| ----------- | ------------------------------------- | ---------- |
+| `a >> b`    | `a.then(b)`                           | `Pipeline` |
+| `a \| b`    | `a.parallel(b)`                       | `FanOut`   |
+| `a * 3`    | `a.times(3)`                          | `Loop`     |
+| `a * until` | `a.timesUntil(pred, { max })`         | `Loop`     |
+| `a // b`    | `a.fallback(b)`                       | `Fallback` |
+| `a @ Schema`| `a.outputAs(Schema)`                  | `Agent`    |
+
+Sub-builders passed into workflow builders are auto-built — do **not** call `.build()` on individual steps.
+
+```ts
+import { Agent } from "adk-fluent-ts";
+
+const writer = new Agent("writer", "gemini-2.5-flash")
+  .instruct("Write a draft about {topic}.")
+  .writes("draft");
+
+const reviewer = new Agent("reviewer", "gemini-2.5-flash")
+  .instruct("Review the draft: {draft}")
+  .writes("feedback");
+
+// Same thing, two styles:
+const pipeline1 = new Pipeline("flow").step(writer).step(reviewer).build();
+const pipeline2 = writer.then(reviewer).build();
+```
+
+## Namespaces
+
+All nine Python namespaces are available:
+
+```ts
+import { S, C, P, T, G, M, A, E, UI } from "adk-fluent-ts";
+import { tap, expect, gate, race, dispatch, join, Route } from "adk-fluent-ts";
+import { reviewLoop, mapReduce, cascade, chain, conditional } from "adk-fluent-ts";
+import { RemoteAgent, A2AServer, AgentRegistry } from "adk-fluent-ts";
+```
+
+| Namespace | What it does                                              |
+| --------- | --------------------------------------------------------- |
+| `S`       | State transforms (`S.pick`, `S.rename`, `S.compute`, ...) |
+| `C`       | Context engineering (`C.window`, `C.fromState`, ...)      |
+| `P`       | Prompt composition (`P.role`, `P.task`, ...)              |
+| `T`       | Tool composition (`T.fn`, `T.googleSearch`, ...)          |
+| `G`       | Output guards (`G.pii`, `G.length`, `G.schema`, ...)      |
+| `M`       | Middleware (`M.retry`, `M.cost`, `M.cache`, ...)          |
+| `A`       | Artifacts (`A.publish`, `A.snapshot`, ...)                |
+| `E`       | Evaluation (`E.case`, `E.criterion`, `E.persona`, ...)    |
+| `UI`      | A2UI — declarative agent UI composition                   |
+| `H`       | Harness — build-your-own coding agent runtime             |
+
+See [`CLAUDE.md`](CLAUDE.md) for the TypeScript-specific LLM context (operator mapping, namespace reference) and the [root `CLAUDE.md`](../CLAUDE.md) for the shared API reference — both are regenerated from the same manifest as the code.
+
+## Examples
+
+Runnable recipes live in [`examples/cookbook/`](examples/cookbook). Highlights:
+
+- [`01_simple_agent.ts`](examples/cookbook/01_simple_agent.ts) — minimal agent
+- [`04_sequential_pipeline.ts`](examples/cookbook/04_sequential_pipeline.ts) — `Pipeline` + `.then()`
+- [`05_parallel_fanout.ts`](examples/cookbook/05_parallel_fanout.ts) — `FanOut` + `.parallel()`
+- [`08_operator_composition.ts`](examples/cookbook/08_operator_composition.ts) — method-chain operator algebra
+- [`12_guards.ts`](examples/cookbook/12_guards.ts) — `G.pii()`, `G.length()`, `G.schema()`
+- [`18_review_loop_pattern.ts`](examples/cookbook/18_review_loop_pattern.ts) — `reviewLoop()` higher-order pattern
+
+Run any example with `npx tsx examples/cookbook/01_simple_agent.ts`.
+
+## Development
+
+From the monorepo root, use the `just` recipes:
+
+```bash
+just ts-setup        # npm install inside ts/
+just ts-generate     # Regenerate TS builders from shared/manifest.json + seeds
+just ts-build        # tsc build
+just ts-typecheck    # tsc --noEmit
+just ts-lint         # eslint
+just ts-test         # vitest run
+```
+
+Or work inside `ts/` directly:
+
+```bash
+cd ts
+npm run build
+npm run test
+npm run lint
+npm run typecheck
+npm run docs        # typedoc → docs/api
+```
+
+Generated files (`ts/src/builders/*.ts`) are owned by `just ts-generate` and should not be hand-edited — changes there will be overwritten on the next regeneration. Hand-written code lives under `ts/src/core/`, `ts/src/namespaces/`, `ts/src/patterns/`, `ts/src/primitives/`, `ts/src/routing/`, and `ts/src/a2a/`.
+
+## How It Works
+
+`adk-fluent-ts` is **auto-generated** from the installed Google ADK via the shared generator:
+
+```
+shared/scripts/scanner.py  ─►  shared/manifest.json
+                                       │
+                                       ▼
+                         shared/scripts/generator.py --target typescript
+                                       │
+                                       ▼
+                               ts/src/builders/*.ts
+```
+
+The same manifest drives the Python builders — API parity between languages is enforced by construction.
+
+## Links
+
+- Monorepo README: [`../README.md`](../README.md)
+- Python package: [`../python/README.md`](../python/README.md) — reference implementation
+- LLM context (shared API reference): [`../CLAUDE.md`](../CLAUDE.md)
+- Python docs site (most guides apply to both languages): <https://vamsiramakrishnan.github.io/adk-fluent/>
+- Changelog: [`../CHANGELOG.md`](../CHANGELOG.md)
+
+## License
+
+Apache-2.0


### PR DESCRIPTION
README.template.md is now the single source of truth for the Python-facing
README (PyPI) and now documents the dual-language monorepo up front:

- New top-level monorepo callout + Packages table covering adk-fluent
  (python/) and adk-fluent-ts (ts/), with shared/ as the generator source.
- TypeScript quick-start block in the Install section with a sample Agent
  pipeline and a pointer to ts/README.md.
- Updated How It Works diagram to show the shared manifest driving both
  Python and TypeScript code generators.
- Development section rewritten around the monorepo layout: just setup,
  python workflow, ts workflow, and monorepo-wide commands
  (generate-all / build-all / test-all).
- Fixed stale paths (visual/, scripts/benchmark.py, visual/.env,
  src/adk_fluent/_version.py) to reflect the new python/ layout.

Also:

- New ts/README.md: TypeScript-focused entry point with install, quick
  start, operator-to-method-chain mapping, namespace summary, examples
  index, and development commands.
- docs/index.md and docs/getting-started.md get a Python+TypeScript
  note so the docs site calls out both packages from the landing page.
- README.md and python/README.md regenerated from the updated template
  via shared/scripts/readme_generator.py.