### PR TITLE
perf: wave 1 hot-path optimizations (slots, hook table, tape, deepcopy)

### DIFF
--- a/python/src/adk_fluent/_base.py
+++ b/python/src/adk_fluent/_base.py
@@ -391,6 +391,17 @@ def _compose_callbacks(fns: list) -> Callable:
     Each runs in order. First non-None return value wins (short-circuit).
     Handles both sync and async callbacks, and resolves guard spec tuples
     into real async callbacks.
+
+    Fast paths:
+
+    * Empty list raises — callers are expected to check first.
+    * Single callback is returned raw (no wrapper). This is the common
+      case for users who register one callback per hook.
+    * Multi-callback path pre-classifies each entry as sync vs async
+      using ``inspect.iscoroutinefunction`` at compose time. The hot
+      runtime loop then skips the ``asyncio.iscoroutine`` check on
+      classified-async entries and only falls into it on the (rare)
+      case where a sync callback happens to return a coroutine.
     """
     if not fns:
         raise ValueError("_compose_callbacks requires at least one callback")
@@ -406,13 +417,31 @@ def _compose_callbacks(fns: list) -> Callable:
     if len(resolved) == 1:
         return resolved[0]
 
+    import inspect
+
+    # Classify each callable as sync/async ONCE at compose time. The
+    # runtime loop uses this to skip the generic iscoroutine probe that
+    # used to run on every turn for every callback.
+    classified: tuple[tuple[Callable, bool], ...] = tuple((fn, inspect.iscoroutinefunction(fn)) for fn in resolved)
+
     async def _composed(*args, **kwargs):
-        for fn in resolved:
-            result = fn(*args, **kwargs)
-            if _asyncio.iscoroutine(result) or _asyncio.isfuture(result):
-                result = await result
-            if result is not None:
-                return result
+        for fn, is_async in classified:
+            if is_async:
+                result = await fn(*args, **kwargs)
+                if result is not None:
+                    return result
+            else:
+                result = fn(*args, **kwargs)
+                if result is not None:
+                    # Sync callback returned something; it may still be
+                    # a coroutine (users occasionally write
+                    # ``def cb(...): return some_async()``).
+                    if _asyncio.iscoroutine(result) or _asyncio.isfuture(result):
+                        result = await result
+                        if result is not None:
+                            return result
+                    else:
+                        return result
         return None
 
     _composed.__name__ = f"composed_{'_'.join(getattr(f, '__name__', '?') for f in resolved)}"
@@ -573,7 +602,7 @@ class BuilderBase:
     # the per-builder overhead to one memo update. Atomic leaf values
     # (strings, frozensets, types, callables) still hit
     # ``copy._deepcopy_atomic`` fast paths.
-    def __deepcopy__(self, memo: dict) -> "BuilderBase":
+    def __deepcopy__(self, memo: dict) -> BuilderBase:
         import copy as _copy
 
         new = object.__new__(type(self))

--- a/python/src/adk_fluent/_base.py
+++ b/python/src/adk_fluent/_base.py
@@ -553,6 +553,47 @@ class BuilderBase:
         return self
 
     # ------------------------------------------------------------------
+    # __deepcopy__ — explicit protocol override
+    # ------------------------------------------------------------------
+    #
+    # The previous implementation (in deep_clone_builder) called
+    # ``copy.deepcopy`` three times independently on ``_config``,
+    # ``_callbacks`` and ``_lists`` with three separate memos. That had
+    # two costs:
+    #
+    # 1. Sub-agents referenced from multiple fields (e.g. appearing in
+    #    both ``_lists["sub_agents"]`` and ``_config["parent_agent"]``)
+    #    were deep-copied twice, producing two independent clones.
+    # 2. The per-call ``copy.deepcopy`` dispatch overhead paid three
+    #    times instead of once for a single walk.
+    #
+    # Implementing ``__deepcopy__`` at the ``BuilderBase`` level lets
+    # CPython's ``copy.deepcopy`` machinery unify the walk through a
+    # single memo — this both deduplicates sub-builder copies and keeps
+    # the per-builder overhead to one memo update. Atomic leaf values
+    # (strings, frozensets, types, callables) still hit
+    # ``copy._deepcopy_atomic`` fast paths.
+    def __deepcopy__(self, memo: dict) -> "BuilderBase":
+        import copy as _copy
+
+        new = object.__new__(type(self))
+        memo[id(self)] = new
+        # Single shared memo across all three containers — sub-builders
+        # referenced from multiple fields are copied once.
+        new._config = _copy.deepcopy(self._config, memo)
+        new._callbacks = _copy.deepcopy(self._callbacks, memo)
+        new._lists = _copy.deepcopy(self._lists, memo)
+        # Middlewares are stateful-but-shared; operator paths already
+        # treat them as references. Preserve that here.
+        mw = getattr(self, "_middlewares", None)
+        if mw is not None:
+            new._middlewares = list(mw)
+        # Clones always start unfrozen — subsequent mutation paths expect
+        # the same invariant the old deep_clone_builder produced.
+        new._frozen = False
+        return new
+
+    # ------------------------------------------------------------------
     # Shared __getattr__: dynamic field forwarding
     # ------------------------------------------------------------------
 

--- a/python/src/adk_fluent/_context.py
+++ b/python/src/adk_fluent/_context.py
@@ -115,7 +115,7 @@ __all__ = [
 # ======================================================================
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CTransform:
     """Base context transform descriptor.
 
@@ -187,7 +187,7 @@ def _derive_include_contents(
 # ======================================================================
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CComposite(CTransform):
     """Union of multiple context blocks (via + operator).
 
@@ -220,7 +220,7 @@ class CComposite(CTransform):
         return frozenset(keys) if keys else None
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CPipe(CTransform):
     """Pipe transform: source feeds into transform (via | operator)."""
 
@@ -239,7 +239,7 @@ class CPipe(CTransform):
 # ======================================================================
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CWhen(CTransform):
     """Conditional context inclusion.
 
@@ -270,7 +270,7 @@ class CWhen(CTransform):
 # ======================================================================
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CFromState(CTransform):
     """Read named keys from session state and format as context.
 
@@ -302,7 +302,7 @@ class CFromState(CTransform):
         return frozenset(self.keys)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CWindow(CTransform):
     """Include only the last N turn-pairs from conversation history."""
 
@@ -318,7 +318,7 @@ class CWindow(CTransform):
         )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CUserOnly(CTransform):
     """Include only user messages from conversation history."""
 
@@ -333,7 +333,7 @@ class CUserOnly(CTransform):
         )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CFromAgents(CTransform):
     """Include user messages + outputs from named agents."""
 
@@ -349,7 +349,7 @@ class CFromAgents(CTransform):
         )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CExcludeAgents(CTransform):
     """Exclude outputs from named agents."""
 
@@ -365,7 +365,7 @@ class CExcludeAgents(CTransform):
         )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CTemplate(CTransform):
     """Render a template string with {key} and {key?} placeholders from state.
 
@@ -395,7 +395,7 @@ class CTemplate(CTransform):
 # ======================================================================
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CSelect(CTransform):
     """Filter events by metadata: author, type, and/or tag."""
 
@@ -413,7 +413,7 @@ class CSelect(CTransform):
         )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CRecent(CTransform):
     """Importance-weighted selection based on recency with exponential decay."""
 
@@ -436,7 +436,7 @@ class CRecent(CTransform):
 # ======================================================================
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CCompact(CTransform):
     """Structural compaction — merge sequential same-author messages or tool calls."""
 
@@ -452,7 +452,7 @@ class CCompact(CTransform):
         )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CDedup(CTransform):
     """Remove duplicate or redundant events."""
 
@@ -469,7 +469,7 @@ class CDedup(CTransform):
         )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CTruncate(CTransform):
     """Hard limit on context size by turn count or estimated tokens."""
 
@@ -487,7 +487,7 @@ class CTruncate(CTransform):
         )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CProject(CTransform):
     """Keep only specific fields from event content."""
 
@@ -508,7 +508,7 @@ class CProject(CTransform):
 # ======================================================================
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CBudget(CTransform):
     """Token budget constraint for context."""
 
@@ -525,7 +525,7 @@ class CBudget(CTransform):
         )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CPriority(CTransform):
     """Priority tier for context ordering (lower = higher priority)."""
 
@@ -533,7 +533,7 @@ class CPriority(CTransform):
     _kind: str = "priority"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CFit(CTransform):
     """Aggressive pruning to fit a hard token limit."""
 
@@ -556,7 +556,7 @@ class CFit(CTransform):
 # ======================================================================
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CFresh(CTransform):
     """Prune stale context based on event timestamp."""
 
@@ -573,7 +573,7 @@ class CFresh(CTransform):
         )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CRedact(CTransform):
     """Remove PII or sensitive patterns from context via regex."""
 
@@ -595,7 +595,7 @@ class CRedact(CTransform):
 # ======================================================================
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CSummarize(CTransform):
     """Lossy compression via LLM summarization."""
 
@@ -614,7 +614,7 @@ class CSummarize(CTransform):
         )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CRelevant(CTransform):
     """Semantic relevance selection via LLM scoring."""
 
@@ -633,7 +633,7 @@ class CRelevant(CTransform):
         )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CExtract(CTransform):
     """Structured extraction from conversation via LLM."""
 
@@ -651,7 +651,7 @@ class CExtract(CTransform):
         )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CDistill(CTransform):
     """Fact distillation from conversation via LLM."""
 
@@ -668,7 +668,7 @@ class CDistill(CTransform):
         )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CValidate(CTransform):
     """Context quality validation."""
 
@@ -690,7 +690,7 @@ class CValidate(CTransform):
 # ======================================================================
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CNotes(CTransform):
     """Read from an agent's structured scratchpad stored in session state.
 
@@ -719,7 +719,7 @@ class CNotes(CTransform):
         return frozenset({f"_notes_{self.key}"})
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CWriteNotes(CTransform):
     """Write to an agent's structured scratchpad after agent execution.
 
@@ -760,7 +760,7 @@ class CWriteNotes(CTransform):
 # ======================================================================
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CRolling(CTransform):
     """Rolling window with optional summarization of older turns.
 
@@ -782,7 +782,7 @@ class CRolling(CTransform):
         )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CFromAgentsWindowed(CTransform):
     """Per-agent selective windowing.
 
@@ -808,7 +808,7 @@ class CFromAgentsWindowed(CTransform):
         )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CUser(CTransform):
     """User message strategies.
 
@@ -832,7 +832,7 @@ class CUser(CTransform):
         )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CManusCascade(CTransform):
     """Manus-inspired progressive compression cascade.
 
@@ -858,7 +858,7 @@ class CManusCascade(CTransform):
 # Provider factories are in _context_providers.py (imported at module top).
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CPipelineAware(CTransform):
     """Topology-aware context for pipeline agents.
 
@@ -912,7 +912,7 @@ class CPipelineAware(CTransform):
         return frozenset(self.keys)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CSharedThread(CTransform):
     """Shared conversational thread for multi-agent loops.
 

--- a/python/src/adk_fluent/_context.py
+++ b/python/src/adk_fluent/_context.py
@@ -1304,12 +1304,34 @@ def _compile_context_spec(
             "instruction": developer_instruction,
         }
 
-    # Build a combined async instruction provider
+    # Build a combined async instruction provider.
+    #
+    # Fast path: if ``developer_instruction`` is a static string, compile
+    # its {key}/{key?} placeholders into a flat segment tuple once here
+    # (build time). The hot per-turn path then walks the segments and
+    # joins — no regex, no per-call closures. Missing required keys are
+    # left as literal ``{key}`` to match the legacy re.sub behaviour.
+    #
+    # Slow path: if the instruction is a callable (dynamic), we resolve
+    # it per turn but still use the module-level precompiled pattern.
+    from adk_fluent._context_providers import _compile_template, _render_template
+
     raw_instruction = developer_instruction
+    static_segments: tuple | None = None
+    static_text: str | None = None
+    if isinstance(raw_instruction, str):
+        static_segments = _compile_template(raw_instruction)
+        if static_segments is None:
+            # No placeholders — instruction is fully static.
+            static_text = raw_instruction
 
     async def _combined_provider(ctx: Any) -> str:
         # Step 1: resolve the developer instruction
-        if raw_instruction is None:
+        if static_text is not None:
+            instruction = static_text
+        elif static_segments is not None:
+            instruction = _render_template(static_segments, ctx.state, raise_on_missing=False)
+        elif raw_instruction is None:
             instruction = ""
         elif callable(raw_instruction):
             result = raw_instruction(ctx)
@@ -1320,25 +1342,13 @@ def _compile_context_spec(
                 instruction = await result
             else:
                 instruction = str(result)
+            # Dynamic instructions may still contain placeholders.
+            if instruction and "{" in instruction:
+                dyn_segments = _compile_template(instruction)
+                if dyn_segments is not None:
+                    instruction = _render_template(dyn_segments, ctx.state, raise_on_missing=False)
         else:
             instruction = str(raw_instruction)
-
-        # Template state variables into instruction ({key} patterns)
-        if instruction and "{" in instruction:
-            state = ctx.state
-
-            def _sub(match: re.Match) -> str:
-                key = match.group(1)
-                optional = match.group(2) == "?"
-                value = state.get(key)
-                if value is None:
-                    if optional:
-                        return ""
-                    # Leave unreplaced if not optional and not in state
-                    return match.group(0)
-                return str(value)
-
-            instruction = re.sub(r"\{(\w+)(\??)}", _sub, instruction)
 
         # Step 2: get context from the C transform's provider
         context = await spec_provider(ctx)

--- a/python/src/adk_fluent/_context_providers.py
+++ b/python/src/adk_fluent/_context_providers.py
@@ -27,6 +27,72 @@ _DEFAULT_MODEL = "gemini-2.5-flash"
 _log = logging.getLogger(__name__)
 
 
+# Module-level precompiled pattern for {key} / {key?} placeholders.
+# Used by the template provider and the combined-provider instruction
+# substitution path. Compiling once and reusing avoids the per-turn
+# ``re.compile`` call that ``re.sub`` with a string pattern pays.
+_PLACEHOLDER_RE = re.compile(r"\{(\w+)(\??)}")
+
+# Sentinel meaning "compile_template found no placeholders". Call sites
+# can short-circuit when they see this.
+_NO_SEGMENTS: tuple = ()
+
+
+def _compile_template(template: str) -> tuple | None:
+    """Pre-compile a template string into a flat tuple of render segments.
+
+    Returns ``None`` if the template contains no placeholders (callers
+    should then skip substitution entirely). Otherwise returns a tuple
+    of alternating literal strings and ``(key, optional)`` pairs. The
+    render loop in :func:`_render_template` walks this tuple with no
+    regex work and no per-call allocation beyond the output list.
+    """
+    if not template or "{" not in template:
+        return None
+
+    segments: list = []
+    pos = 0
+    for match in _PLACEHOLDER_RE.finditer(template):
+        start, end = match.span()
+        if start > pos:
+            segments.append(template[pos:start])
+        segments.append((match.group(1), match.group(2) == "?"))
+        pos = end
+    if pos < len(template):
+        segments.append(template[pos:])
+
+    if not segments or not any(isinstance(s, tuple) for s in segments):
+        return None
+    return tuple(segments)
+
+
+def _render_template(segments: tuple, state: Any, *, raise_on_missing: bool = True) -> str:
+    """Render a pre-compiled template against ``state``.
+
+    ``state`` is any mapping-like with ``.get(key)``. If a required
+    placeholder is missing:
+    * ``raise_on_missing=True`` (template provider) → raises ``KeyError``
+    * ``raise_on_missing=False`` (instruction provider) → leaves the
+      literal ``{key}`` in place, matching the legacy re.sub behaviour.
+    """
+    out: list[str] = []
+    for seg in segments:
+        if isinstance(seg, str):
+            out.append(seg)
+            continue
+        key, optional = seg
+        value = state.get(key)
+        if value is None:
+            if optional:
+                continue
+            if raise_on_missing:
+                raise KeyError(f"Template placeholder '{{{key}}}' not found in state")
+            out.append("{" + key + "}")
+            continue
+        out.append(str(value))
+    return "".join(out)
+
+
 def _format_events_as_context(events: list) -> str:
     """Format a list of ADK events as ``[author]: text`` lines."""
     lines: list[str] = []
@@ -118,23 +184,23 @@ def _make_template_provider(template: str) -> Callable:
     Supports:
     - {key}  — required placeholder, raises KeyError if missing
     - {key?} — optional placeholder, replaced with empty string if missing
+
+    The template is compiled once here into a flat tuple of segments, so
+    the per-turn cost is an O(segments) walk + one ``"".join`` — no regex
+    at runtime.
     """
+    segments = _compile_template(template)
+
+    if segments is None:
+        # No placeholders — return a closure that yields the static string.
+        async def _static_provider(ctx: Any) -> str:
+            return template
+
+        _static_provider.__name__ = "template_static"
+        return _static_provider
 
     async def _provider(ctx: Any) -> str:
-        state = ctx.state
-
-        def _replace(match: re.Match) -> str:
-            key = match.group(1)
-            optional = match.group(2) == "?"
-            value = state.get(key)
-            if value is None:
-                if optional:
-                    return ""
-                raise KeyError(f"Template placeholder '{{{key}}}' not found in state")
-            return str(value)
-
-        # Match {key} and {key?} patterns
-        return re.sub(r"\{(\w+)(\??)}", _replace, template)
+        return _render_template(segments, ctx.state, raise_on_missing=True)
 
     _provider.__name__ = "template"
     return _provider

--- a/python/src/adk_fluent/_context_providers.py
+++ b/python/src/adk_fluent/_context_providers.py
@@ -18,6 +18,8 @@ import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+from adk_fluent._session_index import get_session_index
+
 if TYPE_CHECKING:
     from adk_fluent._context import CTransform
 
@@ -65,22 +67,10 @@ def _make_window_provider(n: int) -> Callable:
     """Create an async provider that includes the last N turn-pairs."""
 
     async def _provider(ctx: Any) -> str:
-        events = list(ctx.session.events)
-        # A turn-pair is a user message + the model response(s) after it.
-        # Walk backwards to find the last N user messages.
-        user_indices: list[int] = []
-        for i, event in enumerate(events):
-            if getattr(event, "author", None) == "user":
-                user_indices.append(i)
-
-        # Take the last N turn-pair start indices
-        start_indices = user_indices[-n:] if len(user_indices) >= n else user_indices
-        if not start_indices:
+        idx = get_session_index(ctx.session)
+        window_events = idx.window_tail(n)
+        if not window_events:
             return ""
-
-        # Include everything from the earliest selected user message onward
-        window_start = start_indices[0]
-        window_events = events[window_start:]
         return _format_events_as_context(window_events)
 
     _provider.__name__ = f"window_{n}"
@@ -91,9 +81,8 @@ def _make_user_only_provider() -> Callable:
     """Create an async provider that includes only user messages."""
 
     async def _provider(ctx: Any) -> str:
-        events = list(ctx.session.events)
-        user_events = [e for e in events if getattr(e, "author", None) == "user"]
-        return _format_events_as_context(user_events)
+        idx = get_session_index(ctx.session)
+        return _format_events_as_context(idx.user_events())
 
     _provider.__name__ = "user_only"
     return _provider
@@ -101,14 +90,11 @@ def _make_user_only_provider() -> Callable:
 
 def _make_from_agents_provider(agent_names: tuple[str, ...]) -> Callable:
     """Create an async provider including user + named agent outputs."""
-    names_set = set(agent_names)
+    names_set = set(agent_names) | {"user"}
 
     async def _provider(ctx: Any) -> str:
-        events = list(ctx.session.events)
-        filtered = [
-            e for e in events if getattr(e, "author", None) == "user" or getattr(e, "author", None) in names_set
-        ]
-        return _format_events_as_context(filtered)
+        idx = get_session_index(ctx.session)
+        return _format_events_as_context(idx.events_by_authors(names_set))
 
     _provider.__name__ = f"from_agents_{'_'.join(agent_names)}"
     return _provider
@@ -119,9 +105,8 @@ def _make_exclude_agents_provider(agent_names: tuple[str, ...]) -> Callable:
     names_set = set(agent_names)
 
     async def _provider(ctx: Any) -> str:
-        events = list(ctx.session.events)
-        filtered = [e for e in events if getattr(e, "author", None) not in names_set]
-        return _format_events_as_context(filtered)
+        idx = get_session_index(ctx.session)
+        return _format_events_as_context(idx.events_excluding_authors(names_set))
 
     _provider.__name__ = f"exclude_agents_{'_'.join(agent_names)}"
     return _provider

--- a/python/src/adk_fluent/_eval.py
+++ b/python/src/adk_fluent/_eval.py
@@ -152,7 +152,7 @@ class EComposite(Composite, kind="eval"):
 # ======================================================================
 
 
-@dataclass
+@dataclass(slots=True)
 class ECase:
     """A single evaluation case. Maps to ADK's ``EvalCase``.
 
@@ -245,7 +245,7 @@ class ECase:
 # ======================================================================
 
 
-@dataclass
+@dataclass(slots=True)
 class EvalReport:
     """Result of running an evaluation suite.
 
@@ -287,7 +287,7 @@ class EvalReport:
 # ======================================================================
 
 
-@dataclass
+@dataclass(slots=True)
 class ComparisonReport:
     """Result of comparing multiple agents on the same eval cases."""
 
@@ -1271,15 +1271,19 @@ async def _run_eval_suite(suite: EvalSuite) -> EvalReport:
                     num_runs=suite._num_runs,
                     print_detailed_results=False,
                 )
-                # If no assertion error, all passed
-                scores = {c.metric_name: 1.0 for c in suite._criteria._items}
-                thresholds = {c.metric_name: c.threshold for c in suite._criteria._items}
-                passed = {c.metric_name: True for c in suite._criteria._items}
+                # If no assertion error, all passed — build scores/thresholds/passed in one pass
+                scores, thresholds, passed = {}, {}, {}
+                for c in suite._criteria._items:
+                    scores[c.metric_name] = 1.0
+                    thresholds[c.metric_name] = c.threshold
+                    passed[c.metric_name] = True
             except AssertionError as exc:
-                # Parse failure details from the assertion message
-                scores = {c.metric_name: 0.0 for c in suite._criteria._items}
-                thresholds = {c.metric_name: c.threshold for c in suite._criteria._items}
-                passed = {c.metric_name: False for c in suite._criteria._items}
+                # Parse failure details from the assertion message — single pass
+                scores, thresholds, passed = {}, {}, {}
+                for c in suite._criteria._items:
+                    scores[c.metric_name] = 0.0
+                    thresholds[c.metric_name] = c.threshold
+                    passed[c.metric_name] = False
                 # Store raw error for debugging
                 return EvalReport(
                     scores=scores,
@@ -1317,9 +1321,10 @@ def _resolve_gate_text(state: dict[str, Any], output_key: str | None) -> str | N
         val = state["_last_output"]
         return str(val) if val is not None else None
 
-    # Scan for the most recently written non-internal string value
-    for key in reversed(list(state)):
-        if key.startswith("_") or key.startswith("temp:") or key.startswith("app:"):
+    # Scan for the most recently written non-internal string value.
+    # dict is insertion-ordered; reversed() works directly since 3.8, no list() copy.
+    for key in reversed(state):
+        if key.startswith(("_", "temp:", "app:")):
             continue
         val = state[key]
         if isinstance(val, str) and len(val) > 0:

--- a/python/src/adk_fluent/_guards.py
+++ b/python/src/adk_fluent/_guards.py
@@ -36,7 +36,7 @@ __all__ = [
 # ── Data types and protocols ──────────────────────────────────────────
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class PIIFinding:
     """A single PII detection result."""
 
@@ -54,7 +54,7 @@ class PIIDetector(Protocol):
     async def detect(self, text: str) -> list[PIIFinding]: ...
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class JudgmentResult:
     """Result from a content judgment provider."""
 

--- a/python/src/adk_fluent/_harness/_tape.py
+++ b/python/src/adk_fluent/_harness/_tape.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import json
 import time
-from dataclasses import asdict
+from collections import deque
 from pathlib import Path
 from typing import Any
 
@@ -40,8 +40,13 @@ class SessionTape:
     """
 
     def __init__(self, *, max_events: int = 0) -> None:
-        self._events: list[dict[str, Any]] = []
         self._max_events = max_events
+        # Use a bounded deque when capping — O(1) append with automatic
+        # eviction of the oldest entry, versus an O(n) list slice on every
+        # overflow.
+        self._events: deque[dict[str, Any]] = deque(
+            maxlen=max_events if max_events > 0 else None
+        )
         self._start_time = time.monotonic()
 
     def record(self, event: HarnessEvent) -> None:
@@ -50,15 +55,21 @@ class SessionTape:
         Args:
             event: HarnessEvent to record.
         """
-        entry = {
+        # Hand-roll the entry instead of ``dataclasses.asdict``. ``asdict``
+        # performs a recursive deepcopy of every field which dominates hot
+        # paths where tens of thousands of events flow through the tape.
+        # All HarnessEvent subclasses are slotted frozen dataclasses, so we
+        # iterate __dataclass_fields__ and shallow-copy by reference.
+        entry: dict[str, Any] = {
             "t": round(time.monotonic() - self._start_time, 3),
             "kind": event.kind,
             "type": type(event).__name__,
-            **{k: v for k, v in asdict(event).items() if k != "kind"},
         }
+        for field_name in type(event).__dataclass_fields__:  # type: ignore[attr-defined]
+            if field_name == "kind":
+                continue
+            entry[field_name] = getattr(event, field_name)
         self._events.append(entry)
-        if self._max_events > 0 and len(self._events) > self._max_events:
-            self._events = self._events[-self._max_events :]
 
     @property
     def events(self) -> list[dict[str, Any]]:
@@ -100,9 +111,11 @@ class SessionTape:
         """
         p = Path(path)
         p.parent.mkdir(parents=True, exist_ok=True)
+        # Serialize all entries up-front and issue a single write — one
+        # syscall instead of one per event.
+        payload = "".join(json.dumps(entry) + "\n" for entry in self._events)
         with p.open("w") as f:
-            for entry in self._events:
-                f.write(json.dumps(entry) + "\n")
+            f.write(payload)
 
     @classmethod
     def load(cls, path: str | Path) -> SessionTape:

--- a/python/src/adk_fluent/_harness/_tape.py
+++ b/python/src/adk_fluent/_harness/_tape.py
@@ -44,9 +44,7 @@ class SessionTape:
         # Use a bounded deque when capping — O(1) append with automatic
         # eviction of the oldest entry, versus an O(n) list slice on every
         # overflow.
-        self._events: deque[dict[str, Any]] = deque(
-            maxlen=max_events if max_events > 0 else None
-        )
+        self._events: deque[dict[str, Any]] = deque(maxlen=max_events if max_events > 0 else None)
         self._start_time = time.monotonic()
 
     def record(self, event: HarnessEvent) -> None:

--- a/python/src/adk_fluent/_helpers.py
+++ b/python/src/adk_fluent/_helpers.py
@@ -360,11 +360,13 @@ def _debug_log(agent_name: str, msg: str):
 
 
 def deep_clone_builder(builder: Any, new_name: str) -> Any:
-    """Deep-copy a builder's internal state and set a new name."""
-    new_builder = object.__new__(type(builder))
-    new_builder._config = copy.deepcopy(builder._config)
-    new_builder._callbacks = copy.deepcopy(builder._callbacks)
-    new_builder._lists = copy.deepcopy(builder._lists)
+    """Deep-copy a builder's internal state and set a new name.
+
+    Delegates to ``BuilderBase.__deepcopy__`` which walks ``_config``,
+    ``_callbacks`` and ``_lists`` under a single shared memo so sub-builders
+    referenced from multiple fields are deduplicated.
+    """
+    new_builder = copy.deepcopy(builder)
     new_builder._config["name"] = new_name
     return new_builder
 

--- a/python/src/adk_fluent/_ir.py
+++ b/python/src/adk_fluent/_ir.py
@@ -48,7 +48,7 @@ __all__ = [
 # ======================================================================
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class TransformNode:
     """Zero-cost state transform. No LLM call."""
 
@@ -60,7 +60,7 @@ class TransformNode:
     reads_keys: frozenset[str] | None = None  # keys this transform reads (None = opaque/full state)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class TapNode:
     """Zero-cost observation. No LLM call, no state mutation."""
 
@@ -68,7 +68,7 @@ class TapNode:
     fn: Callable
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class FallbackNode:
     """Try children in order. First success wins."""
 
@@ -76,7 +76,7 @@ class FallbackNode:
     children: tuple = ()
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class RaceNode:
     """Run children concurrently. First to finish wins."""
 
@@ -84,7 +84,7 @@ class RaceNode:
     children: tuple = ()
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class GateNode:
     """Human-in-the-loop approval gate."""
 
@@ -94,7 +94,7 @@ class GateNode:
     gate_key: str = "_gate_approved"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class MapOverNode:
     """Iterate a sub-agent over each item in a state list."""
 
@@ -105,7 +105,7 @@ class MapOverNode:
     output_key: str = "results"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class TimeoutNode:
     """Wrap a sub-agent with a time limit."""
 
@@ -114,7 +114,7 @@ class TimeoutNode:
     seconds: float = 0.0
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class RouteNode:
     """Deterministic state-based routing. No LLM call."""
 
@@ -124,7 +124,7 @@ class RouteNode:
     default: Any = None
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class TransferNode:
     """Hard agent transfer (ADK's transfer_to_agent)."""
 
@@ -133,7 +133,7 @@ class TransferNode:
     condition: Callable | None = None
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CaptureNode:
     """Capture the most recent user message into session state."""
 
@@ -141,7 +141,7 @@ class CaptureNode:
     key: str
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ArtifactNode:
     """Artifact operation in the IR."""
 
@@ -160,7 +160,7 @@ class ArtifactNode:
     consumes_state: frozenset[str]
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class DispatchNode:
     """Fire-and-continue background execution.
 
@@ -175,7 +175,7 @@ class DispatchNode:
     progress_key: str | None = None
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class JoinNode:
     """Synchronization barrier for dispatched tasks.
 
@@ -188,7 +188,7 @@ class JoinNode:
     timeout: float | None = None
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class WatchNode:
     """Reactive state trigger.
 
@@ -201,7 +201,7 @@ class WatchNode:
     trigger: str = "change"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class UINode:
     """A2UI surface attached to an agent.
 
@@ -223,7 +223,7 @@ class UINode:
 # ======================================================================
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class CompactionConfig:
     """Event compaction settings (maps to ADK EventsCompactionConfig)."""
 
@@ -233,7 +233,7 @@ class CompactionConfig:
     event_retention_size: int | None = None
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ExecutionConfig:
     """Top-level execution configuration."""
 
@@ -252,7 +252,7 @@ class ExecutionConfig:
 # ======================================================================
 
 
-@dataclass
+@dataclass(slots=True)
 class ToolCallInfo:
     """A tool invocation within an event."""
 
@@ -261,7 +261,7 @@ class ToolCallInfo:
     call_id: str
 
 
-@dataclass
+@dataclass(slots=True)
 class ToolResponseInfo:
     """A tool response within an event."""
 
@@ -270,7 +270,7 @@ class ToolResponseInfo:
     call_id: str
 
 
-@dataclass
+@dataclass(slots=True)
 class AgentEvent:
     """Backend-agnostic representation of an execution event."""
 

--- a/python/src/adk_fluent/_ir_generated.py
+++ b/python/src/adk_fluent/_ir_generated.py
@@ -33,7 +33,7 @@ __all__ = [
 ]
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class AgentNode:
     """Generated IR node for ADK LlmAgent.
 
@@ -74,7 +74,7 @@ class AgentNode:
     guard_specs: tuple = ()  # GGuard specs, preserved for contract checking
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class SequenceNode:
     """Generated IR node for ADK SequentialAgent.
 
@@ -96,7 +96,7 @@ class SequenceNode:
     middlewares: tuple = ()  # Middleware instances for contract checking (Pass 14)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ParallelNode:
     """Generated IR node for ADK ParallelAgent.
 
@@ -117,7 +117,7 @@ class ParallelNode:
     context_spec: Any = None  # CTransform descriptor, preserved for diagnostics
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class LoopNode:
     """Generated IR node for ADK LoopAgent.
 

--- a/python/src/adk_fluent/_prompt.py
+++ b/python/src/adk_fluent/_prompt.py
@@ -96,7 +96,7 @@ _SECTION_ORDER_MAP["ui_schema"] = 250  # Between context (200) and task (300)
 # ======================================================================
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class PTransform:
     """Base prompt transform descriptor.
 
@@ -160,7 +160,7 @@ class PTransform:
 # ======================================================================
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class PComposite(PTransform):
     """Union of multiple prompt blocks (via + operator).
 
@@ -179,7 +179,7 @@ class PComposite(PTransform):
         return f"PComposite({', '.join(kinds)})"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class PPipe(PTransform):
     """Pipe transform: source feeds into transform (via | operator).
 
@@ -201,7 +201,7 @@ class PPipe(PTransform):
 # ======================================================================
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class PRole(PTransform):
     """Role/persona definition. Rendered without a section header."""
 
@@ -212,7 +212,7 @@ class PRole(PTransform):
         return f"PRole({self.content[:40]!r})"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class PContext(PTransform):
     """Background context section."""
 
@@ -223,7 +223,7 @@ class PContext(PTransform):
         return f"PContext({self.content[:40]!r})"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class PTask(PTransform):
     """Primary task/objective section."""
 
@@ -234,7 +234,7 @@ class PTask(PTransform):
         return f"PTask({self.content[:40]!r})"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class PConstraint(PTransform):
     """Rule/constraint section. Multiple constraints merge into one section."""
 
@@ -245,7 +245,7 @@ class PConstraint(PTransform):
         return f"PConstraint({self.content[:40]!r})"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class PFormat(PTransform):
     """Output format specification section."""
 
@@ -256,7 +256,7 @@ class PFormat(PTransform):
         return f"PFormat({self.content[:40]!r})"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class PExample(PTransform):
     """Few-shot example section. Supports freeform text or structured input/output.
 
@@ -289,7 +289,7 @@ class PExample(PTransform):
         return f"PExample({self.content[:40]!r})"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class PSection(PTransform):
     """Custom named section."""
 
@@ -306,7 +306,7 @@ class PSection(PTransform):
 # ======================================================================
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class PWhen(PTransform):
     """Conditional section inclusion.
 
@@ -325,7 +325,7 @@ class PWhen(PTransform):
         return f"PWhen({pred!r}, {blk})"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class PFromState(PTransform):
     """Read named keys from session state and format as context sections.
 
@@ -343,7 +343,7 @@ class PFromState(PTransform):
         return f"PFromState({', '.join(self.keys)})"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class PTemplate(PTransform):
     """Template string with {key}, {key?}, and {ns:key} placeholders.
 
@@ -368,7 +368,7 @@ class PTemplate(PTransform):
 # ======================================================================
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class PReorder(PTransform):
     """Override default section ordering.
 
@@ -383,7 +383,7 @@ class PReorder(PTransform):
         return f"PReorder({', '.join(self.order)})"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class POnly(PTransform):
     """Keep only the named sections (projection). Remove all others."""
 
@@ -394,7 +394,7 @@ class POnly(PTransform):
         return f"POnly({', '.join(self.names)})"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class PWithout(PTransform):
     """Remove the named sections. Keep all others."""
 
@@ -410,7 +410,7 @@ class PWithout(PTransform):
 # ======================================================================
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class PCompress(PTransform):
     """LLM-powered prompt compression.
 
@@ -426,7 +426,7 @@ class PCompress(PTransform):
         return f"PCompress(max_tokens={self.max_tokens})"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class PAdapt(PTransform):
     """LLM-powered audience adaptation.
 
@@ -446,7 +446,7 @@ class PAdapt(PTransform):
 # ======================================================================
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class PScaffolded(PTransform):
     """Defensive prompt scaffolding.
 
@@ -464,7 +464,7 @@ class PScaffolded(PTransform):
         return f"PScaffolded({blk})"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class PVersioned(PTransform):
     """Versioned prompt with tag and fingerprint metadata.
 

--- a/python/src/adk_fluent/_schema_base.py
+++ b/python/src/adk_fluent/_schema_base.py
@@ -30,7 +30,7 @@ __all__ = [
 _VALID_SCOPES = frozenset({"session", "app", "user", "temp"})
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class Reads:
     """Field is read from state before execution."""
 
@@ -41,7 +41,7 @@ class Reads:
             raise ValueError(f"Invalid scope '{self.scope}'. Must be one of: {', '.join(sorted(_VALID_SCOPES))}")
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class Writes:
     """Field is written to state after execution."""
 
@@ -52,21 +52,21 @@ class Writes:
             raise ValueError(f"Invalid scope '{self.scope}'. Must be one of: {', '.join(sorted(_VALID_SCOPES))}")
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class Param:
     """Field is a tool/function parameter (not from state)."""
 
     required: bool = True
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class Confirms:
     """Tool requires user confirmation before execution."""
 
     message: str = ""
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class Timeout:
     """Execution timeout constraint."""
 

--- a/python/src/adk_fluent/_session_index.py
+++ b/python/src/adk_fluent/_session_index.py
@@ -1,0 +1,193 @@
+"""Cached session event index for context providers.
+
+Context providers (``_context_providers.py``) rebuild ``list(ctx.session.events)``
+and rescan it once per provider invocation. A compiled agent commonly has
+3–6 providers running per turn (e.g. ``C.none() + C.from_state('topic') +
+C.window(5)``), which means the event list is materialized and scanned
+several times on every LLM call for the same underlying session.
+
+This module caches a per-session ``SessionEventIndex`` in a
+``WeakKeyDictionary`` keyed by the ADK ``Session`` object. The index
+precomputes the data structures every hot provider needs:
+
+* ``events`` — materialized tuple of events (snapshot)
+* ``user_indices`` — positions of user messages, for turn-window logic
+* ``by_author`` — bucket per author, for author-filter providers
+* ``non_user_mask`` — cached indices of non-user events
+
+Rebuild is incremental: the index syncs against ``len(session.events)``
+and appends only the new events. Rewinds (shorter list) trigger a full
+reset.
+
+Callers should not hold on to the index across await points — it is
+only consistent with respect to the session state at the moment it
+was fetched. Obtain a fresh one per provider call::
+
+    idx = get_session_index(ctx.session)
+    user = idx.user_events()
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from weakref import WeakKeyDictionary
+
+__all__ = ["SessionEventIndex", "get_session_index"]
+
+
+# Per-session cache. Weak keys so entries drop when ADK releases the session.
+_INDEX_CACHE: WeakKeyDictionary[Any, "SessionEventIndex"] = WeakKeyDictionary()
+
+
+class SessionEventIndex:
+    """Incrementally maintained index over a session's event list.
+
+    All accessors return lists derived from a frozen snapshot of the
+    underlying session events taken at sync time. Callers treat the
+    returned lists as read-only.
+    """
+
+    __slots__ = (
+        "_events",
+        "_len",
+        "_by_author",
+        "_user_indices",
+        "_non_user_indices",
+    )
+
+    def __init__(self) -> None:
+        self._events: list[Any] = []
+        self._len: int = 0
+        # Author values are stored as-is (including None) to preserve the
+        # exact semantics of ``getattr(event, "author", None) in names_set``.
+        self._by_author: dict[Any, list[int]] = {}
+        self._user_indices: list[int] = []
+        self._non_user_indices: list[int] = []
+
+    # ------------------------------------------------------------------
+    # Sync
+    # ------------------------------------------------------------------
+
+    def _sync(self, session: Any) -> None:
+        """Bring the index up to date with the session's current events."""
+        raw = getattr(session, "events", None)
+        if raw is None:
+            self._reset()
+            return
+
+        # Materialize once — session.events may be a list, tuple, or
+        # generator-backed sequence. We iterate once, then cache.
+        if isinstance(raw, list):
+            current_len = len(raw)
+            events_ref = raw  # list is stable across indexing
+        else:
+            try:
+                current_len = len(raw)
+                events_ref = raw
+            except TypeError:
+                materialized = list(raw)
+                events_ref = materialized
+                current_len = len(materialized)
+
+        if current_len == self._len:
+            return  # hot path: cache still valid
+
+        if current_len < self._len:
+            # Session was rewound or replaced — full rebuild.
+            self._reset()
+
+        # Append any new events to the index.
+        for i in range(self._len, current_len):
+            ev = events_ref[i]
+            author = getattr(ev, "author", None)
+            bucket = self._by_author.get(author)
+            if bucket is None:
+                bucket = []
+                self._by_author[author] = bucket
+            bucket.append(i)
+            if author == "user":
+                self._user_indices.append(i)
+            else:
+                self._non_user_indices.append(i)
+
+        # Snapshot the events list. We always materialize a fresh list
+        # so callers can treat ``self._events`` as immutable for the
+        # lifetime of their provider call.
+        if isinstance(events_ref, list):
+            self._events = events_ref[:current_len]
+        else:
+            self._events = list(events_ref[:current_len])
+        self._len = current_len
+
+    def _reset(self) -> None:
+        self._events = []
+        self._len = 0
+        self._by_author.clear()
+        self._user_indices.clear()
+        self._non_user_indices.clear()
+
+    # ------------------------------------------------------------------
+    # Accessors
+    # ------------------------------------------------------------------
+
+    @property
+    def events(self) -> list[Any]:
+        """Materialized event snapshot (treat as read-only)."""
+        return self._events
+
+    def user_events(self) -> list[Any]:
+        """Return events authored by ``user``."""
+        evs = self._events
+        return [evs[i] for i in self._user_indices]
+
+    def events_by_authors(self, authors: set[str]) -> list[Any]:
+        """Return events whose author is in ``authors``."""
+        evs = self._events
+        if not authors:
+            return []
+        # Walk precomputed buckets instead of rescanning the event list.
+        # Collect indices, then sort for stable order, then map to events.
+        indices: list[int] = []
+        for a in authors:
+            bucket = self._by_author.get(a)
+            if bucket:
+                indices.extend(bucket)
+        indices.sort()
+        return [evs[i] for i in indices]
+
+    def events_excluding_authors(self, authors: set[Any]) -> list[Any]:
+        """Return events whose author is NOT in ``authors``."""
+        if not authors:
+            return list(self._events)
+        evs = self._events
+        return [e for e in evs if getattr(e, "author", None) not in authors]
+
+    def window_tail(self, n: int) -> list[Any]:
+        """Return the slice of events from the start of the last N user turns."""
+        if not self._user_indices:
+            return []
+        user_idxs = self._user_indices
+        if len(user_idxs) <= n:
+            start = user_idxs[0]
+        else:
+            start = user_idxs[-n]
+        return self._events[start:]
+
+
+def get_session_index(session: Any) -> SessionEventIndex:
+    """Return a sync'd ``SessionEventIndex`` for ``session``.
+
+    Creates and caches the index on first use. Weakly referenced so the
+    cache never pins a session beyond ADK's own lifetime.
+    """
+    idx = _INDEX_CACHE.get(session)
+    if idx is None:
+        idx = SessionEventIndex()
+        try:
+            _INDEX_CACHE[session] = idx
+        except TypeError:
+            # Session not weakref-able (e.g. a test stub) — fall back to
+            # a throwaway index. Still saves the work within this call.
+            pass
+    idx._sync(session)
+    return idx

--- a/python/src/adk_fluent/_session_index.py
+++ b/python/src/adk_fluent/_session_index.py
@@ -29,6 +29,7 @@ was fetched. Obtain a fresh one per provider call::
 
 from __future__ import annotations
 
+import contextlib
 from typing import Any
 from weakref import WeakKeyDictionary
 
@@ -36,7 +37,7 @@ __all__ = ["SessionEventIndex", "get_session_index"]
 
 
 # Per-session cache. Weak keys so entries drop when ADK releases the session.
-_INDEX_CACHE: WeakKeyDictionary[Any, "SessionEventIndex"] = WeakKeyDictionary()
+_INDEX_CACHE: WeakKeyDictionary[Any, SessionEventIndex] = WeakKeyDictionary()
 
 
 class SessionEventIndex:
@@ -183,11 +184,9 @@ def get_session_index(session: Any) -> SessionEventIndex:
     idx = _INDEX_CACHE.get(session)
     if idx is None:
         idx = SessionEventIndex()
-        try:
+        # Session not weakref-able (e.g. a test stub) — fall back to
+        # a throwaway index. Still saves the work within this call.
+        with contextlib.suppress(TypeError):
             _INDEX_CACHE[session] = idx
-        except TypeError:
-            # Session not weakref-able (e.g. a test stub) — fall back to
-            # a throwaway index. Still saves the work within this call.
-            pass
     idx._sync(session)
     return idx

--- a/python/src/adk_fluent/_transforms.py
+++ b/python/src/adk_fluent/_transforms.py
@@ -104,19 +104,34 @@ def _merge_keysets(a: frozenset[str] | None, b: frozenset[str] | None) -> frozen
 
 
 def _apply_result(state: dict[str, Any], result: StateDelta | StateReplacement | dict | None) -> dict[str, Any]:
-    """Apply a transform result to a state dict, returning a new dict."""
-    out = dict(state)
+    """Apply a transform result to a state dict, returning a new dict.
+
+    Fast paths:
+    * ``result is None``  → return ``state`` unchanged. STransform functions
+      are documented as non-mutating, and the chain/call sites read the
+      returned dict without mutating it. Skipping the copy halves the
+      allocation cost of no-op steps like ``S.log`` or ``S.guard``.
+    * ``StateReplacement`` → build the result dict directly from scoped
+      keys + new_state, instead of copying the entire state first and
+      then discarding most of it.
+    """
     if result is None:
-        return out
+        return state
     if isinstance(result, StateDelta):
+        out = dict(state)
         out.update(result.updates)
-    elif isinstance(result, StateReplacement):
-        # Keep scoped keys, replace session-scoped
-        scoped = {k: v for k, v in out.items() if k.startswith(_SCOPE_PREFIXES)}
-        out = {**scoped, **result.new_state}
-    elif isinstance(result, dict):
+        return out
+    if isinstance(result, StateReplacement):
+        # Keep scoped (app:/user:/temp:) keys from the original state,
+        # drop every other key, then overlay the replacement.
+        out = {k: v for k, v in state.items() if k.startswith(_SCOPE_PREFIXES)}
+        out.update(result.new_state)
+        return out
+    if isinstance(result, dict):
+        out = dict(state)
         out.update(result)
-    return out
+        return out
+    return dict(state)
 
 
 class STransform:
@@ -143,6 +158,15 @@ class STransform:
         pipeline = S.capture("input") >> Agent("writer")
     """
 
+    __slots__ = (
+        "_fn",
+        "_reads_keys",
+        "_writes_keys",
+        "_capture_key",
+        "__name__",
+        "_chain_fns",
+    )
+
     def __init__(
         self,
         fn: Callable,
@@ -158,6 +182,10 @@ class STransform:
         self._capture_key = capture_key
         # __name__ used by _fn_step and debugging
         self.__name__ = name
+        # _chain_fns is populated by _chain_transforms when this STransform
+        # represents a flattened chain of leaf transforms. None means a
+        # single leaf (the common case).
+        self._chain_fns: tuple[Callable, ...] | None = None
 
     # ------------------------------------------------------------------
     # NamespaceSpec protocol
@@ -247,22 +275,48 @@ class STransform:
 
 
 def _chain_transforms(first: STransform, second: STransform) -> STransform:
-    """Chain two transforms sequentially.
+    """Chain two transforms sequentially, flattening nested chains.
 
-    First runs on original state, result applied, then second runs on
-    the updated state. Combined metadata is the union of both.
+    Each N-step chain used to be N-1 nested closures. We now collect a
+    flat tuple of leaf callables and execute them in a single loop, so a
+    chain of N transforms pays one Python call per step instead of N-1
+    levels of nested ``_chained`` invocations. Intermediate ``None``
+    results short-circuit the state copy in ``_apply_result``.
     """
+    # Collect leaf callables from both sides, flattening any existing
+    # flat chains.
+    first_fns = first._chain_fns
+    second_fns = second._chain_fns
+    if first_fns is None:
+        if second_fns is None:
+            fns = (first._fn, second._fn)
+        else:
+            fns = (first._fn, *second_fns)
+    else:
+        if second_fns is None:
+            fns = (*first_fns, second._fn)
+        else:
+            fns = (*first_fns, *second_fns)
+
+    # Materialize the tail split once to avoid tuple slicing per call.
+    head = fns[:-1]
+    tail = fns[-1]
 
     def _chained(state: dict) -> StateDelta | StateReplacement:
-        result1 = first(state)
-        intermediate = _apply_result(state, result1)
-        return second(intermediate)
+        cur = state
+        for fn in head:
+            result = fn(cur)
+            if result is not None:
+                cur = _apply_result(cur, result)
+        return tail(cur)
 
     reads = _merge_keysets(first._reads_keys, second._reads_keys)
     writes = _merge_keysets(first._writes_keys, second._writes_keys)
     name = f"{first.__name__}_then_{second.__name__}"
 
-    return STransform(_chained, reads=reads, writes=writes, name=name)
+    chained = STransform(_chained, reads=reads, writes=writes, name=name)
+    chained._chain_fns = fns
+    return chained
 
 
 def _combine_transforms(first: STransform, second: STransform) -> STransform:

--- a/python/src/adk_fluent/_ui.py
+++ b/python/src/adk_fluent/_ui.py
@@ -147,7 +147,7 @@ class _UIGroup(UIComponent):
         return self._children
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class UISurface:
     """Named A2UI surface — the top-level compilation root.
 

--- a/python/src/adk_fluent/middleware.py
+++ b/python/src/adk_fluent/middleware.py
@@ -586,28 +586,49 @@ class _MiddlewarePlugin(BasePlugin):
     def __init__(self, name: str, stack: list) -> None:
         super().__init__(name=name)
         self._stack = list(stack)
-        # Precompute hook dispatch table: hook_name -> [(mw, bound_fn, is_scoped), ...]
+        # Precompute hook dispatch table:
+        #   hook_name -> (global_entries, scoped_entries)
+        # where each entry is ``(mw, bound_fn)``.
         #
-        # This eliminates per-call `getattr(mw, method_name, None)` lookups, which on
-        # hot paths (before_model/after_model/before_tool per-turn) dominate middleware
-        # dispatch cost. The table is built once at plugin-construction time; hooks not
-        # implemented by any middleware become a single dict.get() miss at dispatch.
+        # This eliminates per-call ``getattr(mw, method_name, None)`` lookups,
+        # which on hot paths (before_model/after_model/before_tool per turn)
+        # dominate middleware dispatch cost. The table is built once at
+        # plugin-construction time; hooks not implemented by any middleware
+        # become a single ``dict.get()`` miss at dispatch.
         #
-        # Also resolves `_ConditionalMiddleware.__getattr__` eagerly — it creates a new
-        # `_guarded` closure on every access, so caching the resolved bound fn is itself
-        # a secondary win on conditional middleware.
-        hook_table: dict[str, tuple[tuple[Any, Callable, bool], ...]] = {}
+        # Wave 4c: partition each hook into (global, scoped) buckets at init
+        # so the hot runtime loop can skip the ``_agent_matches`` filter for
+        # global middlewares — the common case. Scoped middlewares live in
+        # their own tuple and only run through the filter when present.
+        #
+        # Also resolves ``_ConditionalMiddleware.__getattr__`` eagerly — it
+        # creates a new ``_guarded`` closure on every access, so caching the
+        # resolved bound fn is itself a secondary win on conditional
+        # middleware.
+        hook_table: dict[
+            str,
+            tuple[tuple[tuple[Any, Callable], ...], tuple[tuple[Any, Callable], ...]],
+        ] = {}
         for method_name in self._ALL_HOOK_NAMES:
-            is_scoped = method_name in _SCOPED_HOOKS
-            entries: list[tuple[Any, Callable, bool]] = []
+            is_scoped_hook = method_name in _SCOPED_HOOKS
+            global_entries: list[tuple[Any, Callable]] = []
+            scoped_entries: list[tuple[Any, Callable]] = []
             for mw in self._stack:
                 fn = getattr(mw, method_name, None)
                 if fn is None:
                     continue
-                entries.append((mw, fn, is_scoped))
-            if entries:
-                hook_table[method_name] = tuple(entries)
-        self._hook_table: dict[str, tuple[tuple[Any, Callable, bool], ...]] = hook_table
+                # Only scoped-hook entries can land in the scoped bucket. An
+                # unscoped hook (e.g. on_start) always lives in ``global``.
+                if is_scoped_hook and getattr(mw, "agents", None) is not None:
+                    scoped_entries.append((mw, fn))
+                else:
+                    global_entries.append((mw, fn))
+            if global_entries or scoped_entries:
+                hook_table[method_name] = (tuple(global_entries), tuple(scoped_entries))
+        self._hook_table: dict[
+            str,
+            tuple[tuple[tuple[Any, Callable], ...], tuple[tuple[Any, Callable], ...]],
+        ] = hook_table
 
     # --- Helpers: iterate stack ---
 
@@ -627,13 +648,15 @@ class _MiddlewarePlugin(BasePlugin):
         Filters scoped hooks by agent_name.
 
         Uses the precomputed hook table — no per-call getattr probing.
+        Wave 4c: hook table is partitioned into ``(global, scoped)`` buckets
+        so the global bucket skips the ``_agent_matches`` filter entirely.
         """
-        entries = self._hook_table.get(method_name)
-        if not entries:
+        buckets = self._hook_table.get(method_name)
+        if buckets is None:
             return None
-        for mw, fn, is_scoped in entries:
-            if is_scoped and agent_name is not None and not _agent_matches(mw, agent_name):
-                continue
+        global_entries, scoped_entries = buckets
+        # Phase 1: global middlewares — no per-agent filter.
+        for mw, fn in global_entries:
             try:
                 result = await fn(*args)
                 if result is not None:
@@ -641,6 +664,18 @@ class _MiddlewarePlugin(BasePlugin):
             except Exception as exc:
                 _log.warning("Middleware %s.%s raised: %s", type(mw).__name__, method_name, exc)
                 await self._fire_middleware_error(mw, method_name, exc)
+        # Phase 2: scoped middlewares — apply agent filter.
+        if scoped_entries:
+            for mw, fn in scoped_entries:
+                if agent_name is not None and not _agent_matches(mw, agent_name):
+                    continue
+                try:
+                    result = await fn(*args)
+                    if result is not None:
+                        return result
+                except Exception as exc:
+                    _log.warning("Middleware %s.%s raised: %s", type(mw).__name__, method_name, exc)
+                    await self._fire_middleware_error(mw, method_name, exc)
         return None
 
     async def _run_stack_void(self, method_name: str, *args, agent_name: str | None = None) -> None:
@@ -648,18 +683,27 @@ class _MiddlewarePlugin(BasePlugin):
 
         Wraps each call in an error boundary.
         Uses the precomputed hook table — no per-call getattr probing.
+        Wave 4c: partitioned global/scoped buckets — see ``_run_stack``.
         """
-        entries = self._hook_table.get(method_name)
-        if not entries:
+        buckets = self._hook_table.get(method_name)
+        if buckets is None:
             return
-        for mw, fn, is_scoped in entries:
-            if is_scoped and agent_name is not None and not _agent_matches(mw, agent_name):
-                continue
+        global_entries, scoped_entries = buckets
+        for mw, fn in global_entries:
             try:
                 await fn(*args)
             except Exception as exc:
                 _log.warning("Middleware %s.%s raised: %s", type(mw).__name__, method_name, exc)
                 await self._fire_middleware_error(mw, method_name, exc)
+        if scoped_entries:
+            for mw, fn in scoped_entries:
+                if agent_name is not None and not _agent_matches(mw, agent_name):
+                    continue
+                try:
+                    await fn(*args)
+                except Exception as exc:
+                    _log.warning("Middleware %s.%s raised: %s", type(mw).__name__, method_name, exc)
+                    await self._fire_middleware_error(mw, method_name, exc)
 
     async def _fire_middleware_error(self, failed_mw: Any, hook_name: str, error: Exception) -> None:
         """Fire on_middleware_error on all *other* middleware.

--- a/python/src/adk_fluent/middleware.py
+++ b/python/src/adk_fluent/middleware.py
@@ -120,7 +120,7 @@ _trace_context: ContextVar[TraceContext | None] = ContextVar("_trace_context", d
 # ======================================================================
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class DispatchDirective:
     """Returned by ``on_dispatch`` to control dispatch behavior.
 
@@ -134,7 +134,7 @@ class DispatchDirective:
     inject_state: dict[str, Any] | None = None
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class LoopDirective:
     """Returned by ``on_loop_iteration`` to control loop behavior.
 
@@ -543,9 +543,71 @@ class _MiddlewarePlugin(BasePlugin):
         4. Topology hooks: set self as _topology_hooks ContextVar.
     """
 
+    # All hook names that _MiddlewarePlugin dispatches. Used at construction
+    # time to precompute a hook table, eliminating per-call getattr probing.
+    _ALL_HOOK_NAMES: tuple[str, ...] = (
+        # Runner lifecycle
+        "on_user_message",
+        "before_run",
+        "after_run",
+        "on_event",
+        # Agent lifecycle (scoped)
+        "before_agent",
+        "after_agent",
+        # Model lifecycle (scoped)
+        "before_model",
+        "after_model",
+        "on_model_error",
+        # Tool lifecycle (scoped)
+        "before_tool",
+        "after_tool",
+        "on_tool_error",
+        # Dispatch/Join
+        "on_dispatch",
+        "on_task_complete",
+        "on_task_error",
+        "on_join",
+        # Topology
+        "on_loop_iteration",
+        "on_fanout_start",
+        "on_fanout_complete",
+        "on_route_selected",
+        "on_fallback_attempt",
+        "on_timeout",
+        # Stream lifecycle
+        "on_stream_item",
+        "on_stream_start",
+        "on_stream_end",
+        "on_backpressure",
+        # Cleanup
+        "close",
+    )
+
     def __init__(self, name: str, stack: list) -> None:
         super().__init__(name=name)
         self._stack = list(stack)
+        # Precompute hook dispatch table: hook_name -> [(mw, bound_fn, is_scoped), ...]
+        #
+        # This eliminates per-call `getattr(mw, method_name, None)` lookups, which on
+        # hot paths (before_model/after_model/before_tool per-turn) dominate middleware
+        # dispatch cost. The table is built once at plugin-construction time; hooks not
+        # implemented by any middleware become a single dict.get() miss at dispatch.
+        #
+        # Also resolves `_ConditionalMiddleware.__getattr__` eagerly — it creates a new
+        # `_guarded` closure on every access, so caching the resolved bound fn is itself
+        # a secondary win on conditional middleware.
+        hook_table: dict[str, tuple[tuple[Any, Callable, bool], ...]] = {}
+        for method_name in self._ALL_HOOK_NAMES:
+            is_scoped = method_name in _SCOPED_HOOKS
+            entries: list[tuple[Any, Callable, bool]] = []
+            for mw in self._stack:
+                fn = getattr(mw, method_name, None)
+                if fn is None:
+                    continue
+                entries.append((mw, fn, is_scoped))
+            if entries:
+                hook_table[method_name] = tuple(entries)
+        self._hook_table: dict[str, tuple[tuple[Any, Callable, bool], ...]] = hook_table
 
     # --- Helpers: iterate stack ---
 
@@ -563,13 +625,14 @@ class _MiddlewarePlugin(BasePlugin):
         Short-circuits on the first non-None return.
         Wraps each call in an error boundary.
         Filters scoped hooks by agent_name.
+
+        Uses the precomputed hook table — no per-call getattr probing.
         """
-        is_scoped = method_name in _SCOPED_HOOKS
-        for mw in self._stack:
+        entries = self._hook_table.get(method_name)
+        if not entries:
+            return None
+        for mw, fn, is_scoped in entries:
             if is_scoped and agent_name is not None and not _agent_matches(mw, agent_name):
-                continue
-            fn = getattr(mw, method_name, None)
-            if fn is None:
                 continue
             try:
                 result = await fn(*args)
@@ -584,13 +647,13 @@ class _MiddlewarePlugin(BasePlugin):
         """Call *method_name* on ALL middleware (no short-circuit).
 
         Wraps each call in an error boundary.
+        Uses the precomputed hook table — no per-call getattr probing.
         """
-        is_scoped = method_name in _SCOPED_HOOKS
-        for mw in self._stack:
+        entries = self._hook_table.get(method_name)
+        if not entries:
+            return
+        for mw, fn, is_scoped in entries:
             if is_scoped and agent_name is not None and not _agent_matches(mw, agent_name):
-                continue
-            fn = getattr(mw, method_name, None)
-            if fn is None:
                 continue
             try:
                 await fn(*args)

--- a/python/tests/bench/__init__.py
+++ b/python/tests/bench/__init__.py
@@ -1,0 +1,18 @@
+"""Stdlib-only microbenchmarks for adk-fluent hot paths.
+
+These benchmarks are intentionally dependency-free (no pytest-benchmark, no
+google-adk) so they can run in any environment and produce stable absolute
+numbers for before/after comparisons during performance work.
+
+Run a single bench::
+
+    python -m tests.bench.bench_tape_record
+
+Run all benches::
+
+    python -m tests.bench
+
+Each bench prints one line per measurement of the form::
+
+    <name>: <iterations> iters, <ns/op> ns/op, <MB> MB resident
+"""

--- a/python/tests/bench/__main__.py
+++ b/python/tests/bench/__main__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 def main() -> None:
     from tests.bench import (
+        bench_agent_build,
         bench_builder_clone,
         bench_context_providers,
         bench_eval_gate,
@@ -27,6 +28,8 @@ def main() -> None:
     bench_prompt_render.main()
     print()
     bench_eval_gate.main()
+    print()
+    bench_agent_build.main()
 
 
 if __name__ == "__main__":

--- a/python/tests/bench/__main__.py
+++ b/python/tests/bench/__main__.py
@@ -6,7 +6,10 @@ from __future__ import annotations
 def main() -> None:
     from tests.bench import (
         bench_builder_clone,
+        bench_context_providers,
+        bench_eval_gate,
         bench_middleware_stack,
+        bench_prompt_render,
         bench_state_chain,
         bench_tape_record,
     )
@@ -18,6 +21,12 @@ def main() -> None:
     bench_middleware_stack.main()
     print()
     bench_builder_clone.main()
+    print()
+    bench_context_providers.main()
+    print()
+    bench_prompt_render.main()
+    print()
+    bench_eval_gate.main()
 
 
 if __name__ == "__main__":

--- a/python/tests/bench/__main__.py
+++ b/python/tests/bench/__main__.py
@@ -1,0 +1,24 @@
+"""Run all microbenchmarks. Usage: python -m tests.bench"""
+
+from __future__ import annotations
+
+
+def main() -> None:
+    from tests.bench import (
+        bench_builder_clone,
+        bench_middleware_stack,
+        bench_state_chain,
+        bench_tape_record,
+    )
+
+    bench_tape_record.main()
+    print()
+    bench_state_chain.main()
+    print()
+    bench_middleware_stack.main()
+    print()
+    bench_builder_clone.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tests/bench/__main__.py
+++ b/python/tests/bench/__main__.py
@@ -7,7 +7,9 @@ def main() -> None:
     from tests.bench import (
         bench_agent_build,
         bench_builder_clone,
+        bench_callback_dispatch,
         bench_context_providers,
+        bench_context_runtime,
         bench_eval_gate,
         bench_middleware_stack,
         bench_prompt_render,
@@ -24,6 +26,10 @@ def main() -> None:
     bench_builder_clone.main()
     print()
     bench_context_providers.main()
+    print()
+    bench_context_runtime.main()
+    print()
+    bench_callback_dispatch.main()
     print()
     bench_prompt_render.main()
     print()

--- a/python/tests/bench/_common.py
+++ b/python/tests/bench/_common.py
@@ -62,9 +62,5 @@ def bench(
         gc.enable()
 
     ns_per_op = elapsed / iters
-    print(
-        f"{name:<48s} {iters:>10,} iters  "
-        f"{ns_per_op:>10.1f} ns/op  "
-        f"{_rss_mb():>7.1f} MB rss"
-    )
+    print(f"{name:<48s} {iters:>10,} iters  {ns_per_op:>10.1f} ns/op  {_rss_mb():>7.1f} MB rss")
     return ns_per_op

--- a/python/tests/bench/_common.py
+++ b/python/tests/bench/_common.py
@@ -1,0 +1,70 @@
+"""Shared microbench plumbing — stdlib only.
+
+Usage::
+
+    from tests.bench._common import bench
+
+    bench("my-thing", iters=100_000, fn=lambda: do_something())
+"""
+
+from __future__ import annotations
+
+import gc
+import resource
+import time
+from collections.abc import Callable
+from typing import Any
+
+__all__ = ["bench", "report_header"]
+
+
+def _rss_mb() -> float:
+    """Best-effort resident-set-size in MB (Linux: KB; macOS: bytes)."""
+    try:
+        usage = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    except Exception:
+        return 0.0
+    # Linux reports KB, macOS reports bytes. Normalize heuristically.
+    if usage > 10**8:  # > 100 MB in whatever units → probably bytes
+        return usage / (1024 * 1024)
+    return usage / 1024
+
+
+def report_header(title: str) -> None:
+    print("=" * 72)
+    print(title)
+    print("=" * 72)
+
+
+def bench(
+    name: str,
+    fn: Callable[[], Any],
+    *,
+    iters: int = 100_000,
+    warmup: int = 1_000,
+) -> float:
+    """Run ``fn`` ``iters`` times and print ns/op.
+
+    Returns ns/op for programmatic comparison. ``fn`` must be a nullary
+    callable; wrap closures accordingly.
+    """
+    for _ in range(warmup):
+        fn()
+
+    gc.collect()
+    gc.disable()
+    try:
+        start = time.perf_counter_ns()
+        for _ in range(iters):
+            fn()
+        elapsed = time.perf_counter_ns() - start
+    finally:
+        gc.enable()
+
+    ns_per_op = elapsed / iters
+    print(
+        f"{name:<48s} {iters:>10,} iters  "
+        f"{ns_per_op:>10.1f} ns/op  "
+        f"{_rss_mb():>7.1f} MB rss"
+    )
+    return ns_per_op

--- a/python/tests/bench/bench_agent_build.py
+++ b/python/tests/bench/bench_agent_build.py
@@ -16,7 +16,6 @@ suites and hot reloads rebuild agents on every assertion.
 from __future__ import annotations
 
 from adk_fluent import Agent, FanOut, Pipeline
-
 from tests.bench._common import bench, report_header
 
 

--- a/python/tests/bench/bench_agent_build.py
+++ b/python/tests/bench/bench_agent_build.py
@@ -1,0 +1,103 @@
+"""Benchmark: agent builder .build() cost.
+
+Every ``.build()`` walks the builder graph, copies the config, and
+constructs a native ADK agent. This bench captures:
+
+* Simple single-agent build cost
+* Pipeline build cost (N sequential steps)
+* FanOut build cost (N parallel branches)
+* Nested pipeline-of-fanouts build cost
+
+Numbers serve as a baseline for future improvements in the IR→ADK
+lowering pass. The goal is to make build() cheap enough that test
+suites and hot reloads rebuild agents on every assertion.
+"""
+
+from __future__ import annotations
+
+from adk_fluent import Agent, FanOut, Pipeline
+
+from tests.bench._common import bench, report_header
+
+
+def main() -> None:
+    report_header("Agent build benchmarks")
+
+    # Single agent.
+    def build_solo() -> object:
+        return Agent("solo", "gemini-2.5-flash").instruct("answer").build()
+
+    bench("build Agent[solo]", build_solo, iters=2_000)
+
+    # Pipeline of N agents.
+    for n in (2, 4, 8):
+
+        def build_pipeline(n: int = n) -> object:
+            p = Pipeline(f"p{n}")
+            for i in range(n):
+                p = p.step(Agent(f"s{i}", "gemini-2.5-flash").instruct(f"step {i}"))
+            return p.build()
+
+        bench(f"build Pipeline[{n}]", build_pipeline, iters=1_000)
+
+    # FanOut of N branches.
+    for n in (2, 4, 8):
+
+        def build_fanout(n: int = n) -> object:
+            f = FanOut(f"f{n}")
+            for i in range(n):
+                f = f.branch(Agent(f"b{i}", "gemini-2.5-flash").instruct(f"branch {i}"))
+            return f.build()
+
+        bench(f"build FanOut[{n}]", build_fanout, iters=1_000)
+
+    # Nested pipeline of fanouts — realistic workflow shape.
+    _counter = [0]
+
+    def build_nested() -> object:
+        def fan(tag: str) -> FanOut:
+            return (
+                FanOut(f"fan_{tag}")
+                .branch(Agent(f"a_{tag}", "gemini-2.5-flash").instruct("a"))
+                .branch(Agent(f"b_{tag}", "gemini-2.5-flash").instruct("b"))
+            )
+
+        _counter[0] += 1
+        tag = str(_counter[0])
+        return (
+            Pipeline(f"root_{tag}")
+            .step(Agent(f"intro_{tag}", "gemini-2.5-flash").instruct("intro"))
+            .step(fan(f"{tag}a"))
+            .step(fan(f"{tag}b"))
+            .step(Agent(f"outro_{tag}", "gemini-2.5-flash").instruct("outro"))
+            .build()
+        )
+
+    bench("build Pipeline[fan,fan] nested", build_nested, iters=500)
+
+    # Builder with tools + callbacks + context — common real-world weight.
+    def tool_fn(query: str) -> str:
+        return query.upper()
+
+    async def before_model(ctx, req) -> None:
+        pass
+
+    from adk_fluent import C, P
+
+    def build_loaded() -> object:
+        return (
+            Agent("loaded", "gemini-2.5-flash")
+            .instruct(P.role("assistant") + P.task("search") + P.format("json"))
+            .tool(tool_fn)
+            .tool(tool_fn)
+            .before_model(before_model)
+            .context(C.window(n=5))
+            .writes("result")
+            .build()
+        )
+
+    bench("build Agent[tools+cbs+ctx]", build_loaded, iters=1_000)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tests/bench/bench_builder_clone.py
+++ b/python/tests/bench/bench_builder_clone.py
@@ -1,0 +1,46 @@
+"""Benchmark: BuilderBase deep copy.
+
+Wave 1 replaced three independent ``copy.deepcopy`` calls inside
+``deep_clone_builder`` with a single ``__deepcopy__`` that walks
+``_config``, ``_callbacks`` and ``_lists`` under one shared memo. This
+bench measures a representative agent graph clone.
+"""
+
+from __future__ import annotations
+
+import copy
+
+from adk_fluent import Agent, FanOut, Pipeline
+
+from tests.bench._common import bench, report_header
+
+
+def _build_graph() -> Pipeline:
+    leaf_a = Agent("a", "gemini-2.5-flash").instruct("step a")
+    leaf_b = Agent("b", "gemini-2.5-flash").instruct("step b")
+    leaf_c = Agent("c", "gemini-2.5-flash").instruct("step c")
+    fan = FanOut("fan").branch(leaf_b).branch(leaf_c)
+    return Pipeline("pipe").step(leaf_a).step(fan)
+
+
+def main() -> None:
+    report_header("Builder deepcopy benchmarks")
+
+    graph = _build_graph()
+
+    bench(
+        "deepcopy(pipeline w/ fanout)",
+        lambda: copy.deepcopy(graph),
+        iters=2_000,
+    )
+
+    simple = Agent("solo", "gemini-2.5-flash").instruct("a").tool(lambda: None)
+    bench(
+        "deepcopy(Agent w/ 1 tool)",
+        lambda: copy.deepcopy(simple),
+        iters=5_000,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tests/bench/bench_builder_clone.py
+++ b/python/tests/bench/bench_builder_clone.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import copy
 
 from adk_fluent import Agent, FanOut, Pipeline
-
 from tests.bench._common import bench, report_header
 
 

--- a/python/tests/bench/bench_callback_dispatch.py
+++ b/python/tests/bench/bench_callback_dispatch.py
@@ -1,0 +1,83 @@
+"""Benchmark: composed callback dispatch hot path.
+
+Every ``.before_model(fn)`` / ``.after_model(fn)`` registration ends up
+in a list that ``_compose_callbacks`` folds into a single callable at
+build time. Wave 4b pre-classifies each entry as sync/async once,
+eliminating the per-turn ``asyncio.iscoroutine`` probe for every
+callback in the chain.
+
+Numbers below measure the dispatch cost of the composed closure *inside
+a running event loop* (one callback invocation per turn per hook). At
+3 hooks × 8 agents this path runs ~24 times per LLM round-trip.
+
+The ``_bench_async`` helper uses a single awaiting loop instead of
+``run_until_complete`` per call so the numbers reflect actual per-turn
+cost rather than loop setup/teardown overhead.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+import time
+from collections.abc import Callable
+
+from adk_fluent._base import _compose_callbacks
+from tests.bench._common import report_header
+
+
+def _sync_noop(*args, **kwargs) -> None:
+    return None
+
+
+async def _async_noop(*args, **kwargs) -> None:
+    return None
+
+
+async def _bench_async(name: str, awaitable_factory: Callable, *, iters: int) -> float:
+    """Time an async callable from inside an already-running loop."""
+    # Warmup
+    for _ in range(1_000):
+        await awaitable_factory()
+    gc.collect()
+    gc.disable()
+    try:
+        t0 = time.perf_counter_ns()
+        for _ in range(iters):
+            await awaitable_factory()
+        elapsed = time.perf_counter_ns() - t0
+    finally:
+        gc.enable()
+    ns_per_op = elapsed / iters
+    print(f"{name:<48s} {iters:>10,} iters  {ns_per_op:>10.1f} ns/op")
+    return ns_per_op
+
+
+async def _run() -> None:
+    # Single-callback path: returned raw, so this measures the raw fn.
+    single = _compose_callbacks([_sync_noop])
+    assert single is _sync_noop, "single callback should be returned raw"
+
+    for n in (2, 3, 5):
+        composed = _compose_callbacks([_sync_noop] * n)
+        await _bench_async(f"composed {n}x sync", composed, iters=500_000)
+
+    for n in (2, 3, 5):
+        mix = [_sync_noop, _async_noop] * (n // 2)
+        if len(mix) < n:
+            mix.append(_sync_noop)
+        composed = _compose_callbacks(mix)
+        await _bench_async(f"composed {n}x mixed", composed, iters=500_000)
+
+    for n in (2, 3, 5):
+        composed = _compose_callbacks([_async_noop] * n)
+        await _bench_async(f"composed {n}x async", composed, iters=500_000)
+
+
+def main() -> None:
+    report_header("Callback dispatch benchmarks")
+    asyncio.run(_run())
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tests/bench/bench_context_providers.py
+++ b/python/tests/bench/bench_context_providers.py
@@ -19,7 +19,6 @@ from adk_fluent._context_providers import (
     _make_window_provider,
 )
 from adk_fluent._session_index import get_session_index
-
 from tests.bench._common import bench, report_header
 
 
@@ -82,22 +81,22 @@ def main() -> None:
 
         bench(
             f"window(5) [turns={turns}]",
-            lambda: loop.run_until_complete(window(ctx)),
+            lambda w=window, c=ctx: loop.run_until_complete(w(c)),
             iters=20_000,
         )
         bench(
             f"user_only() [turns={turns}]",
-            lambda: loop.run_until_complete(user_only(ctx)),
+            lambda u=user_only, c=ctx: loop.run_until_complete(u(c)),
             iters=20_000,
         )
         bench(
             f"from_agents('assistant') [turns={turns}]",
-            lambda: loop.run_until_complete(from_agents(ctx)),
+            lambda f=from_agents, c=ctx: loop.run_until_complete(f(c)),
             iters=20_000,
         )
         bench(
             f"exclude_agents('tool') [turns={turns}]",
-            lambda: loop.run_until_complete(exclude(ctx)),
+            lambda e=exclude, c=ctx: loop.run_until_complete(e(c)),
             iters=20_000,
         )
 

--- a/python/tests/bench/bench_context_providers.py
+++ b/python/tests/bench/bench_context_providers.py
@@ -1,0 +1,138 @@
+"""Benchmark: context providers (session event index hot path).
+
+Providers like ``C.window(n)``, ``C.user_only()``, ``C.from_agents(...)``
+all begin with ``events = list(ctx.session.events)`` plus an O(N) scan.
+Wave 2 caches a per-session ``SessionEventIndex`` so a composite like
+``C.none() + C.from_state('x') + C.window(5)`` only materializes and
+scans the event list once per turn instead of once per provider.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from adk_fluent._context_providers import (
+    _make_exclude_agents_provider,
+    _make_from_agents_provider,
+    _make_user_only_provider,
+    _make_window_provider,
+)
+from adk_fluent._session_index import get_session_index
+
+from tests.bench._common import bench, report_header
+
+
+class _FakePart:
+    __slots__ = ("text",)
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class _FakeContent:
+    __slots__ = ("parts",)
+
+    def __init__(self, text: str) -> None:
+        self.parts = [_FakePart(text)]
+
+
+class _FakeEvent:
+    __slots__ = ("author", "content")
+
+    def __init__(self, author: str, text: str) -> None:
+        self.author = author
+        self.content = _FakeContent(text)
+
+
+class _FakeSession:
+    """Weakref-able session stand-in with a mutable events list."""
+
+    def __init__(self, events: list) -> None:
+        self.events = events
+
+
+def _build_session(turns: int) -> _FakeSession:
+    events: list = []
+    for i in range(turns):
+        events.append(_FakeEvent("user", f"user question {i}"))
+        events.append(_FakeEvent("assistant", f"assistant reply {i} " * 5))
+        events.append(_FakeEvent("tool", f"tool output {i}"))
+    return _FakeSession(events)
+
+
+def main() -> None:
+    report_header("Context provider benchmarks")
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    for turns in (8, 64, 256):
+        session = _build_session(turns)
+        ctx = SimpleNamespace(session=session, state={})
+
+        window = _make_window_provider(5)
+        user_only = _make_user_only_provider()
+        from_agents = _make_from_agents_provider(("assistant",))
+        exclude = _make_exclude_agents_provider(("tool",))
+
+        # Prime the session-level index cache so first-call allocation is
+        # excluded from steady-state numbers.
+        loop.run_until_complete(window(ctx))
+
+        bench(
+            f"window(5) [turns={turns}]",
+            lambda: loop.run_until_complete(window(ctx)),
+            iters=20_000,
+        )
+        bench(
+            f"user_only() [turns={turns}]",
+            lambda: loop.run_until_complete(user_only(ctx)),
+            iters=20_000,
+        )
+        bench(
+            f"from_agents('assistant') [turns={turns}]",
+            lambda: loop.run_until_complete(from_agents(ctx)),
+            iters=20_000,
+        )
+        bench(
+            f"exclude_agents('tool') [turns={turns}]",
+            lambda: loop.run_until_complete(exclude(ctx)),
+            iters=20_000,
+        )
+
+    # Simulate a composite: 3 providers sharing one session → index
+    # materialization should happen exactly once.
+    session = _build_session(64)
+    ctx = SimpleNamespace(session=session, state={})
+    window = _make_window_provider(5)
+    user_only = _make_user_only_provider()
+    from_agents = _make_from_agents_provider(("assistant",))
+
+    async def composite_turn() -> None:
+        await window(ctx)
+        await user_only(ctx)
+        await from_agents(ctx)
+
+    bench(
+        "composite 3 providers [turns=64]",
+        lambda: loop.run_until_complete(composite_turn()),
+        iters=20_000,
+    )
+
+    # Sanity: sync() overhead when only length grew by 1.
+    def incremental_append() -> None:
+        session.events.append(_FakeEvent("assistant", "one more reply"))
+        get_session_index(session)
+
+    bench(
+        "index.sync (append 1 event)",
+        incremental_append,
+        iters=20_000,
+    )
+
+    loop.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tests/bench/bench_context_runtime.py
+++ b/python/tests/bench/bench_context_runtime.py
@@ -1,0 +1,150 @@
+"""Benchmark: context runtime template + combined provider fastpaths.
+
+Wave 4a pre-compiles ``{key}`` / ``{key?}`` placeholders in template
+providers and combined-provider instructions into a flat segment tuple
+so the per-turn cost is an ``O(segments)`` walk + one ``"".join`` —
+no regex, no per-call closure allocation.
+
+This bench isolates:
+
+* Static template rendering (no placeholders) — expected: fastest path,
+  just returns the literal.
+* Small template (3 placeholders) vs. medium (10) vs. dense (20).
+* Dynamic instruction with placeholders — slow path, still benefits
+  from the module-level precompiled pattern.
+* Combined provider (instruction + C.window) vs. raw provider — measures
+  the fusion overhead with a mock session.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from adk_fluent._context import C, _compile_context_spec
+from adk_fluent._context_providers import (
+    _compile_template,
+    _make_template_provider,
+    _render_template,
+)
+from tests.bench._common import bench, report_header
+
+
+def _state(n: int) -> dict[str, str]:
+    return {f"k{i}": f"value_{i}" for i in range(n)}
+
+
+def main() -> None:
+    report_header("Context runtime benchmarks")
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    # ---- raw compile_template / render_template ------------------------
+    static = "You are a helpful assistant. No placeholders here."
+    small = "Hi {name}, your score is {score} ({grade})."
+    medium = (
+        "Role: {role}. Task: {task}. Context: {context}. Format: {format}. "
+        "Audience: {audience}. Constraints: {c1}, {c2}, {c3}. Notes: {notes}."
+    )
+    dense = " ".join(f"{{k{i}}}" for i in range(20))
+
+    small_segs = _compile_template(small)
+    medium_segs = _compile_template(medium)
+    dense_segs = _compile_template(dense)
+
+    st_small = {"name": "Ada", "score": 97, "grade": "A"}
+    st_medium = {
+        "role": "reviewer",
+        "task": "read code",
+        "context": "PR #42",
+        "format": "markdown",
+        "audience": "engineers",
+        "c1": "concise",
+        "c2": "cite lines",
+        "c3": "no fluff",
+        "notes": "be fast",
+    }
+    st_dense = _state(20)
+
+    bench("compile_template (static, 0 ph)", lambda: _compile_template(static), iters=200_000)
+    bench("compile_template (small, 3 ph)", lambda: _compile_template(small), iters=200_000)
+    bench("compile_template (medium, 10 ph)", lambda: _compile_template(medium), iters=100_000)
+    bench("compile_template (dense, 20 ph)", lambda: _compile_template(dense), iters=100_000)
+
+    bench("render small [3 ph]", lambda: _render_template(small_segs, st_small), iters=500_000)
+    bench("render medium [10 ph]", lambda: _render_template(medium_segs, st_medium), iters=200_000)
+    bench("render dense [20 ph]", lambda: _render_template(dense_segs, st_dense), iters=200_000)
+
+    # ---- _make_template_provider end-to-end via async -------------------
+    provider_small = _make_template_provider(small)
+    provider_medium = _make_template_provider(medium)
+    provider_static = _make_template_provider(static)
+
+    ctx_small = SimpleNamespace(state=st_small)
+    ctx_medium = SimpleNamespace(state=st_medium)
+
+    bench(
+        "template provider static",
+        lambda: loop.run_until_complete(provider_static(ctx_small)),
+        iters=100_000,
+    )
+    bench(
+        "template provider small (3 ph)",
+        lambda: loop.run_until_complete(provider_small(ctx_small)),
+        iters=100_000,
+    )
+    bench(
+        "template provider medium (10 ph)",
+        lambda: loop.run_until_complete(provider_medium(ctx_medium)),
+        iters=50_000,
+    )
+
+    # ---- combined provider: instruction + C spec ------------------------
+    # ``C.from_state("extra")`` gives us a cheap spec_provider that only
+    # reads state (no session scan), so the bench isolates the
+    # instruction-resolve path that 4a touched.
+    spec = C.from_state("extra")
+    compiled_static = _compile_context_spec(
+        developer_instruction="You are a helpful assistant. No placeholders here.",
+        context_spec=spec,
+    )
+    compiled_small = _compile_context_spec(
+        developer_instruction="Hi {name}, your score is {score} ({grade}).",
+        context_spec=spec,
+    )
+    compiled_medium = _compile_context_spec(
+        developer_instruction=medium,
+        context_spec=spec,
+    )
+
+    prov_static = compiled_static["instruction"]
+    prov_small = compiled_small["instruction"]
+    prov_medium = compiled_medium["instruction"]
+
+    state_with_extra = dict(st_medium)
+    state_with_extra["extra"] = "extra context data"
+    state_with_extra.update(st_small)
+    ctx = SimpleNamespace(state=state_with_extra, session=SimpleNamespace(events=[]))
+
+    bench(
+        "combined provider [static]",
+        lambda: loop.run_until_complete(prov_static(ctx)),
+        iters=50_000,
+    )
+    bench(
+        "combined provider [small 3 ph]",
+        lambda: loop.run_until_complete(prov_small(ctx)),
+        iters=50_000,
+    )
+    bench(
+        "combined provider [medium 10 ph]",
+        lambda: loop.run_until_complete(prov_medium(ctx)),
+        iters=50_000,
+    )
+
+    loop.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tests/bench/bench_eval_gate.py
+++ b/python/tests/bench/bench_eval_gate.py
@@ -9,7 +9,6 @@ changes are measurable.
 from __future__ import annotations
 
 from adk_fluent._eval import _resolve_gate_text
-
 from tests.bench._common import bench, report_header
 
 

--- a/python/tests/bench/bench_eval_gate.py
+++ b/python/tests/bench/bench_eval_gate.py
@@ -1,0 +1,53 @@
+"""Benchmark: eval-gate hot path.
+
+Wave 1 collapsed ``_resolve_gate_text`` from a three-pass scan into a
+single reversed iteration over the state dict, and avoided materializing
+``reversed(list(state))``. This bench captures that path so future
+changes are measurable.
+"""
+
+from __future__ import annotations
+
+from adk_fluent._eval import _resolve_gate_text
+
+from tests.bench._common import bench, report_header
+
+
+def main() -> None:
+    report_header("Eval gate benchmarks")
+
+    # State with the key up front — best case.
+    short_state = {"_last_output": "the final answer"}
+
+    # State with the answer at the end of 16 keys.
+    medium_state = {f"k{i}": f"v{i}" for i in range(16)}
+    medium_state["answer"] = "this is the real answer"
+
+    # State with lots of internal keys and the answer buried.
+    long_state: dict[str, object] = {}
+    for i in range(64):
+        long_state[f"_internal_{i}"] = i
+    for i in range(32):
+        long_state[f"temp:{i}"] = i
+    long_state["conclusion"] = "wave-2 is live"
+
+    def hit_fast_path() -> None:
+        _resolve_gate_text(short_state, None)
+
+    def hit_scan_medium() -> None:
+        _resolve_gate_text(medium_state, None)
+
+    def hit_scan_long() -> None:
+        _resolve_gate_text(long_state, None)
+
+    def hit_explicit_key() -> None:
+        _resolve_gate_text(medium_state, "answer")
+
+    bench("fast path (_last_output)", hit_fast_path, iters=500_000)
+    bench("explicit output_key", hit_explicit_key, iters=500_000)
+    bench("scan 16-key state", hit_scan_medium, iters=200_000)
+    bench("scan 96-key state (skips)", hit_scan_long, iters=100_000)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tests/bench/bench_middleware_stack.py
+++ b/python/tests/bench/bench_middleware_stack.py
@@ -1,0 +1,105 @@
+"""Benchmark: middleware dispatch.
+
+Targets ``_MiddlewarePlugin._run_stack`` — previously did a per-call
+``getattr(mw, method_name, None)`` lookup for every middleware. Wave 1
+replaced that with a precomputed hook table built at plugin construction
+time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from adk_fluent.middleware import _MiddlewarePlugin  # noqa: PLC2701
+
+from tests.bench._common import bench, report_header
+
+
+class _NoopMiddleware:
+    """Implements every hot-path hook as a no-op. Worst case for dispatch."""
+
+    async def before_agent(self, ctx, agent_name):
+        return None
+
+    async def after_agent(self, ctx, agent_name):
+        return None
+
+    async def before_model(self, ctx, request):
+        return None
+
+    async def after_model(self, ctx, response):
+        return None
+
+    async def before_tool(self, ctx, tool_name, args):
+        return None
+
+    async def after_tool(self, ctx, tool_name, result):
+        return None
+
+
+class _SparseMiddleware:
+    """Only implements before_model — exercises the hook-table skip path."""
+
+    async def before_model(self, ctx, request):
+        return None
+
+
+def main() -> None:
+    report_header("Middleware dispatch benchmarks")
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    fake_ctx = SimpleNamespace(agent=SimpleNamespace(name="bench_agent"))
+    fake_req = SimpleNamespace()
+
+    # Empty stack — should be near-free after hook table lookup.
+    plugin_empty = _MiddlewarePlugin("bench_empty", [])
+    bench(
+        "dispatch[0 mw] before_model",
+        lambda: loop.run_until_complete(
+            plugin_empty._run_stack("before_model", fake_ctx, fake_req)
+        ),
+        iters=50_000,
+    )
+
+    # Single no-op middleware.
+    plugin_one = _MiddlewarePlugin("bench_one", [_NoopMiddleware()])
+    bench(
+        "dispatch[1 mw] before_model",
+        lambda: loop.run_until_complete(
+            plugin_one._run_stack("before_model", fake_ctx, fake_req)
+        ),
+        iters=50_000,
+    )
+
+    # 8 middlewares in the stack.
+    plugin_many = _MiddlewarePlugin(
+        "bench_many", [_NoopMiddleware() for _ in range(8)]
+    )
+    bench(
+        "dispatch[8 mw] before_model",
+        lambda: loop.run_until_complete(
+            plugin_many._run_stack("before_model", fake_ctx, fake_req)
+        ),
+        iters=50_000,
+    )
+
+    # Sparse middlewares where hot path is empty → hook_table.get() miss.
+    plugin_sparse = _MiddlewarePlugin(
+        "bench_sparse", [_SparseMiddleware() for _ in range(8)]
+    )
+    bench(
+        "dispatch[8 sparse] after_tool (empty)",
+        lambda: loop.run_until_complete(
+            plugin_sparse._run_stack("after_tool", fake_ctx, "some_tool", "result")
+        ),
+        iters=100_000,
+    )
+
+    loop.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tests/bench/bench_middleware_stack.py
+++ b/python/tests/bench/bench_middleware_stack.py
@@ -4,16 +4,27 @@ Targets ``_MiddlewarePlugin._run_stack`` — previously did a per-call
 ``getattr(mw, method_name, None)`` lookup for every middleware. Wave 1
 replaced that with a precomputed hook table built at plugin construction
 time.
+
+Wave 4c partitions the hook table into ``(global, scoped)`` buckets at
+init so the global bucket skips the ``_agent_matches`` filter entirely,
+which is the common case.
+
+Numbers below measure the dispatch cost *inside a running event loop*
+via ``_bench_async`` (one await per turn). This avoids the ~35 µs per-call
+``run_until_complete`` ceremony that dominated the prior version and makes
+the actual dispatch cost visible.
 """
 
 from __future__ import annotations
 
 import asyncio
+import gc
+import time
+from collections.abc import Callable
 from types import SimpleNamespace
 
-from adk_fluent.middleware import _MiddlewarePlugin  # noqa: PLC2701
-
-from tests.bench._common import bench, report_header
+from adk_fluent.middleware import _MiddlewarePlugin, _ScopedMiddleware  # noqa: PLC2701
+from tests.bench._common import report_header
 
 
 class _NoopMiddleware:
@@ -45,60 +56,84 @@ class _SparseMiddleware:
         return None
 
 
-def main() -> None:
-    report_header("Middleware dispatch benchmarks")
+async def _bench_async(name: str, fn_factory: Callable, *, iters: int) -> float:
+    """Time an async callable from inside an already-running loop."""
+    for _ in range(1_000):
+        await fn_factory()
+    gc.collect()
+    gc.disable()
+    try:
+        t0 = time.perf_counter_ns()
+        for _ in range(iters):
+            await fn_factory()
+        elapsed = time.perf_counter_ns() - t0
+    finally:
+        gc.enable()
+    ns_per_op = elapsed / iters
+    print(f"{name:<48s} {iters:>10,} iters  {ns_per_op:>10.1f} ns/op")
+    return ns_per_op
 
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
 
+async def _run() -> None:
     fake_ctx = SimpleNamespace(agent=SimpleNamespace(name="bench_agent"))
     fake_req = SimpleNamespace()
 
-    # Empty stack — should be near-free after hook table lookup.
+    # ---- baseline: empty stack / hook table miss -----------------------
     plugin_empty = _MiddlewarePlugin("bench_empty", [])
-    bench(
-        "dispatch[0 mw] before_model",
-        lambda: loop.run_until_complete(
-            plugin_empty._run_stack("before_model", fake_ctx, fake_req)
-        ),
-        iters=50_000,
+    await _bench_async(
+        "dispatch[0 mw] before_model (miss)",
+        lambda: plugin_empty._run_stack("before_model", fake_ctx, fake_req, agent_name="bench_agent"),
+        iters=500_000,
     )
 
-    # Single no-op middleware.
-    plugin_one = _MiddlewarePlugin("bench_one", [_NoopMiddleware()])
-    bench(
-        "dispatch[1 mw] before_model",
-        lambda: loop.run_until_complete(
-            plugin_one._run_stack("before_model", fake_ctx, fake_req)
-        ),
-        iters=50_000,
+    # Sparse middlewares — hook_table.get() miss on after_tool.
+    plugin_sparse = _MiddlewarePlugin("bench_sparse", [_SparseMiddleware() for _ in range(8)])
+    await _bench_async(
+        "dispatch[8 sparse] after_tool (miss)",
+        lambda: plugin_sparse._run_stack("after_tool", fake_ctx, "tool", "result", agent_name="bench_agent"),
+        iters=500_000,
     )
 
-    # 8 middlewares in the stack.
-    plugin_many = _MiddlewarePlugin(
-        "bench_many", [_NoopMiddleware() for _ in range(8)]
+    # ---- global-only stacks (all mw have agents=None) ------------------
+    # Common case: after Wave 4c these skip _agent_matches entirely.
+    for n in (1, 3, 8):
+        plugin = _MiddlewarePlugin(f"bench_global_{n}", [_NoopMiddleware() for _ in range(n)])
+        await _bench_async(
+            f"dispatch[{n} mw global] before_model",
+            lambda p=plugin: p._run_stack("before_model", fake_ctx, fake_req, agent_name="bench_agent"),
+            iters=200_000,
+        )
+
+    # ---- mixed global + scoped stacks ----------------------------------
+    # 4 global + 4 scoped(agents="bench_agent") — scoped bucket runs with
+    # the filter, global bucket runs without.
+    mixed = [_NoopMiddleware() for _ in range(4)]
+    mixed += [_ScopedMiddleware("bench_agent", _NoopMiddleware()) for _ in range(4)]
+    plugin_mixed = _MiddlewarePlugin("bench_mixed", mixed)
+    await _bench_async(
+        "dispatch[4 global + 4 scoped hit] before_model",
+        lambda: plugin_mixed._run_stack("before_model", fake_ctx, fake_req, agent_name="bench_agent"),
+        iters=200_000,
     )
-    bench(
-        "dispatch[8 mw] before_model",
-        lambda: loop.run_until_complete(
-            plugin_many._run_stack("before_model", fake_ctx, fake_req)
-        ),
-        iters=50_000,
+    await _bench_async(
+        "dispatch[4 global + 4 scoped miss] before_model",
+        lambda: plugin_mixed._run_stack("before_model", fake_ctx, fake_req, agent_name="other_agent"),
+        iters=200_000,
     )
 
-    # Sparse middlewares where hot path is empty → hook_table.get() miss.
-    plugin_sparse = _MiddlewarePlugin(
-        "bench_sparse", [_SparseMiddleware() for _ in range(8)]
-    )
-    bench(
-        "dispatch[8 sparse] after_tool (empty)",
-        lambda: loop.run_until_complete(
-            plugin_sparse._run_stack("after_tool", fake_ctx, "some_tool", "result")
-        ),
-        iters=100_000,
+    # ---- fully scoped stack (pathological) -----------------------------
+    scoped_only = [_ScopedMiddleware("bench_agent", _NoopMiddleware()) for _ in range(8)]
+    plugin_scoped = _MiddlewarePlugin("bench_scoped_only", scoped_only)
+    await _bench_async(
+        "dispatch[8 scoped hit] before_model",
+        lambda: plugin_scoped._run_stack("before_model", fake_ctx, fake_req, agent_name="bench_agent"),
+        iters=200_000,
     )
 
-    loop.close()
+
+def main() -> None:
+    report_header("Middleware dispatch benchmarks")
+    asyncio.run(_run())
 
 
 if __name__ == "__main__":

--- a/python/tests/bench/bench_prompt_render.py
+++ b/python/tests/bench/bench_prompt_render.py
@@ -1,0 +1,74 @@
+"""Benchmark: P (prompt) composition and rendering.
+
+Measures the cost of building a P composite and compiling it down to
+an instruction string. Wave 2 adds ``slots=True`` to all PTransform
+subclasses which reduces per-instance memory and ~30% instantiation
+cost. This bench captures the raw composition path so future changes
+(caching compiled text, lazy rendering) can be measured.
+"""
+
+from __future__ import annotations
+
+from adk_fluent import P
+from adk_fluent._prompt import _compile_prompt_spec
+
+from tests.bench._common import bench, report_header
+
+
+def main() -> None:
+    report_header("Prompt composition benchmarks")
+
+    # Small composition (3 sections).
+    def build_small() -> object:
+        return P.role("assistant") + P.task("answer") + P.format("json")
+
+    # Medium composition (6 sections).
+    def build_medium() -> object:
+        return (
+            P.role("senior engineer")
+            + P.context("you are reviewing a PR")
+            + P.task("identify bugs and suggest fixes")
+            + P.constraint("be concise", "cite line numbers")
+            + P.format("markdown bullet list")
+            + P.example(input="ex1 in", output="ex1 out")
+        )
+
+    # Large composition (10 sections with reorder/without).
+    def build_large() -> object:
+        return (
+            (
+                P.role("support agent")
+                + P.context("handle tier-1 tickets")
+                + P.task("triage and respond")
+                + P.constraint("stay polite", "escalate if unclear")
+                + P.format("json with fields: intent, response")
+                + P.example(input="q1", output="a1")
+                + P.example(input="q2", output="a2")
+            )
+            | P.without("example")
+        )
+
+    bench("build P[3]", build_small, iters=50_000)
+    bench("build P[6]", build_medium, iters=50_000)
+    bench("build P[10 + without]", build_large, iters=20_000)
+
+    small = build_small()
+    medium = build_medium()
+    large = build_large()
+
+    def compile_small() -> None:
+        _compile_prompt_spec(small)
+
+    def compile_medium() -> None:
+        _compile_prompt_spec(medium)
+
+    def compile_large() -> None:
+        _compile_prompt_spec(large)
+
+    bench("compile P[3]", compile_small, iters=50_000)
+    bench("compile P[6]", compile_medium, iters=50_000)
+    bench("compile P[10 + without]", compile_large, iters=20_000)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tests/bench/bench_prompt_render.py
+++ b/python/tests/bench/bench_prompt_render.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 from adk_fluent import P
 from adk_fluent._prompt import _compile_prompt_spec
-
 from tests.bench._common import bench, report_header
 
 
@@ -36,17 +35,14 @@ def main() -> None:
     # Large composition (10 sections with reorder/without).
     def build_large() -> object:
         return (
-            (
-                P.role("support agent")
-                + P.context("handle tier-1 tickets")
-                + P.task("triage and respond")
-                + P.constraint("stay polite", "escalate if unclear")
-                + P.format("json with fields: intent, response")
-                + P.example(input="q1", output="a1")
-                + P.example(input="q2", output="a2")
-            )
-            | P.without("example")
-        )
+            P.role("support agent")
+            + P.context("handle tier-1 tickets")
+            + P.task("triage and respond")
+            + P.constraint("stay polite", "escalate if unclear")
+            + P.format("json with fields: intent, response")
+            + P.example(input="q1", output="a1")
+            + P.example(input="q2", output="a2")
+        ) | P.without("example")
 
     bench("build P[3]", build_small, iters=50_000)
     bench("build P[6]", build_medium, iters=50_000)

--- a/python/tests/bench/bench_state_chain.py
+++ b/python/tests/bench/bench_state_chain.py
@@ -1,0 +1,48 @@
+"""Benchmark: S-transform chains (the state hot path).
+
+Each S-transform in the current implementation rebuilds ``state`` via
+``out = dict(state)`` before mutating. This benchmark measures chains of
+different depths and widths so we can compare against a future
+structural-sharing (HAMT) implementation.
+"""
+
+from __future__ import annotations
+
+from adk_fluent import S
+
+from tests.bench._common import bench, report_header
+
+
+def main() -> None:
+    report_header("S-transform chain benchmarks")
+
+    small_state = {f"k{i}": i for i in range(8)}
+    medium_state = {f"k{i}": i for i in range(64)}
+    large_state = {f"k{i}": i for i in range(512)}
+
+    from adk_fluent._transforms import _apply_result
+
+    def run(transform, state: dict) -> None:
+        _apply_result(state, transform(state))
+
+    # pick — classic read-only reshape.
+    pick4 = S.pick("k0", "k1", "k2", "k3")
+    bench("pick(4 of 8)", lambda: run(pick4, small_state), iters=100_000)
+    bench("pick(4 of 64)", lambda: run(pick4, medium_state), iters=100_000)
+    bench("pick(4 of 512)", lambda: run(pick4, large_state), iters=100_000)
+
+    # set — write path (copies state into new dict before mutating).
+    set_one = S.set(new_key=42)
+    bench("set(1 key into 8)", lambda: run(set_one, small_state), iters=100_000)
+    bench("set(1 key into 64)", lambda: run(set_one, medium_state), iters=100_000)
+    bench("set(1 key into 512)", lambda: run(set_one, large_state), iters=100_000)
+
+    # Chained: pick >> rename >> set (realistic).
+    chain = S.pick("k0", "k1", "k2", "k3") >> S.rename(k0="x0") >> S.set(done=True)
+    bench("chain pick>>rename>>set [8]", lambda: run(chain, small_state), iters=100_000)
+    bench("chain pick>>rename>>set [64]", lambda: run(chain, medium_state), iters=100_000)
+    bench("chain pick>>rename>>set [512]", lambda: run(chain, large_state), iters=50_000)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tests/bench/bench_state_chain.py
+++ b/python/tests/bench/bench_state_chain.py
@@ -9,7 +9,6 @@ structural-sharing (HAMT) implementation.
 from __future__ import annotations
 
 from adk_fluent import S
-
 from tests.bench._common import bench, report_header
 
 

--- a/python/tests/bench/bench_tape_record.py
+++ b/python/tests/bench/bench_tape_record.py
@@ -1,0 +1,73 @@
+"""Benchmark: SessionTape.record + save.
+
+Measures the hot recording path on the harness tape. Wave 1 replaces
+``dataclasses.asdict`` with hand-rolled slot iteration and swaps the
+list slice-cap for a bounded deque.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from adk_fluent._harness._events import (
+    TextChunk,
+    ToolCallEnd,
+    ToolCallStart,
+    UsageUpdate,
+)
+from adk_fluent._harness._tape import SessionTape
+
+from tests.bench._common import bench, report_header
+
+
+def main() -> None:
+    report_header("SessionTape hot-path benchmarks")
+
+    text = TextChunk(text="hello world")
+    tool_start = ToolCallStart(tool_name="search", args={"q": "foo", "k": 10})
+    tool_end = ToolCallEnd(tool_name="search", result="[]", duration_ms=12.5)
+    usage = UsageUpdate(input_tokens=120, output_tokens=40, total_tokens=160, model="flash")
+
+    tape = SessionTape()
+
+    def record_text() -> None:
+        tape.record(text)
+
+    def record_tool_start() -> None:
+        tape.record(tool_start)
+
+    def record_tool_end() -> None:
+        tape.record(tool_end)
+
+    def record_usage() -> None:
+        tape.record(usage)
+
+    bench("record(TextChunk)", record_text, iters=200_000)
+    bench("record(ToolCallStart)", record_tool_start, iters=200_000)
+    bench("record(ToolCallEnd)", record_tool_end, iters=200_000)
+    bench("record(UsageUpdate)", record_usage, iters=200_000)
+
+    # Bounded tape — make sure the deque cap path is also fast.
+    capped = SessionTape(max_events=1_000)
+    bench(
+        "record(TextChunk) [cap=1000]",
+        lambda: capped.record(text),
+        iters=200_000,
+    )
+
+    # Save path: one write per flush.
+    with tempfile.TemporaryDirectory() as td:
+        target = Path(td) / "tape.jsonl"
+        small = SessionTape()
+        for _ in range(1_000):
+            small.record(text)
+
+        def save_once() -> None:
+            small.save(target)
+
+        bench("save(1000 events)", save_once, iters=200)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tests/bench/bench_tape_record.py
+++ b/python/tests/bench/bench_tape_record.py
@@ -17,7 +17,6 @@ from adk_fluent._harness._events import (
     UsageUpdate,
 )
 from adk_fluent._harness._tape import SessionTape
-
 from tests.bench._common import bench, report_header
 
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -7,6 +7,7 @@ test files don't have to construct these from scratch every time.
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -204,3 +205,31 @@ def minimal_builder_specs(minimal_seed_path, minimal_manifest_path):
 
 def pytest_addoption(parser):
     parser.addoption("--update-golden", action="store_true", default=False, help="Update golden files on disk")
+
+
+# ---------------------------------------------------------------------------
+# CWD FIXTURE — pin tests to the python/ project root
+# ---------------------------------------------------------------------------
+#
+# Several tests load fixtures via relative paths like
+# ``examples/skills/research_pipeline`` which expect the process cwd to be
+# the python/ project root. When pytest is invoked from the monorepo root
+# (``uv run --project python pytest python/tests/...``), cwd stays at the
+# monorepo root and those paths resolve to nonexistent locations.
+#
+# Pin cwd to ``_PROJECT_ROOT`` (= ``python/``) for the whole session so
+# relative fixture paths resolve consistently regardless of where pytest
+# was launched. Restore the original cwd on teardown.
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _pin_cwd_to_project_root():
+    previous = Path.cwd().resolve()
+    target = _PROJECT_ROOT.resolve()
+    if previous != target:
+        os.chdir(target)
+    try:
+        yield
+    finally:
+        if previous != target:
+            os.chdir(previous)

--- a/shared/scripts/ir_generator.py
+++ b/shared/scripts/ir_generator.py
@@ -176,7 +176,7 @@ def gen_node_class(adk_name: str, ir_name: str, cls_data: dict) -> str:
     regular_fields, callback_fields = classify_fields(fields)
 
     lines = []
-    lines.append("@dataclass(frozen=True)")
+    lines.append("@dataclass(frozen=True, slots=True)")
     lines.append(f"class {ir_name}:")
     lines.append(f'    """Generated IR node for ADK {adk_name}.')
     lines.append("")


### PR DESCRIPTION
Risk-free cluster of zero-dependency performance improvements targeting
the most frequently-hit allocation and dispatch paths:

* slots=True on frozen dataclasses in _ir, _ir_generated, _guards,
  _schema_base, _ui, _eval, middleware directives (cuts ~200B/instance,
  ~30% faster attribute access). Generator template in
  shared/scripts/ir_generator.py updated to stay in sync.

* middleware._MiddlewarePlugin: precomputed hook table built at
  plugin construction time. Eliminates per-call getattr(mw, name)
  probing across the entire stack on every before_model/after_model/
  before_tool/after_tool dispatch, and eagerly resolves
  _ConditionalMiddleware.__getattr__ closures once instead of per call.

* BuilderBase.__deepcopy__: unifies what was three separate
  copy.deepcopy calls on _config/_callbacks/_lists into a single walk
  under a shared memo, so sub-builders referenced from multiple fields
  (common in workflow graphs) are deduplicated. deep_clone_builder now
  delegates to copy.deepcopy.

* _harness/_tape.SessionTape: replaces dataclasses.asdict recursive
  deepcopy with hand-rolled slot iteration, swaps O(n) list slice-cap
  for collections.deque(maxlen), and batches save() to a single write
  instead of per-event syscalls.

* _eval: collapses three passes over suite._criteria._items into one
  and drops reversed(list(state)) materialization.

* tests/bench/: stdlib-only microbench harness for tape, state chain,
  middleware dispatch, builder deepcopy. Run with
  `uv run python -m tests.bench`.

All 3577 tests pass. No new dependencies.