### PR TITLE
docs: comprehensive user-guide overhaul with Mermaid diagrams, tables…

### DIFF
--- a/docs/user-guide/a2a.md
+++ b/docs/user-guide/a2a.md
@@ -1,5 +1,13 @@
 # A2A -- Agent-to-Agent Communication
 
+:::{admonition} At a Glance
+:class: tip
+
+- A2A enables remote agent-to-agent communication over HTTP using the A2A protocol
+- `RemoteAgent` consumes remote agents; `A2AServer` publishes local agents
+- All operators (`>>`, `|`, `//`, `*`) work with remote agents --- same composition as local
+:::
+
 The **A2A (Agent-to-Agent)** protocol enables agents to communicate across process boundaries, machines, and organizations. adk-fluent wraps Google's A2A protocol with the same fluent builder API used for local agents.
 
 :::{admonition} Install

--- a/docs/user-guide/a2ui.md
+++ b/docs/user-guide/a2ui.md
@@ -1,5 +1,13 @@
 # A2UI -- Agent-to-UI Composition
 
+:::{admonition} At a Glance
+:class: tip
+
+- UI module provides declarative UI composition for agents
+- Compose with `|` (row) and `>>` (column), attach with `.ui(spec)`
+- Three modes: declarative (you define), LLM-guided (agent decides), hybrid
+:::
+
 The **UI namespace** lets agents define rich, interactive user interfaces declaratively. Agents emit [A2UI protocol](https://github.com/google/A2UI) JSON that clients render as native widgets -- no frontend code required from the agent developer.
 
 :::{admonition} Install

--- a/docs/user-guide/architecture-and-concepts.md
+++ b/docs/user-guide/architecture-and-concepts.md
@@ -1,168 +1,538 @@
 # Architecture & Core Concepts
 
-Before diving into builders and operators, it's crucial to understand the underlying mechanics of ADK and how `adk-fluent` interacts with them. This conceptual foundation will help you design robust, predictable agent systems.
+:::{admonition} At a Glance
+:class: tip
 
-## The Three Channels
+- **adk-fluent** is a thin builder layer on top of Google ADK --- every `.build()` returns a real ADK object
+- Builders are typed configuration objects that compile to native ADK at build time
+- Nine modules (S, C, P, A, M, T, E, G, UI) provide composable, orthogonal concerns
+:::
 
-ADK has three independent mechanisms for agents to communicate. Every confusion about state traces back to developers not realizing they're coordinating three systems manually.
+## System Architecture
 
-**Channel 1: Conversation History**
-All events (user messages, agent responses, tool calls) are appended to `session.events`. When the next agent runs, `contents.py` assembles these events into the LLM prompt. Every agent sees every prior agent's raw text output by default. Controlled by `include_contents`: `'default'` (everything) or `'none'` (current turn only). Binary switch. No middle ground.
+adk-fluent sits between your code and Google ADK. It adds zero runtime overhead --- builders exist only at definition time.
 
-**Channel 2: Session State (key-value store)**
-Flat dictionary at `session.state`. Written via `output_key` (LlmAgent writes its text here automatically), `ctx.session.state[k] = v` (manual), or `event.actions.state_delta` (event-carried). Read via `session.state[k]` in code. Scoped: unprefixed (session), `app:`, `user:`, `temp:`.
+```mermaid
+graph LR
+    subgraph "Your Code"
+        A["Agent('helper')
+        .instruct(...)
+        .tool(...)"]
+    end
 
-**Channel 3: Instruction Templating**
-`inject_session_state()` replaces `{key}` placeholders in instruction strings with `session.state[key]` values. Runs every invocation, just before the LLM call. This is the bridge: state values appear inside the system prompt.
+    subgraph "adk-fluent Layer"
+        B["Builder API"] --> C["IR Tree"]
+        C --> D{"Backend?"}
+    end
 
-These three channels are configured independently but deeply entangled at runtime. In `classifier >> booker`:
+    subgraph "ADK Layer"
+        D -->|"default"| E["Native ADK Objects"]
+        D -->|"temporal"| F["Temporal Workflow"]
+        D -->|"asyncio"| G["Asyncio Interpreter"]
+    end
 
-```
-classifier (output_key="intent") produces "booking"
-  → Channel 1: "booking" appended to session.events
-  → Channel 2: session.state["intent"] = "booking" (via state_delta on event)
+    subgraph "Deployment"
+        E --> H["adk web / run / deploy"]
+        F --> I["Temporal Server"]
+        G --> J["Python asyncio"]
+    end
 
-booker (instruction="Help book. The intent is: {intent}") runs
-  → Channel 1: LLM context includes classifier's "booking" text
-  → Channel 3: instruction becomes "Help book. The intent is: booking"
-  → booker's LLM sees "booking" TWICE: once in conversation, once in instruction
-```
+    A --> B
 
-This duplication is not a bug. It's the natural consequence of three independent channels converging on one LLM prompt. The developer is expected to manage this. Most don't realize it's happening.
-
-## What include_contents Actually Does
-
-The source (`contents.py`) reveals `include_contents='none'` finds the most recent user message or other-agent reply and only includes events from that point forward. In a pipeline:
-
-```
-User: "I want to fly to London"          ← turn start
-Classifier: "booking"                     ← agent reply
-
-Booker runs with include_contents='none':
-  → Looks backward, finds classifier's reply as "other agent reply"
-  → Only includes events from classifier's reply onward
-  → Booker sees: "booking"
-  → Booker does NOT see: "I want to fly to London"
-```
-
-The user's original message is lost. `include_contents='none'` was designed for stateless utility agents that get all their context from state variables in the instruction template. It was not designed for pipeline composition where a downstream agent needs the conversation *and* structured data from an upstream agent.
-
-There is no `include_contents='user_only'` or `include_contents='exclude_agents'`. The switch is binary: everything, or current turn. ADK has no mechanism for topology-aware content filtering.
-
-## What output_key Actually Does
-
-`__maybe_save_output_to_state` runs inside `LlmAgent._run_async_impl`:
-
-```python
-async for event in self._llm_flow.run_async(ctx):
-    self.__maybe_save_output_to_state(event)  # mutates event.actions.state_delta
-    yield event                                # yields event WITH content AND state_delta
+    style A fill:#1a1a2e,stroke:#e94560,color:#fff
+    style B fill:#16213e,stroke:#e94560,color:#fff
+    style C fill:#16213e,stroke:#0ea5e9,color:#fff
+    style D fill:#0f3460,stroke:#f59e0b,color:#fff
+    style E fill:#0f3460,stroke:#10b981,color:#fff
+    style F fill:#0f3460,stroke:#a78bfa,color:#fff
+    style G fill:#0f3460,stroke:#a78bfa,color:#fff
 ```
 
-It mutates the event's `state_delta` field in-place. It does not suppress, replace, or redirect the content. The event still carries full text. `append_event` in the Runner then: (1) appends the event to `session.events`, and (2) applies `state_delta` to `session.state`. Both writes happen atomically from the same event.
+:::{tip}
+**Mental model:** Think of builders as typed configuration objects that compile to ADK at `.build()` time. After `.build()`, adk-fluent is gone --- you have a pure ADK object.
+:::
 
-`output_key` is therefore a *duplication* mechanism, not a *routing* mechanism. It copies the LLM's text response into state under a named key. The original text still exists in conversation history. Downstream agents get it through both channels.
+## Lifecycle of an Agent
 
-## What the S Module Does Today
+Every agent follows the same path: configure with fluent methods, then compile to a native ADK object.
 
-The S module provides pure state transforms that compile to `FnAgent` — a zero-cost agent that mutates `ctx.session.state` directly and yields no events:
+```mermaid
+sequenceDiagram
+    participant Dev as Developer
+    participant B as Builder
+    participant IR as IR Tree
+    participant ADK as Native ADK
 
-```python
-pipeline = (
-    Agent("researcher").instruct("Find data.").writes("findings")
-    >> S.pick("findings", "sources")
-    >> S.rename(findings="input")
-    >> Agent("writer").instruct("Write report using {input}.")
-)
+    Dev->>B: Agent("helper", "gemini-2.5-flash")
+    Dev->>B: .instruct("You are helpful.")
+    Dev->>B: .tool(search_fn)
+    Dev->>B: .writes("response")
+    Dev->>B: .build()
+    B->>IR: Compile builder state
+    IR->>IR: Validate contracts
+    IR->>ADK: Emit LlmAgent(...)
+    Note over ADK: Pure ADK object ---<br/>works with adk web/run/deploy
 ```
 
-`S.pick` → keeps only named keys, nulls everything else (session-scoped)
-`S.drop` → removes named keys
-`S.rename` → renames keys
-`S.default` → fills missing keys
-`S.merge` → combines keys
-`S.transform` → applies function to single key
-`S.compute` → derives new keys from full state
-`S.set` → sets explicit values
-`S.guard` → asserts invariant
-`S.log` → debug print
+## adk-fluent Concepts vs ADK Concepts
 
-These operate exclusively on Channel 2 (session state). They don't touch Channel 1 (conversation history) or Channel 3 (instruction templating). FnAgent writes directly to `ctx.session.state` and yields nothing — no events, no state_delta, no conversation history entry.
+Every adk-fluent concept maps directly to an ADK concept. Nothing is invented --- everything compiles down.
 
-## What's Actually Missing
+| adk-fluent | ADK Equivalent | Relationship |
+|---|---|---|
+| `Agent` builder | `LlmAgent` | 1:1 --- identical object after `.build()` |
+| `Pipeline` / `>>` | `SequentialAgent` | Sequential execution |
+| `FanOut` / `\|` | `ParallelAgent` | Concurrent execution |
+| `Loop` / `*` | `LoopAgent` | Iterative execution |
+| `.instruct()` | `instruction` kwarg | System prompt |
+| `.writes()` | `output_key` kwarg | State storage |
+| `.returns()` | `output_schema` kwarg | Structured output |
+| `.tool()` | `tools` list | Tool registration |
+| `.sub_agent()` | `sub_agents` list | Transfer targets |
+| S transforms | `FnAgent` (zero-cost) | State dict manipulation |
+| IR Tree | _(no equivalent)_ | adk-fluent's compile step |
 
-The S module is fine for what it does. It's a clean set of state transforms. The problem isn't the transforms — it's that the developer has to manually coordinate all three channels, and the common patterns require getting the coordination exactly right.
+## The Nine Modules
 
-### Missing: The >> operator doesn't encode data flow
+adk-fluent organizes capabilities into nine composable modules. Each controls one concern.
 
-When a developer writes `a >> b`, they mean "a's output feeds b." But `>>` in adk-fluent compiles to `SequentialAgent`, which just runs agents in order within the same session. The operator implies data flow but implements sequential execution. The gap between these is where every state management mistake lives.
+```mermaid
+graph TB
+    subgraph "Prompt & Context"
+        P["P — Prompt<br/>What the LLM is told"]
+        C["C — Context<br/>What the agent sees"]
+    end
 
-Unix pipes work because `|` means "stdout of left connects to stdin of right." The shell handles the plumbing. Programs don't think about it. `>>` should carry that same weight: the developer declares the relationship, the library figures out the wiring.
+    subgraph "Data Flow"
+        S["S — State<br/>Transforms between agents"]
+        A_["A — Artifacts<br/>File publish/load"]
+    end
 
-### Missing: output_key should be inferred from topology, not manually assigned
+    subgraph "Quality & Safety"
+        G["G — Guards<br/>Output validation"]
+        E["E — Evaluation<br/>Testing & scoring"]
+    end
 
-If an agent has a successor in a pipeline and the successor reads from state, the intermediate agent needs an `output_key`. Today the developer has to know this. There's no signal from the library that says "you put classifier before a Route that reads 'intent', but classifier has no output_key — its output won't be in state."
+    subgraph "Infrastructure"
+        M["M — Middleware<br/>Retry, logging, cost"]
+        T["T — Tools<br/>Tool composition"]
+    end
 
-### Missing: include_contents should have a topology-aware mode
+    subgraph "Interface"
+        UI["UI — Agent-to-UI<br/>Declarative UI"]
+    end
 
-The binary choice (everything / current turn) is insufficient for pipelines. A downstream agent often needs: the user's original message (conversational context) + structured data from state (routing info, extracted entities) — but NOT the raw text of intermediate agents (noise, duplication).
-
-This isn't something adk-fluent can fix at the ADK level. But it could provide a mechanism: a custom `InstructionProvider` that assembles context from state rather than relying on ADK's conversation history. Agents with `include_contents='none'` plus a carefully constructed instruction that includes `{user_message}` from state — where `{user_message}` was captured by an earlier agent or S transform.
-
-### Missing: Contract validation across all three channels
-
-The build-time check the developer actually needs isn't "does key X exist in state." It's a coherence analysis across channels:
-
-- Agent B's instruction template references `{intent}`. Does any upstream agent produce `intent` via `output_key`?
-- Agent A has `output_key="intent"` but agent B has `include_contents='default'`. B will see "booking" twice (state + conversation). Is this intentional?
-- Agent A has no `output_key` and B has `include_contents='none'`. A's output reaches B through neither channel. Data is lost.
-- Route reads `state["intent"]` but classifier has no `output_key`. Route will read stale or missing state.
-
-## What the Thoughtful Library Does
-
-The 100x team doesn't add more S transforms. The S module is already complete for explicit state manipulation. They focus on three things:
-
-### 1. Make >> aware of data contracts
-
-`output_key` is not just a storage mechanism — it's a declaration of agent role. An agent with `output_key` is saying "my text is data, not conversation." An agent without `output_key` is saying "my text IS the conversation."
-
-The `>>` operator should respect this:
-
-```python
-# When classifier writes "intent", the >> operator knows
-# that downstream agents can read it from state
-classifier = Agent("classify").instruct("Classify intent.").writes("intent")
-resolver = Agent("resolve").instruct("Resolve the {intent} issue.")
-
-pipeline = classifier >> resolver
-# adk-fluent infers: classifier needs output_key="intent"
-# adk-fluent infers: resolver needs include_contents behavior
+    style P fill:#e94560,color:#fff
+    style C fill:#0ea5e9,color:#fff
+    style S fill:#10b981,color:#fff
+    style A_ fill:#f59e0b,color:#fff
+    style G fill:#f472b6,color:#fff
+    style E fill:#a78bfa,color:#fff
+    style M fill:#64748b,color:#fff
+    style T fill:#06b6d4,color:#fff
+    style UI fill:#8b5cf6,color:#fff
 ```
 
-### 2. Infer output_key from topology
-
-If an agent has `.writes("intent")` and appears before a `Route("intent")`, the library can verify at build time that the data contract is satisfiable. If the developer forgets `.writes()`, the contract checker flags it before any LLM call.
-
-### 3. Provide topology-aware context filtering
-
-The C module (`C.none()`, `C.from_state()`, `C.user_only()`, `C.window()`) gives developers fine-grained control over what each agent sees — without relying on ADK's binary `include_contents` switch. See [Context Engineering](context-engineering.md) for the full catalog.
+| Module | Import | Used With | Compose With |
+|--------|--------|-----------|-------------|
+| **S** — State | `from adk_fluent import S` | `>>` operator | `>>` (chain), `+` (combine) |
+| **C** — Context | `from adk_fluent import C` | `.context()` | `+` (union), `\|` (pipe) |
+| **P** — Prompt | `from adk_fluent import P` | `.instruct()` | `+` (union), `\|` (pipe) |
+| **A** — Artifacts | `from adk_fluent import A` | `.artifacts()`, `>>` | `>>` (chain) |
+| **M** — Middleware | `from adk_fluent import M` | `.middleware()` | `\|` (chain) |
+| **T** — Tools | `from adk_fluent import T` | `.tools()` | `\|` (chain) |
+| **E** — Evaluation | `from adk_fluent import E` | `.eval()` | builder pattern |
+| **G** — Guards | `from adk_fluent import G` | `.guard()` | `\|` (chain) |
+| **UI** — Agent-to-UI | `from adk_fluent import UI` | `.ui()` | `\|` (row), `>>` (column) |
 
 ---
 
-## Context Engineering: The Five Operations
+## The Three Channels of ADK Communication
 
-Context engineering is not just overflow handling. It is the *continuous discipline* of assembling the smallest, highest-signal token set that maximizes an agent's likelihood of producing the desired outcome.
+ADK has three independent mechanisms for agents to communicate. Every confusion about state traces back to not realizing they're three separate systems.
 
-The five operations that adk-fluent exposes on every agent builder correspond to five orthogonal concerns:
+```mermaid
+graph TB
+    subgraph "Channel 1: Conversation History"
+        CH1["All events appended to session.events<br/>Every agent sees prior agents' text by default<br/>Controlled by include_contents: 'default' or 'none'"]
+    end
 
-| Operation | Builder method | What it controls |
-|-----------|---------------|-----------------|
-| **Context** | `.reads()`, `.context()` | What history/state the agent sees |
-| **Input** | `.accepts()` | What schema is expected when invoked as a tool |
-| **Output** | `.returns()` | What schema the LLM must produce |
-| **Storage** | `.writes()` | Where the agent's response is stored in state |
-| **Contract** | `.produces()`, `.consumes()` | Static annotations for build-time validation |
+    subgraph "Channel 2: Session State"
+        CH2["Flat dict at session.state<br/>Written via output_key or ctx.session.state<br/>Scoped: unprefixed, app:, user:, temp:"]
+    end
 
-These five concerns are independent. Setting `.writes("intent")` does not affect what the agent *sees* (context), and setting `.context(C.none())` does not affect where the agent *stores* its output (storage). This orthogonality is what makes pipelines predictable.
+    subgraph "Channel 3: Instruction Templating"
+        CH3["{key} placeholders in instructions<br/>Replaced with state values before LLM call<br/>Bridge between state and prompt"]
+    end
 
-For a deep dive into each concern with diagrams and examples, see [Data Flow](data-flow.md).
+    CH1 -.->|"converge on"| LLM["LLM Prompt"]
+    CH2 -.->|"converge on"| LLM
+    CH3 -.->|"converge on"| LLM
+
+    style CH1 fill:#0ea5e9,color:#fff
+    style CH2 fill:#10b981,color:#fff
+    style CH3 fill:#f59e0b,color:#fff
+    style LLM fill:#e94560,color:#fff
+```
+
+:::{warning}
+These three channels are configured independently but deeply entangled at runtime. A single agent response flows through **all three** simultaneously --- it becomes a conversation event, may be stored in state, and state values may appear in downstream instructions. This duplication is the source of most multi-agent debugging confusion.
+:::
+
+### Example: How Channels Converge
+
+```python
+classifier = Agent("classify").instruct("Classify intent.").writes("intent")
+booker = Agent("booker").instruct("Help book. The intent is: {intent}")
+
+pipeline = classifier >> booker
+```
+
+When `classifier` produces `"booking"`:
+
+| Channel | What Happens | Result |
+|---------|-------------|--------|
+| **1. History** | `"booking"` appended to `session.events` | `booker` sees it in conversation |
+| **2. State** | `state["intent"] = "booking"` via `output_key` | Available for `{intent}` template |
+| **3. Template** | `{intent}` in `booker`'s instruction replaced | Instruction becomes `"Help book. The intent is: booking"` |
+
+The booker's LLM sees `"booking"` **twice**: once in conversation history, once in the instruction. This isn't a bug --- it's three channels converging. adk-fluent's context engineering (C module) helps you control this.
+
+---
+
+## What `include_contents` Actually Does
+
+The binary switch that controls conversation history visibility:
+
+| Value | Behavior | Use Case |
+|-------|----------|----------|
+| `"default"` | Full conversation history (filtered, rearranged) | Conversational agents |
+| `"none"` | Current turn only (latest user/agent message forward) | Stateless utility agents |
+
+:::{warning}
+`include_contents="none"` was designed for stateless utility agents that get all context from state variables. In a pipeline, a downstream agent with `"none"` **loses the user's original message**. Use `.reads()` or `.context(C.from_state(...))` to inject exactly the state keys you need.
+:::
+
+```mermaid
+flowchart LR
+    subgraph "include_contents = 'default'"
+        D1["User msg"] --> D2["Agent A reply"] --> D3["Agent B reply"] --> D4["Agent C sees ALL"]
+    end
+
+    subgraph "include_contents = 'none'"
+        N1["User msg"] --> N2["Agent A reply"] --> N3["Agent B reply"]
+        N3 --> N4["Agent C sees ONLY<br/>Agent B's reply onward"]
+    end
+```
+
+There is no `"user_only"` or `"exclude_agents"` in native ADK. adk-fluent bridges this gap with the **C module**: `C.user_only()`, `C.from_agents()`, `C.window()`, and more. See [Context Engineering](context-engineering.md).
+
+---
+
+## What `output_key` Actually Does
+
+:::{note}
+`output_key` is a **duplication** mechanism, not a **routing** mechanism. It copies the LLM's text response into state under a named key. The original text still exists in conversation history.
+:::
+
+```mermaid
+sequenceDiagram
+    participant LLM as LLM
+    participant E as Event
+    participant H as Conversation History
+    participant St as Session State
+
+    LLM->>E: Response text: "booking"
+    Note over E: event.actions.state_delta<br/>mutated in-place
+    E->>H: Append to session.events<br/>(text in conversation)
+    E->>St: state["intent"] = "booking"<br/>(text in state)
+    Note over H,St: Both writes happen<br/>atomically from same event
+```
+
+Downstream agents get the response through **both** channels. Use `.context(C.none())` or `.reads()` on downstream agents to suppress the conversation channel when you only want structured state data.
+
+---
+
+## The Five Orthogonal Data Flow Concerns
+
+Every data-flow method in adk-fluent maps to exactly one of five concerns. They are fully independent of each other.
+
+| Concern | Method | Controls | When |
+|---------|--------|----------|------|
+| **Context** | `.reads()`, `.context()` | What the agent SEES | Before LLM call |
+| **Input** | `.accepts()` | Schema for tool-mode invocation | At tool-call time |
+| **Output** | `.returns()`, `@ Schema` | Response shape (structured JSON) | During LLM call |
+| **Storage** | `.writes()` | Where response is saved in state | After LLM call |
+| **Contract** | `.produces()`, `.consumes()` | Static annotations for validation | Build time only |
+
+```python
+classifier = (
+    Agent("classifier", "gemini-2.0-flash")
+    .instruct("Classify the user query: {query}")
+    .reads("query")              # CONTEXT: sees state["query"] only
+    .accepts(SearchQuery)        # INPUT:   tool-mode validation
+    .returns(Intent)             # OUTPUT:  structured JSON response
+    .writes("intent")            # STORAGE: save to state["intent"]
+    .produces(Intent)            # CONTRACT: static annotation
+)
+```
+
+:::{seealso}
+[Data Flow](data-flow.md) for detailed diagrams and examples of each concern.
+:::
+
+---
+
+## What the S Module Does
+
+The S module provides pure state transforms that compile to zero-cost `FnAgent` nodes --- no LLM calls, no events, just dict manipulation.
+
+```mermaid
+graph LR
+    A1["Agent A<br/>.writes('findings')"] -->|state| S1["S.pick('findings')"]
+    S1 -->|state| S2["S.rename(findings='input')"]
+    S2 -->|state| A2["Agent B<br/>.reads('input')"]
+
+    style S1 fill:#10b981,color:#fff
+    style S2 fill:#10b981,color:#fff
+```
+
+S transforms operate exclusively on **Channel 2** (session state). They don't touch conversation history or instruction templating. This makes them predictable and composable.
+
+| Transform | Effect | Type |
+|-----------|--------|------|
+| `S.pick(*keys)` | Keep only named keys | Replacement |
+| `S.drop(*keys)` | Remove named keys | Replacement |
+| `S.rename(**mapping)` | Rename keys | Replacement |
+| `S.merge(*keys, into=)` | Combine keys | Delta |
+| `S.transform(key, fn)` | Apply function to value | Delta |
+| `S.compute(**factories)` | Derive new keys | Delta |
+| `S.set(**kv)` | Set explicit values | Delta |
+| `S.default(**kv)` | Fill missing keys | Delta |
+| `S.guard(pred, msg=)` | Assert state invariant | Inspection |
+| `S.log(*keys)` | Debug print | Inspection |
+
+:::{seealso}
+[State Transforms](state-transforms.md) for visual before/after diagrams of each transform.
+:::
+
+---
+
+## What adk-fluent Infers From Topology
+
+The library doesn't just wrap ADK --- it performs three kinds of inference that native ADK requires you to do manually:
+
+### 1. Data contract verification
+
+When you write `.writes("intent")` upstream and `Route("intent")` downstream, the contract checker verifies at build time that the data flow is satisfiable. If you forget `.writes()`, it flags the issue before any LLM call.
+
+### 2. Topology-aware context filtering
+
+The C module provides fine-grained control that ADK's binary `include_contents` switch cannot:
+
+```python
+# Agent sees only the user's messages + last 3 turns
+agent.context(C.user_only() + C.window(n=3))
+
+# Agent sees only state keys, no conversation history
+agent.reads("topic", "constraints")
+```
+
+### 3. Cross-channel coherence analysis
+
+The contract checker warns about common pitfalls:
+
+| Pitfall | What Happens | How to Fix |
+|---------|-------------|------------|
+| Agent B references `{intent}` but no upstream writes `"intent"` | Template resolves to empty string | Add `.writes("intent")` to upstream agent |
+| Agent A has `.writes("intent")` but B has full history | B sees `"booking"` twice (state + conversation) | Add `.reads("intent")` to B |
+| Agent A has no `.writes()` and B has `.context(C.none())` | A's output reaches B through neither channel | Add `.writes()` to A or change B's context |
+
+---
+
+## Native ADK vs adk-fluent
+
+::::{tab-set}
+:::{tab-item} Native ADK
+```python
+from google.adk.agents import LlmAgent, SequentialAgent
+from google.adk.tools import FunctionTool
+
+classifier = LlmAgent(
+    name="classifier",
+    model="gemini-2.5-flash",
+    instruction="Classify the intent.",
+    output_key="intent",
+)
+
+handler = LlmAgent(
+    name="handler",
+    model="gemini-2.5-flash",
+    instruction="Handle the {intent} query.",
+    include_contents="none",
+)
+
+pipeline = SequentialAgent(
+    name="pipeline",
+    sub_agents=[classifier, handler],
+)
+```
+:::
+:::{tab-item} adk-fluent
+```python
+from adk_fluent import Agent
+
+pipeline = (
+    Agent("classifier", "gemini-2.5-flash")
+    .instruct("Classify the intent.")
+    .writes("intent")
+    >> Agent("handler", "gemini-2.5-flash")
+    .instruct("Handle the {intent} query.")
+    .reads("intent")
+).build()
+```
+:::
+::::
+
+Both produce identical ADK objects. The fluent version is shorter, catches typos at definition time, and makes data flow explicit.
+
+---
+
+## When to Use What
+
+```mermaid
+flowchart TD
+    START{What are you building?} -->|"Single agent"| SINGLE["Agent builder<br/><code>Agent('name', 'model')</code>"]
+    START -->|"Multiple agents"| MULTI{How do they interact?}
+
+    MULTI -->|"Run in sequence"| SEQ["Pipeline / >><br/><code>a >> b >> c</code>"]
+    MULTI -->|"Run in parallel"| PAR["FanOut / |<br/><code>a | b | c</code>"]
+    MULTI -->|"Iterate until done"| LOOP["Loop / *<br/><code>(a >> b) * 3</code>"]
+    MULTI -->|"LLM picks the agent"| TRANSFER[".sub_agent()<br/>Transfer routing"]
+    MULTI -->|"Route by state value"| ROUTE["Route<br/><code>Route('key').eq(...)</code>"]
+    MULTI -->|"Try cheaper first"| FALL["Fallback / //<br/><code>fast // strong</code>"]
+
+    style START fill:#e94560,color:#fff
+    style SINGLE fill:#0ea5e9,color:#fff
+    style SEQ fill:#10b981,color:#fff
+    style PAR fill:#0ea5e9,color:#fff
+    style LOOP fill:#f59e0b,color:#fff
+    style TRANSFER fill:#a78bfa,color:#fff
+    style ROUTE fill:#f472b6,color:#fff
+    style FALL fill:#a78bfa,color:#fff
+```
+
+---
+
+## Common Mistakes
+
+::::{grid} 1
+:gutter: 3
+
+:::{grid-item-card} Forgetting `.writes()` before a Route
+:class-card: sd-border-danger
+
+```python
+# ❌ Wrong — Route reads state["intent"] but nobody writes it
+classifier = Agent("classify").instruct("Classify.")
+pipeline = classifier >> Route("intent").eq("booking", booker)
+```
+
+```python
+# ✅ Correct — classifier writes to state
+classifier = Agent("classify").instruct("Classify.").writes("intent")
+pipeline = classifier >> Route("intent").eq("booking", booker)
+```
+:::
+
+:::{grid-item-card} Using full history when you only need state
+:class-card: sd-border-danger
+
+```python
+# ❌ Wrong — handler sees "booking" twice (history + template)
+handler = Agent("handler").instruct("Handle {intent}.")
+```
+
+```python
+# ✅ Correct — suppress history, use only state
+handler = Agent("handler").instruct("Handle {intent}.").reads("intent")
+```
+:::
+
+:::{grid-item-card} Calling `.build()` on sub-builders
+:class-card: sd-border-danger
+
+```python
+# ❌ Wrong — don't build sub-builders manually
+Pipeline("flow")
+    .step(Agent("a").instruct("...").build())  # NO!
+    .build()
+```
+
+```python
+# ✅ Correct — let the parent auto-build children
+Pipeline("flow")
+    .step(Agent("a").instruct("..."))
+    .build()
+```
+:::
+::::
+
+---
+
+## Interplay With Other Concepts
+
+```mermaid
+graph TB
+    ARCH[["Architecture &<br/>Core Concepts"]]
+    EXPR["Expression Language"]
+    DATA["Data Flow"]
+    BUILD["Builders"]
+    PATT["Patterns"]
+    CTX["Context Engineering"]
+    ST["State Transforms"]
+
+    ARCH --> EXPR
+    ARCH --> DATA
+    ARCH --> BUILD
+    EXPR --> PATT
+    DATA --> CTX
+    DATA --> ST
+
+    style ARCH fill:#e65100,color:#fff
+```
+
+| Concept | Relationship |
+|---------|-------------|
+| [Expression Language](expression-language.md) | Operators that compose builders into topologies |
+| [Data Flow](data-flow.md) | The five concerns that control agent I/O |
+| [Builders](builders.md) | The fluent API for configuring agents |
+| [Context Engineering](context-engineering.md) | Fine-grained control over what agents see |
+| [State Transforms](state-transforms.md) | Data manipulation between pipeline steps |
+| [Patterns](patterns.md) | Higher-order constructors for common architectures |
+
+---
+
+## API Quick Reference
+
+| Method | Purpose | Details |
+|--------|---------|---------|
+| `.model(str)` | Set LLM model | [Builders](builders.md) |
+| `.instruct(str \| P)` | System prompt | [Prompts](prompts.md) |
+| `.tool(fn)` | Add tool | [Builders](builders.md) |
+| `.writes(key)` | Store output in state | [Data Flow](data-flow.md) |
+| `.reads(*keys)` | Inject state keys | [Data Flow](data-flow.md) |
+| `.returns(Schema)` | Structured output | [Structured Data](structured-data.md) |
+| `.context(C)` | Context control | [Context Engineering](context-engineering.md) |
+| `.sub_agent(agent)` | Transfer target | [Transfer Control](transfer-control.md) |
+| `.build()` | Compile to ADK | [Builders](builders.md) |
+
+---
+
+:::{seealso}
+- {doc}`expression-language` --- compose agents with operators
+- {doc}`data-flow` --- the five orthogonal data flow concerns
+- {doc}`builders` --- full builder method reference
+- {doc}`../getting-started` --- 5-minute quickstart
+- [ADK Documentation](https://google.github.io/adk-docs/) --- upstream Google ADK docs
+:::

--- a/docs/user-guide/best-practices.md
+++ b/docs/user-guide/best-practices.md
@@ -1,5 +1,13 @@
 # Best Practices & Anti-Patterns
 
+:::{admonition} At a Glance
+:class: tip
+
+- Opinionated guidance: when to use what, anti-patterns to avoid, recommended patterns
+- Rule of thumb: deterministic routing over LLM routing, `.inject()` for infra deps, S transforms for data
+- Each practice is a do/don't pair with code examples
+:::
+
 Nine rules that separate production agents from prototypes. Each rule is shown as an anti-pattern / best-practice pair — copy the green tab, avoid the red one.
 
 :::{admonition} The one-sentence version

--- a/docs/user-guide/builders.md
+++ b/docs/user-guide/builders.md
@@ -1,23 +1,16 @@
 # Builders
 
-Every adk-fluent builder does one thing: it turns a chain of readable method calls into a native ADK object. No subclassing. No boilerplate. No silent misconfiguration.
+:::{admonition} At a Glance
+:class: tip
+
+- Every builder turns fluent method calls into a native ADK object via `.build()`
+- 132 builders across 9 modules, all with IDE autocomplete and typo detection
+- Sub-builders in workflows auto-build --- don't call `.build()` on children
+:::
+
+## Builder vs Native ADK
 
 ::::{tab-set}
-:::{tab-item} Native ADK (22 lines)
-```python
-from google.adk.agents import LlmAgent
-from google.adk.tools import FunctionTool
-
-agent = LlmAgent(
-    name="helper",
-    model="gemini-2.5-flash",
-    instruction="You are a helpful assistant.",
-    description="A general-purpose helper",
-    output_key="response",
-    tools=[FunctionTool(search_fn)],
-)
-```
-:::
 :::{tab-item} adk-fluent (6 lines)
 ```python
 from adk_fluent import Agent
@@ -32,25 +25,67 @@ agent = (
 )
 ```
 :::
+:::{tab-item} Native ADK (10 lines)
+```python
+from google.adk.agents import LlmAgent
+from google.adk.tools import FunctionTool
+
+agent = LlmAgent(
+    name="helper",
+    model="gemini-2.5-flash",
+    instruction="You are a helpful assistant.",
+    description="A general-purpose helper",
+    output_key="response",
+    tools=[FunctionTool(search_fn)],
+)
+```
+:::
 ::::
 
-Both produce the **exact same `LlmAgent`**. The difference: the builder catches typos at definition time, provides IDE autocomplete for every field, and chains naturally.
+Both produce the **exact same `LlmAgent`**. The builder catches typos at definition time, provides IDE autocomplete, and chains naturally.
 
-## Constructor Arguments
+---
 
-Every builder takes a required `name` as the first positional argument. Some builders accept additional optional positional arguments. For example, the `Agent` builder accepts an optional `model` as a second positional argument:
+## Builder Lifecycle
+
+```mermaid
+graph LR
+    I["Instantiate<br/>Agent('name', 'model')"] --> C["Configure<br/>.instruct() .tool() .writes()"]
+    C --> V["Validate (optional)<br/>.validate()"]
+    V --> B["Build<br/>.build()"]
+    B --> ADK["Native ADK Object<br/>LlmAgent / SequentialAgent / ..."]
+
+    style I fill:#e94560,color:#fff
+    style C fill:#0ea5e9,color:#fff
+    style V fill:#f59e0b,color:#fff
+    style B fill:#10b981,color:#fff
+    style ADK fill:#a78bfa,color:#fff
+```
+
+## Quick Start
 
 ```python
 from adk_fluent import Agent
 
+# Minimal agent --- name + model + instruction
+agent = Agent("helper", "gemini-2.5-flash").instruct("You are helpful.").build()
+```
+
+---
+
+## Constructor Arguments
+
+Every builder takes a required `name` as the first positional argument. `Agent` accepts an optional `model` as second:
+
+```python
 # These are equivalent:
 agent = Agent("helper", "gemini-2.5-flash")
 agent = Agent("helper").model("gemini-2.5-flash")
 ```
 
-## Method Chaining (Fluent API)
+## Method Chaining
 
-Every configuration method returns `self`, enabling fluent chaining:
+Every configuration method returns `self`. Methods can be called in **any order**:
 
 ```python
 agent = (
@@ -63,36 +98,80 @@ agent = (
 )
 ```
 
-Methods can be called in any order. Each call records a configuration value that is applied when `.build()` is invoked.
-
-## `.build()` -- Terminal Method
+## `.build()` --- Compile to ADK
 
 `.build()` resolves the builder into a native ADK object:
 
-```python
-from adk_fluent import Agent, Pipeline, FanOut, Loop
+| Builder | ADK Object | Example |
+|---------|-----------|---------|
+| `Agent` | `LlmAgent` | `Agent("x").build()` |
+| `Pipeline` | `SequentialAgent` | `Pipeline("p").step(...).build()` |
+| `FanOut` | `ParallelAgent` | `FanOut("f").branch(...).build()` |
+| `Loop` | `LoopAgent` | `Loop("l").step(...).build()` |
 
-agent = Agent("x", "gemini-2.5-flash").instruct("Help.").build()       # -> LlmAgent
-pipe  = Pipeline("p").step(agent).build()                               # -> SequentialAgent
-fan   = FanOut("f").branch(agent).build()                               # -> ParallelAgent
-loop  = Loop("l").step(agent).max_iterations(3).build()                 # -> LoopAgent
+:::{warning}
+Sub-builders passed to workflow builders are **auto-built**. Do NOT call `.build()` on individual steps:
+```python
+# ❌ Wrong
+Pipeline("p").step(Agent("a").build()).build()
+
+# ✅ Correct
+Pipeline("p").step(Agent("a").instruct("...")).build()
+```
+:::
+
+---
+
+## Builder Taxonomy
+
+```mermaid
+graph TB
+    subgraph "Core Builders"
+        AGENT["Agent<br/>LlmAgent"]
+        PIPE["Pipeline<br/>SequentialAgent"]
+        FAN["FanOut<br/>ParallelAgent"]
+        LOOP["Loop<br/>LoopAgent"]
+    end
+
+    subgraph "Config Builders (38)"
+        CFG["AgentConfig, RunConfig,<br/>ToolConfig, RetryConfig, ..."]
+    end
+
+    subgraph "Tool Builders (51)"
+        TOOL["FunctionTool, AgentTool,<br/>MCPToolset, GoogleSearchTool, ..."]
+    end
+
+    subgraph "Service Builders (15)"
+        SVC["InMemorySessionService,<br/>DatabaseSessionService, ..."]
+    end
+
+    subgraph "Other (28)"
+        OTHER["Executors (5), Planners (3),<br/>Plugins (12), Runtime (3)"]
+    end
+
+    style AGENT fill:#e94560,color:#fff
+    style PIPE fill:#0ea5e9,color:#fff
+    style FAN fill:#0ea5e9,color:#fff
+    style LOOP fill:#0ea5e9,color:#fff
 ```
 
-Sub-builders passed to workflow builders (Pipeline, FanOut, Loop) are automatically built at `.build()` time, so you do not need to call `.build()` on each step individually.
+| Module | Count | Key Builders |
+|--------|-------|-------------|
+| **agent** | 2 | `Agent`, `BaseAgent` |
+| **workflow** | 3 | `Pipeline`, `FanOut`, `Loop` |
+| **tool** | 51 | `FunctionTool`, `AgentTool`, `MCPToolset`, `GoogleSearchTool`, ... |
+| **config** | 38 | `AgentConfig`, `RunConfig`, `ToolConfig`, `RetryConfig`, ... |
+| **service** | 15 | `InMemorySessionService`, `DatabaseSessionService`, ... |
+| **plugin** | 12 | `LoggingPlugin`, `DebugLoggingPlugin`, ... |
+| **executor** | 5 | `BuiltInCodeExecutor`, `VertexAiCodeExecutor`, ... |
+| **planner** | 3 | `BuiltInPlanner`, `PlanReActPlanner`, ... |
+| **runtime** | 3 | `App`, `InMemoryRunner`, `Runner` |
 
-## `__getattr__` Forwarding
-
-Any ADK field that does not have an explicit builder method can still be set through dynamic attribute forwarding:
-
-```python
-agent = Agent("x").generate_content_config(my_config)  # Works via forwarding
-```
-
-The builder inspects the underlying ADK class and forwards the value to the matching field. This means every ADK field is accessible, even if adk-fluent does not define a dedicated method for it.
+---
 
 ## Typo Detection
 
-Misspelled method names raise `AttributeError` with the closest match suggestion:
+Misspelled method names raise `AttributeError` with the closest match:
 
 ```python
 agent = Agent("demo")
@@ -101,132 +180,103 @@ agent.instuction("oops")
 #    Did you mean: 'instruction'?
 ```
 
-Typos are caught at builder definition time, not at runtime, making it easy to spot mistakes early.
+## `__getattr__` Forwarding
 
-## `.explain()` -- Introspection
-
-`.explain()` returns a multi-line summary of the builder's current state:
+Any ADK field without an explicit builder method can still be set through dynamic forwarding:
 
 ```python
-print(Agent("demo").model("gemini-2.5-flash").instruct("Help.").explain())
+agent = Agent("x").generate_content_config(my_config)  # Works via forwarding
+```
+
+---
+
+## Introspection Methods
+
+| Method | Purpose | Returns |
+|--------|---------|---------|
+| `.explain()` | Full builder state summary | Multi-line string |
+| `.validate()` | Early error detection (chainable) | `self` |
+| `.data_flow()` | Five-concern snapshot | Formatted string |
+| `.llm_anatomy()` | What the LLM will see | Formatted string |
+| `.inspect()` | Plain-text state | String |
+| `.diagnose()` | Structured IR diagnosis | Dict |
+| `.doctor()` | Formatted diagnostic report | String |
+| `.to_ir()` | IR tree node | `AgentNode` / `SequenceNode` / ... |
+| `.to_mermaid()` | Mermaid diagram | String |
+
+### `.explain()` Example
+
+```python
+print(Agent("demo", "gemini-2.5-flash").instruct("Help.").writes("response").explain())
 # Agent: demo
-#   Config fields: model, instruction
+#   model: gemini-2.5-flash
+#   instruction: Help.
+#   writes: response
 ```
 
-This is useful for debugging complex builders to verify what configuration has been applied.
+---
 
-## `.validate()` -- Early Error Detection
+## Cloning and Variants
 
-`.validate()` tries to call `.build()` internally and raises a `ValueError` with a clear message if the configuration is invalid. It returns `self` so it can be chained:
+### `.clone(new_name)` --- Deep Copy
 
 ```python
-agent = (
-    Agent("demo")
-    .model("gemini-2.5-flash")
-    .instruct("Help.")
-    .validate()  # Raises ValueError if config is broken
-    .build()
-)
+base = Agent("base", "gemini-2.5-flash").instruct("Be helpful.")
+
+math_agent = base.clone("math").instruct("Solve math.")   # Independent copy
+code_agent = base.clone("code").instruct("Write code.")    # Independent copy
 ```
 
-## `.clone()` and `.with_()` -- Variants
-
-### `.clone(new_name)`
-
-Creates an independent deep copy of the builder with a new name:
+### `.with_(**overrides)` --- Immutable Variant
 
 ```python
-base = Agent("base").model("gemini-2.5-flash").instruct("Be helpful.")
-
-math_agent = base.clone("math").instruct("Solve math.")
-code_agent = base.clone("code").instruct("Write code.")
-```
-
-The cloned builders are fully independent; modifying one does not affect the other or the original.
-
-### `.with_(**overrides)`
-
-Creates an immutable variant. The original builder is not modified:
-
-```python
-base = Agent("base").model("gemini-2.5-flash").instruct("Be helpful.")
-
+base = Agent("base", "gemini-2.5-flash").instruct("Be helpful.")
 creative = base.with_(name="creative", model="gemini-2.5-pro")
 # base is unchanged
 ```
 
-## Serialization
+---
 
-Builders can be serialized to and from dictionaries and YAML:
+## Serialization
 
 ```python
 # Serialize
 data = agent.to_dict()
-yaml_str = agent.to_yaml()
+yaml_str = agent.to_yaml()   # requires adk-fluent[yaml]
 
 # Reconstruct
 agent = Agent.from_dict(data)
 agent = Agent.from_yaml(yaml_str)
 ```
 
-## IR Compilation
+---
 
-Every builder can produce an Intermediate Representation (IR) -- a frozen dataclass tree that decouples the builder from ADK:
+## Dependency Injection
 
-```python
-from adk_fluent import Agent
-
-# Inspect the IR tree
-ir = Agent("helper").model("gemini-2.5-flash").instruct("Help.").to_ir()
-print(ir)  # AgentNode(name='helper', model='gemini-2.5-flash', ...)
-```
-
-### `.to_ir()`
-
-Returns a frozen dataclass IR node. Agent builders return `AgentNode`, pipelines return `SequenceNode`, etc.:
-
-| Builder    | IR Node        |
-| ---------- | -------------- |
-| `Agent`    | `AgentNode`    |
-| `Pipeline` | `SequenceNode` |
-| `FanOut`   | `ParallelNode` |
-| `Loop`     | `LoopNode`     |
-
-### `.to_app(config=None)`
-
-Compiles through IR → ADKBackend → native ADK `App`. An alternative to `.build()` that goes through the full compilation pipeline:
+`.inject()` registers resources injected into tool functions at call time. Injected parameters are **hidden from the LLM schema**:
 
 ```python
-from adk_fluent import Agent, ExecutionConfig
-
-app = Agent("helper").instruct("Help.").to_app(
-    config=ExecutionConfig(app_name="my_app", resumable=True)
+agent = (
+    Agent("lookup")
+    .tool(search_db)       # search_db(query: str, db: Database) -> str
+    .inject(db=my_database)
 )
+# LLM sees: search_db(query: str) -> str
+# At call time: db=my_database injected automatically
 ```
 
-### `.to_mermaid()`
+:::{tip}
+Use `.inject()` for infrastructure dependencies (DB clients, API keys, config objects). Never expose these in the LLM tool schema.
+:::
 
-Generates a Mermaid graph diagram from the builder's IR tree:
-
-```python
-pipeline = Agent("a") >> Agent("b") >> Agent("c")
-print(pipeline.to_mermaid())
-# graph TD
-#     n1[["a_then_b_then_c (sequence)"]]
-#     n2["a"]
-#     n3["b"]
-#     n4["c"]
-#     n2 --> n3
-#     n3 --> n4
-```
+---
 
 ## Data Contracts
 
-`.produces()` and `.consumes()` declare the Pydantic schemas an agent writes to and reads from state:
+`.produces()` and `.consumes()` declare schemas for build-time validation:
 
 ```python
 from pydantic import BaseModel
-from adk_fluent import Agent
 
 class Intent(BaseModel):
     category: str
@@ -235,95 +285,12 @@ class Intent(BaseModel):
 classifier = Agent("classifier").produces(Intent)
 resolver = Agent("resolver").consumes(Intent)
 
-pipeline = classifier >> resolver
+pipeline = classifier >> resolver  # Contract checker verifies compatibility
 ```
 
-The contract annotations are stored on the IR nodes and can be verified with `check_contracts()`. See [Testing](testing.md) for details.
-
-## Dependency Injection
-
-`.inject()` registers resources that are injected into tool functions at call time. Injected parameters are hidden from the LLM schema:
-
-```python
-from adk_fluent import Agent
-
-agent = (
-    Agent("lookup")
-    .tool(search_db)  # search_db(query: str, db: Database) -> str
-    .inject(db=my_database)
-)
-# LLM sees: search_db(query: str) -> str
-# At call time: db=my_database is injected automatically
-```
-
-## Middleware
-
-`.middleware()` attaches app-global middleware. Unlike callbacks (which are per-agent), middleware applies to the entire execution:
-
-```python
-from adk_fluent import Agent, RetryMiddleware
-
-pipeline = (
-    Agent("a") >> Agent("b")
-).middleware(RetryMiddleware(max_iterations=3))
-
-app = pipeline.to_app()  # Middleware compiled into App plugins
-```
-
-See [Middleware](middleware.md) for the full middleware guide.
-
-## Escape Hatches
-
-When the fluent API doesn't expose an ADK feature you need, two escape hatches let you reach the underlying objects directly.
-
-### `.with_raw_config(**kwargs)` -- Declarative
-
-Sets arbitrary attributes on the built ADK object. This is the recommended approach for simple field overrides:
-
-```python
-agent = (
-    Agent("helper", "gemini-2.5-flash")
-    .instruct("You are helpful.")
-    .with_raw_config(
-        disallow_transfer_to_parent=True,
-        include_contents="none",
-    )
-    .build()
-)
-```
-
-If a field name doesn't exist on the ADK object, a warning is raised at build time with suggestions -- the same typo protection as the rest of the builder API.
-
-### `.native(fn)` -- Programmatic
-
-Registers a post-build hook that receives the raw ADK object for direct manipulation:
-
-```python
-def customize(adk_agent):
-    if len(adk_agent.sub_agents) > 3:
-        adk_agent.disallow_transfer_to_peers = True
-
-agent = (
-    Agent("router", "gemini-2.5-flash")
-    .instruct("Route requests.")
-    .sub_agent(a).sub_agent(b).sub_agent(c).sub_agent(d)
-    .native(customize)
-    .build()
-)
-```
-
-Multiple `.native()` calls chain in order. Each hook receives the same object after the previous hook has run.
-
-### When to use which
-
-| Approach | Best for |
-| --- | --- |
-| `.with_raw_config()` | Setting one or more known fields to fixed values |
-| `.native(fn)` | Conditional logic, complex mutations, or inspecting the built object |
+---
 
 ## Workflow Builders
-
-All workflow builders (Pipeline, FanOut, Loop) accept both built ADK agents and fluent builders as arguments. Builders are auto-built at `.build()` time.
 
 ### Pipeline (Sequential)
 
@@ -333,16 +300,11 @@ from adk_fluent import Pipeline, Agent
 pipeline = (
     Pipeline("data_processing")
     .step(Agent("extractor", "gemini-2.5-flash").instruct("Extract entities.").writes("entities"))
-    .step(Agent("enricher", "gemini-2.5-flash").instruct("Enrich {entities}.").tool(lookup_db))
-    .step(Agent("formatter", "gemini-2.5-flash").instruct("Format output.").context(C.none()))
+    .step(Agent("enricher", "gemini-2.5-flash").instruct("Enrich {entities}."))
+    .step(Agent("formatter", "gemini-2.5-flash").instruct("Format output."))
     .build()
 )
 ```
-
-| Method         | Description                                                        |
-| -------------- | ------------------------------------------------------------------ |
-| `.step(agent)` | Append an agent as the next step. Lazy -- built at `.build()` time |
-| `.build()`     | Resolve into a native ADK `SequentialAgent`                        |
 
 ### FanOut (Parallel)
 
@@ -351,16 +313,11 @@ from adk_fluent import FanOut, Agent
 
 fanout = (
     FanOut("research")
-    .branch(Agent("web", "gemini-2.5-flash").instruct("Search the web.").writes("web_results"))
-    .branch(Agent("papers", "gemini-2.5-pro").instruct("Search academic papers.").writes("paper_results"))
+    .branch(Agent("web", "gemini-2.5-flash").instruct("Search web.").writes("web_results"))
+    .branch(Agent("papers", "gemini-2.5-pro").instruct("Search papers.").writes("paper_results"))
     .build()
 )
 ```
-
-| Method           | Description                                                   |
-| ---------------- | ------------------------------------------------------------- |
-| `.branch(agent)` | Add a parallel branch agent. Lazy -- built at `.build()` time |
-| `.build()`       | Resolve into a native ADK `ParallelAgent`                     |
 
 ### Loop
 
@@ -377,53 +334,130 @@ loop = (
 )
 ```
 
-| Method               | Description                                            |
-| -------------------- | ------------------------------------------------------ |
-| `.step(agent)`       | Append a step agent. Lazy -- built at `.build()` time  |
-| `.max_iterations(n)` | Set maximum loop iterations                            |
-| `.until(pred)`       | Set exit predicate. Exits when `pred(state)` is truthy |
-| `.build()`           | Resolve into a native ADK `LoopAgent`                  |
+### Workflow Builder Methods
+
+| Builder | Key Methods | ADK Type |
+|---------|-----------|----------|
+| **Pipeline** | `.step(agent)` | `SequentialAgent` |
+| **FanOut** | `.branch(agent)` | `ParallelAgent` |
+| **Loop** | `.step(agent)`, `.max_iterations(n)`, `.until(pred)` | `LoopAgent` |
+
+---
+
+## Escape Hatches
+
+When the fluent API doesn't expose an ADK feature:
+
+### `.with_raw_config(**kwargs)` --- Declarative
+
+```python
+agent = (
+    Agent("helper", "gemini-2.5-flash")
+    .instruct("Help.")
+    .with_raw_config(disallow_transfer_to_parent=True)
+    .build()
+)
+```
+
+### `.native(fn)` --- Programmatic
+
+```python
+def customize(adk_agent):
+    if len(adk_agent.sub_agents) > 3:
+        adk_agent.disallow_transfer_to_peers = True
+
+agent = Agent("router").native(customize).build()
+```
+
+| Approach | Best For |
+|----------|---------|
+| `.with_raw_config()` | Setting known fields to fixed values |
+| `.native(fn)` | Conditional logic, complex mutations |
+
+---
 
 ## Combining Builder and Operator Styles
 
-The builder and operator styles mix freely. Use builders for complex individual steps and operators for composition:
+Builders and operators mix freely:
 
 ```python
-from adk_fluent import Agent, Pipeline, FanOut, S, until, Prompt
+from adk_fluent import Agent, FanOut, S, until
 
-# Define reusable agents with full builder configuration
+# Complex agents with full builder configuration
 researcher = (
     Agent("researcher", "gemini-2.5-flash")
-    .instruct(Prompt().role("You are a research analyst.").task("Find relevant information."))
+    .instruct("Find relevant information.")
     .tool(search_tool)
-    .before_model(log_fn)
     .writes("findings")
 )
 
-writer = (
-    Agent("writer", "gemini-2.5-pro")
-    .instruct("Write a report about {findings}.")
-    .static("Company style guide: use formal tone, cite sources...")
-    .writes("draft")
-)
+writer = Agent("writer", "gemini-2.5-pro").instruct("Write about {findings}.").writes("draft")
+reviewer = Agent("reviewer", "gemini-2.5-flash").instruct("Score 1-10.").writes("score")
 
-reviewer = (
-    Agent("reviewer", "gemini-2.5-flash")
-    .instruct("Score the draft 1-10 for quality.")
-    .writes("quality_score")
-)
-
-# Compose with operators — each sub-expression is reusable
-research_phase = (
-    FanOut("gather")
-    .branch(researcher.clone("web").tool(web_search))
-    .branch(researcher.clone("papers").tool(paper_search))
-)
-
+# Compose with operators
 pipeline = (
-    research_phase
+    (researcher.clone("web").tool(web_search) | researcher.clone("papers").tool(paper_search))
     >> S.merge("web", "papers", into="findings")
     >> writer
-    >> (reviewer >> writer) * until(lambda s: int(s.get("quality_score", 0)) >= 8, max=3)
+    >> (reviewer >> writer) * until(lambda s: int(s.get("score", 0)) >= 8, max=3)
 )
 ```
+
+---
+
+## Common Mistakes
+
+::::{grid} 1
+:gutter: 3
+
+:::{grid-item-card} Confusing `.instruct()` with `.describe()`
+:class-card: sd-border-danger
+
+```python
+# ❌ .describe() is metadata for routing, NOT sent to the LLM
+agent = Agent("helper").describe("You are a helpful assistant.")
+```
+
+```python
+# ✅ .instruct() sets the system prompt (what the LLM sees)
+agent = Agent("helper").instruct("You are a helpful assistant.")
+# .describe() is for transfer routing metadata
+agent = Agent("helper").instruct("Help users.").describe("General-purpose helper")
+```
+:::
+
+:::{grid-item-card} Missing `.build()` when using outside a workflow
+:class-card: sd-border-danger
+
+```python
+# ❌ Passing a builder where ADK expects an agent
+runner.run(Agent("helper").instruct("Help."))  # Error!
+```
+
+```python
+# ✅ Call .build() to get the native ADK object
+runner.run(Agent("helper").instruct("Help.").build())
+```
+:::
+::::
+
+---
+
+## Interplay With Other Concepts
+
+| Combines With | To Achieve | Example |
+|--------------|-----------|---------|
+| [Expression Language](expression-language.md) | Compose into workflows | `Agent("a") >> Agent("b")` |
+| [Data Flow](data-flow.md) | Explicit I/O contracts | `.writes("k")`, `.reads("k")` |
+| [Presets](presets.md) | Reuse configuration bundles | `.use(production_preset)` |
+| [Callbacks](callbacks.md) | Lifecycle hooks | `.before_model(fn)` |
+| [Middleware](middleware.md) | Cross-cutting concerns | `.middleware(M.retry())` |
+
+---
+
+:::{seealso}
+- {doc}`expression-language` --- compose builders with operators
+- {doc}`data-flow` --- the five data flow concerns
+- {doc}`presets` --- reusable configuration bundles
+- {doc}`../generated/api/index` --- full API reference for all 132 builders
+:::

--- a/docs/user-guide/callbacks.md
+++ b/docs/user-guide/callbacks.md
@@ -1,46 +1,110 @@
 # Callbacks
 
-adk-fluent provides a fluent API for attaching callbacks to agents. All callback methods are **additive** -- multiple calls accumulate handlers, never replace.
+:::{admonition} At a Glance
+:class: tip
 
-## Callback Methods
+- Eight callback methods for hooking into the agent lifecycle (before/after model, agent, tool + error handlers)
+- All callback methods are **additive** --- multiple calls accumulate handlers, never replace
+- Use callbacks for per-agent behavior; use middleware for pipeline-wide concerns
+:::
 
-| Method                | Alias for                 | Description                                                           |
-| --------------------- | ------------------------- | --------------------------------------------------------------------- |
-| `.before_model(fn)`   | `before_model_callback`   | Runs before each LLM call. Receives `(callback_context, llm_request)` |
-| `.after_model(fn)`    | `after_model_callback`    | Runs after each LLM call. Receives `(callback_context, llm_response)` |
-| `.before_agent(fn)`   | `before_agent_callback`   | Runs before agent execution                                           |
-| `.after_agent(fn)`    | `after_agent_callback`    | Runs after agent execution                                            |
-| `.before_tool(fn)`    | `before_tool_callback`    | Runs before each tool call                                            |
-| `.after_tool(fn)`     | `after_tool_callback`     | Runs after each tool call                                             |
-| `.on_model_error(fn)` | `on_model_error_callback` | Handles LLM errors                                                    |
-| `.on_tool_error(fn)`  | `on_tool_error_callback`  | Handles tool errors                                                   |
+## Callback Execution Order
 
-## Additive Semantics
+```mermaid
+sequenceDiagram
+    participant BA as before_agent
+    participant BM as before_model
+    participant LLM as LLM Call
+    participant AM as after_model
+    participant BT as before_tool
+    participant Tool as Tool Call
+    participant AT as after_tool
+    participant AA as after_agent
 
-Each call appends to the list of handlers for that callback type. This is different from native ADK where setting a callback replaces the previous one:
+    BA->>BM: Agent starts
+    BM->>LLM: Pre-process request
+    LLM->>AM: Response received
+    Note over AM: Guards run here<br/>(via .guard())
+    AM->>BT: Tool call needed?
+    BT->>Tool: Execute tool
+    Tool->>AT: Tool result
+    AT->>BM: Another LLM call?
+    BM->>LLM: (loop continues)
+    LLM->>AM: Final response
+    AM->>AA: Agent completes
+```
+
+---
+
+## All Eight Callback Methods
+
+| Method | ADK Field | Timing | Receives |
+|--------|----------|--------|----------|
+| `.before_agent(fn)` | `before_agent_callback` | Before agent execution | `(callback_context,)` |
+| `.after_agent(fn)` | `after_agent_callback` | After agent execution | `(callback_context,)` |
+| `.before_model(fn)` | `before_model_callback` | Before each LLM call | `(callback_context, llm_request)` |
+| `.after_model(fn)` | `after_model_callback` | After each LLM call | `(callback_context, llm_response)` |
+| `.before_tool(fn)` | `before_tool_callback` | Before each tool call | `(callback_context, tool_call)` |
+| `.after_tool(fn)` | `after_tool_callback` | After each tool call | `(callback_context, tool_result)` |
+| `.on_model_error(fn)` | `on_model_error_callback` | On LLM failure | `(callback_context, error)` |
+| `.on_tool_error(fn)` | `on_tool_error_callback` | On tool failure | `(callback_context, error)` |
+
+---
+
+## Quick Start
 
 ```python
 from adk_fluent import Agent
 
-def log_fn(ctx, req):
-    print(f"Request: {req}")
+def log_request(ctx, req):
+    print(f"[LOG] LLM request for {ctx.agent_name}")
 
-def metrics_fn(ctx, req):
-    print(f"Metrics: {req}")
-
-# Both handlers run before every LLM call
 agent = (
-    Agent("service", "gemini-2.5-flash")
-    .instruct("Handle requests.")
-    .before_model(log_fn)
-    .before_model(metrics_fn)
+    Agent("helper", "gemini-2.5-flash")
+    .instruct("Help the user.")
+    .before_model(log_request)
     .build()
 )
 ```
 
+---
+
+## Additive Semantics
+
+Each call **appends** to the handler list. This differs from native ADK where setting a callback replaces the previous one:
+
+```mermaid
+graph LR
+    subgraph "adk-fluent (additive)"
+        A1[".before_model(log)"] --> A2[".before_model(metrics)"]
+        A2 --> A3["Both run"]
+    end
+
+    subgraph "Native ADK (replacement)"
+        N1["before_model = log"] --> N2["before_model = metrics"]
+        N2 --> N3["Only metrics runs"]
+    end
+
+    style A3 fill:#10b981,color:#fff
+    style N3 fill:#e94560,color:#fff
+```
+
+```python
+# Both handlers run before every LLM call
+agent = (
+    Agent("service", "gemini-2.5-flash")
+    .instruct("Handle requests.")
+    .before_model(log_fn)       # Handler 1
+    .before_model(metrics_fn)   # Handler 2 (stacks, doesn't replace)
+    .build()
+)
+```
+
+---
+
 ## Conditional Callbacks
 
-Conditional variants append only when the condition is true:
+Append only when a condition is true:
 
 ```python
 debug_mode = True
@@ -55,52 +119,29 @@ agent = (
 )
 ```
 
-This is useful for toggling callbacks based on environment variables or feature flags without cluttering your code with if-else blocks.
+---
 
-## Guards
+## Guards as Callbacks
 
-`.guard(fn)` is a shorthand that registers the function as both `before_model` and `after_model`:
-
-```python
-def safety_check(ctx, data):
-    # Runs both before and after model calls
-    if "dangerous" in str(data):
-        raise ValueError("Safety violation detected")
-
-agent = (
-    Agent("service", "gemini-2.5-flash")
-    .instruct("Handle requests.")
-    .guard(safety_check)
-    .build()
-)
-```
-
-## Middleware Stacks with `.apply()`
-
-For agents that need multiple layers of callbacks, use Presets to bundle them into reusable middleware stacks:
+`.guard(fn)` registers a function as an `after_model` callback for output validation. The G module provides structured, composable guards:
 
 ```python
-from adk_fluent.presets import Preset
+from adk_fluent import Agent, G
 
-# Define reusable middleware
-logging_preset = Preset(before_model=log_fn, after_model=log_response_fn)
-security_preset = Preset(before_model=safety_check, after_model=audit_fn)
+# G module: declarative, composable
+agent = Agent("safe").guard(G.pii("redact") | G.length(max=500))
 
-# Apply multiple presets
-agent = (
-    Agent("service", "gemini-2.5-flash")
-    .instruct("Handle requests.")
-    .use(logging_preset)
-    .use(security_preset)
-    .build()
-)
+# Raw callback: custom validation logic
+agent = Agent("custom").after_model(my_validation_fn)
 ```
 
-See [Presets](presets.md) for more on reusable configuration bundles.
+:::{seealso}
+{doc}`guards` for the full G module reference.
+:::
+
+---
 
 ## Error Handling
-
-Error callbacks handle failures in LLM calls and tool executions:
 
 ```python
 def handle_model_error(ctx, error):
@@ -109,18 +150,18 @@ def handle_model_error(ctx, error):
 
 def handle_tool_error(ctx, error):
     print(f"Tool error: {error}")
-    # Optionally return a fallback result
 
 agent = (
     Agent("service", "gemini-2.5-flash")
-    .instruct("Handle requests.")
     .on_model_error(handle_model_error)
     .on_tool_error(handle_tool_error)
     .build()
 )
 ```
 
-## Complete Example
+---
+
+## Full Example: Production Agent
 
 ```python
 from adk_fluent import Agent
@@ -141,109 +182,146 @@ def audit_tool(ctx, result):
 agent = (
     Agent("production_agent", "gemini-2.5-flash")
     .instruct("You are a production service.")
-    .before_model(log_request)
-    .after_model(log_response)
-    .after_model(validate_output)
-    .before_tool(lambda ctx, tool: print(f"Calling tool: {tool}"))
-    .after_tool(audit_tool)
+    .before_model(log_request)              # Logging
+    .after_model(log_response)              # Logging
+    .after_model(validate_output)           # Validation (stacks with above)
+    .before_tool(lambda ctx, tool: print(f"Calling: {tool}"))
+    .after_tool(audit_tool)                 # Audit
     .on_model_error(lambda ctx, e: print(f"Error: {e}"))
     .build()
 )
 ```
 
-## Callbacks vs. Middleware
+---
 
-Callbacks are **per-agent** -- they apply only to the agent they're attached to. For cross-cutting concerns that should apply to the entire execution (all agents in a pipeline), use **middleware** instead.
+## Callbacks vs Middleware vs Guards
 
-| Aspect       | Callbacks           | Middleware                      |
-| ------------ | ------------------- | ------------------------------- |
-| Scope        | Single agent        | Entire execution                |
-| Attachment   | `.before_model(fn)` | `.middleware(mw)`               |
-| Multiplicity | Multiple per agent  | Stack of middleware on pipeline |
-| Compilation  | Stored on IR node   | Stored in ExecutionConfig       |
+```mermaid
+flowchart TD
+    Q1{"What's the scope?"} -->|"One agent"| Q2{"What kind of logic?"}
+    Q1 -->|"All agents in pipeline"| MW["Middleware<br/>M.retry() | M.log()"]
+    Q2 -->|"Validate/block output"| GUARD["Guard<br/>G.pii() | G.length()"]
+    Q2 -->|"Log, transform, audit"| CB["Callback<br/>.before_model(fn)"]
 
-```python
-# Per-agent callback: only affects this agent
-agent = Agent("a").before_model(log_fn)
-
-# App-global middleware: affects all agents in the pipeline
-from adk_fluent import RetryMiddleware
-pipeline = (Agent("a") >> Agent("b")).middleware(RetryMiddleware())
+    style MW fill:#64748b,color:#fff
+    style GUARD fill:#f472b6,color:#fff
+    style CB fill:#0ea5e9,color:#fff
 ```
 
-See [Middleware](middleware.md) for the full middleware guide.
+| Aspect | Callbacks | Middleware | Guards |
+|--------|-----------|-----------|--------|
+| **Scope** | Single agent | Entire pipeline | Single agent (output) |
+| **Attachment** | `.before_model(fn)` | `.middleware(mw)` | `.guard(G.xxx())` |
+| **Purpose** | Logging, transforms, audit | Retry, cost tracking, circuit breaker | Safety, validation, PII |
+| **Multiplicity** | Multiple per agent | Stack on pipeline | Chain with `\|` |
+| **Compilation** | Stored on IR node | Stored in ExecutionConfig | Compiles to `after_model` |
 
-## Interplay with Other Modules
+---
 
-### Callbacks + Guards
+## Reusable Callback Bundles with Presets
 
-`.guard(fn)` registers a function as both `before_model` and `after_model`. The G module provides structured guards that compile to callbacks automatically. Prefer G for safety/validation, raw callbacks for custom logic:
-
-```python
-from adk_fluent import Agent, G
-
-# G module: declarative, composable, phase-aware
-agent = Agent("safe").guard(G.pii("redact") | G.length(max=500))
-
-# Raw callback: custom logic that doesn't fit G
-agent = Agent("custom").before_model(my_custom_check)
-```
-
-See [Guards](guards.md).
-
-### Callbacks + Presets
-
-Bundle callbacks into reusable Presets to avoid repetition across agents:
+Bundle callbacks into reusable Presets to avoid repetition:
 
 ```python
 from adk_fluent.presets import Preset
 
 observability = Preset(before_model=log_fn, after_model=metrics_fn)
-agent_a = Agent("a").use(observability)
-agent_b = Agent("b").use(observability)
+security = Preset(before_model=safety_check, after_model=audit_fn)
+
+# Apply to multiple agents
+agent_a = Agent("a").use(observability).use(security)
+agent_b = Agent("b").use(observability).use(security)
 ```
 
-See [Presets](presets.md).
+:::{seealso}
+{doc}`presets` for reusable configuration bundles.
+:::
 
-### Callbacks + Context Engineering
+---
 
-Callbacks run *after* context engineering. The LLM request that `before_model` receives already has context filtering applied:
+## Callback Timing With Context Engineering
+
+Callbacks run **after** context engineering. The LLM request that `before_model` receives already has context filtering applied:
+
+```mermaid
+graph LR
+    CTX["Context Engineering<br/>C.window(3)"] --> BM["before_model(fn)<br/>Sees filtered request"]
+    BM --> LLM["LLM Call"]
+    LLM --> AM["after_model(fn)<br/>Sees raw response"]
+
+    style CTX fill:#0ea5e9,color:#fff
+    style BM fill:#f59e0b,color:#fff
+    style AM fill:#f59e0b,color:#fff
+```
+
+---
+
+## Common Mistakes
+
+::::{grid} 1
+:gutter: 3
+
+:::{grid-item-card} Using callbacks for pipeline-wide concerns
+:class-card: sd-border-danger
 
 ```python
-from adk_fluent import Agent, C
-
-agent = (
-    Agent("classifier")
-    .context(C.none())            # Context filtered first
-    .before_model(log_request)    # Sees the filtered request
-)
+# ❌ Repeating the same callback on every agent
+agent_a = Agent("a").before_model(log_fn)
+agent_b = Agent("b").before_model(log_fn)
+agent_c = Agent("c").before_model(log_fn)
 ```
-
-See [Context Engineering](context-engineering.md).
-
-### Callbacks + Testing
-
-Test that callbacks are attached correctly by inspecting the IR:
 
 ```python
-ir = agent.to_ir()
-assert ir.before_model_callbacks  # Callbacks preserved in IR
+# ✅ Use middleware for pipeline-wide concerns
+pipeline = (Agent("a") >> Agent("b") >> Agent("c")).middleware(M.log())
+```
+:::
+
+:::{grid-item-card} Side effects in callbacks
+:class-card: sd-border-danger
+
+```python
+# ❌ Heavy side effects make testing hard
+def before_model(ctx, req):
+    db.insert(req)                 # DB write in callback
+    external_api.notify(req)       # API call in callback
 ```
 
-See [Testing](testing.md).
+```python
+# ✅ Keep callbacks light: log, validate, transform
+def before_model(ctx, req):
+    logger.info(f"Request: {req}")  # Log only
+```
+:::
+::::
+
+---
+
+## Interplay With Other Concepts
+
+| Combines With | To Achieve | Example |
+|--------------|-----------|---------|
+| [Guards](guards.md) | Structured output validation | `.guard(G.pii() \| G.length(max=500))` |
+| [Middleware](middleware.md) | Pipeline-wide concerns | `.middleware(M.retry() \| M.log())` |
+| [Presets](presets.md) | Reusable callback bundles | `.use(observability_preset)` |
+| [Context Engineering](context-engineering.md) | Context runs before callbacks | `.context(C.none()).before_model(fn)` |
+| [Testing](testing.md) | Verify callbacks in IR | `assert ir.before_model_callbacks` |
+
+---
 
 ## Best Practices
 
-1. **Use callbacks for agent-specific behavior.** Logging one agent's requests? Callback. Logging all agents? Middleware
-2. **Use additive semantics intentionally.** Multiple `.before_model()` calls accumulate. If you want to replace, build a new agent
-3. **Use `.guard()` for safety, not `.before_model()`.** Guards are semantically clearer and compose with the G module
-4. **Use Presets for shared callbacks.** Don't repeat the same `.before_model().after_model()` chain on 10 agents
-5. **Keep callbacks pure.** Side effects (DB writes, API calls) in callbacks make testing hard. Log, validate, or transform -- don't orchestrate
+1. **Callbacks for per-agent behavior.** Logging one agent? Callback. Logging all? Middleware.
+2. **Use additive semantics intentionally.** Multiple `.before_model()` calls stack.
+3. **Use `.guard()` for safety.** Guards are semantically clearer than raw `after_model` callbacks.
+4. **Use Presets for shared callbacks.** Don't repeat `.before_model().after_model()` on 10 agents.
+5. **Keep callbacks pure.** Log, validate, or transform --- don't orchestrate.
+
+---
 
 :::{seealso}
-- [Middleware](middleware.md) -- pipeline-wide cross-cutting concerns
-- [Presets](presets.md) -- reusable callback bundles
-- [Guards](guards.md) -- structured safety with the G module
-- [Testing](testing.md) -- verifying callbacks are attached correctly
-- [Best Practices](best-practices.md) -- the "Callbacks vs. Middleware" decision tree
+- {doc}`middleware` --- pipeline-wide cross-cutting concerns
+- {doc}`presets` --- reusable callback bundles
+- {doc}`guards` --- structured safety with the G module
+- {doc}`testing` --- verifying callbacks are attached correctly
 :::

--- a/docs/user-guide/cheat-sheet.md
+++ b/docs/user-guide/cheat-sheet.md
@@ -1,0 +1,214 @@
+# Cheat Sheet
+
+:::{admonition} At a Glance
+:class: tip
+
+- One-page quick reference for all operators, modules, and key methods
+- Print this page and pin it to your monitor
+- Every entry links to its full documentation
+:::
+
+## Expression Operators
+
+| Operator | Meaning | Result | Example |
+|----------|---------|--------|---------|
+| `>>` | Sequence | `SequentialAgent` | `a >> b >> c` |
+| `>> fn` | Function step | `FnAgent` | `a >> my_func >> b` |
+| `\|` | Parallel | `ParallelAgent` | `a \| b \| c` |
+| `* n` | Loop (fixed) | `LoopAgent` | `(a >> b) * 3` |
+| `* until(pred)` | Loop (conditional) | `LoopAgent` | `(a >> b) * until(pred, max=5)` |
+| `@` | Typed output | `output_schema` | `a @ MyModel` |
+| `//` | Fallback | First success | `fast // strong` |
+| `Route(key)` | Deterministic branch | Custom | `Route("k").eq("v", agent)` |
+
+## Agent Builder --- Core Methods
+
+| Method | Purpose | ADK Field |
+|--------|---------|-----------|
+| `.model(str)` | Set LLM model | `model` |
+| `.instruct(str \| P)` | System prompt | `instruction` |
+| `.describe(str)` | Metadata (NOT sent to LLM) | `description` |
+| `.static(str)` | Cached instruction (enables context caching) | `instruction` → system |
+| `.tool(fn)` | Add a tool | `tools` |
+| `.tools(list \| T)` | Set/replace all tools | `tools` |
+| `.build()` | Compile to native ADK object | --- |
+
+## Agent Builder --- Data Flow
+
+| Method | Concern | Effect |
+|--------|---------|--------|
+| `.reads(*keys)` | Context | Inject state keys, suppress history |
+| `.context(C)` | Context | Fine-grained history control |
+| `.accepts(Schema)` | Input | Tool-mode input validation |
+| `.returns(Schema)` | Output | Constrain to structured JSON |
+| `.writes(key)` | Storage | Store response in state |
+| `.produces(Schema)` | Contract | Static annotation (no runtime effect) |
+| `.consumes(Schema)` | Contract | Static annotation (no runtime effect) |
+
+## Agent Builder --- Flow Control
+
+| Method | Purpose |
+|--------|---------|
+| `.sub_agent(agent)` | Add transfer target (LLM decides when) |
+| `.agent_tool(agent)` | Wrap agent as tool (parent stays in control) |
+| `.isolate()` | Prevent all transfers (most predictable) |
+| `.stay()` | Prevent transfer to parent |
+| `.no_peers()` | Prevent transfer to siblings |
+| `.loop_until(pred, max=)` | Loop while predicate is false |
+| `.proceed_if(pred)` | Skip if predicate is false |
+| `.timeout(seconds)` | Wrap with time limit |
+
+## Agent Builder --- Callbacks
+
+| Method | Timing |
+|--------|--------|
+| `.before_agent(fn)` | Before agent execution |
+| `.after_agent(fn)` | After agent execution |
+| `.before_model(fn)` | Before each LLM call |
+| `.after_model(fn)` | After each LLM call |
+| `.before_tool(fn)` | Before each tool call |
+| `.after_tool(fn)` | After each tool call |
+| `.guard(fn \| G)` | Output validation (after_model) |
+| `.on_model_error(fn)` | LLM error handler |
+| `.on_tool_error(fn)` | Tool error handler |
+
+## Agent Builder --- Execution
+
+| Method | Mode | Async? |
+|--------|------|--------|
+| `.build()` | Compile to ADK | No |
+| `.ask(prompt)` | One-shot sync | No |
+| `.ask_async(prompt)` | One-shot async | Yes |
+| `.stream(prompt)` | Streaming iterator | Yes |
+| `.events(prompt)` | Raw ADK events | Yes |
+| `.session()` | Multi-turn chat | Yes (context manager) |
+| `.map(prompts)` | Batch sync | No |
+| `.map_async(prompts)` | Batch async | Yes |
+| `.test(prompt, contains=)` | Smoke test | No |
+| `.mock(responses)` | Replace LLM | No |
+
+## Agent Builder --- Introspection
+
+| Method | Returns |
+|--------|---------|
+| `.explain()` | Full builder state summary |
+| `.validate()` | Early error detection (chainable) |
+| `.data_flow()` | Five-concern snapshot |
+| `.llm_anatomy()` | What the LLM sees |
+| `.to_ir()` | IR tree node |
+| `.to_mermaid()` | Mermaid diagram |
+| `.clone(name)` | Deep copy with new name |
+| `.with_(**overrides)` | Immutable variant |
+
+## S --- State Transforms
+
+| Factory | Effect | Type |
+|---------|--------|------|
+| `S.pick(*keys)` | Keep only named keys | Replacement |
+| `S.drop(*keys)` | Remove named keys | Replacement |
+| `S.rename(**kw)` | Rename keys | Replacement |
+| `S.set(**kv)` | Set values | Delta |
+| `S.default(**kv)` | Fill missing keys | Delta |
+| `S.merge(*keys, into=)` | Combine keys | Delta |
+| `S.transform(key, fn)` | Apply function | Delta |
+| `S.compute(**fns)` | Derive new keys | Delta |
+| `S.guard(pred)` | Assert invariant | Inspection |
+| `S.log(*keys)` | Debug print | Inspection |
+
+Compose: `>>` (chain), `+` (combine)
+
+## C --- Context Engineering
+
+| Factory | LLM Sees |
+|---------|----------|
+| `C.default()` | All history |
+| `C.none()` | Instruction only |
+| `C.user_only()` | User messages only |
+| `C.window(n=)` | Last N turn-pairs |
+| `C.from_state(*keys)` | Named state keys |
+| `C.from_agents(*names)` | User + named agents |
+| `C.exclude_agents(*names)` | Everything except named |
+| `C.template(str)` | Rendered template |
+| `C.budget(max_tokens=)` | Token-limited |
+| `C.summarize()` | LLM-summarized |
+
+Compose: `+` (union), `|` (pipe)
+
+## P --- Prompt Composition
+
+| Factory | Section |
+|---------|---------|
+| `P.role(text)` | Agent persona |
+| `P.context(text)` | Background |
+| `P.task(text)` | Primary objective |
+| `P.constraint(*rules)` | Rules |
+| `P.format(text)` | Output format |
+| `P.example(input=, output=)` | Few-shot |
+| `P.section(name, text)` | Custom section |
+| `P.when(pred, block)` | Conditional |
+| `P.from_state(*keys)` | Dynamic state |
+| `P.template(text)` | Placeholders |
+
+Compose: `+` (union), `|` (pipe). Order: role → context → task → constraint → format → example.
+
+## M --- Middleware
+
+| Factory | Purpose |
+|---------|---------|
+| `M.retry(max_attempts=)` | Retry with backoff |
+| `M.log()` | Structured logging |
+| `M.cost()` | Token usage tracking |
+| `M.latency()` | Per-agent latency |
+| `M.circuit_breaker(max_fails=)` | Circuit breaker |
+| `M.timeout(seconds)` | Per-agent timeout |
+| `M.cache(ttl=)` | Response caching |
+| `M.fallback_model(model)` | Fallback model |
+
+Compose: `|` (chain)
+
+## T --- Tool Composition
+
+| Factory | Purpose |
+|---------|---------|
+| `T.fn(callable)` | Wrap function |
+| `T.agent(agent)` | Wrap agent as tool |
+| `T.google_search()` | Google Search |
+| `T.mcp(server)` | MCP server |
+| `T.openapi(spec)` | OpenAPI spec |
+| `T.mock(responses)` | Mock tool |
+| `T.confirm(prompt=)` | Human confirmation |
+| `T.timeout(seconds)` | Tool timeout |
+
+Compose: `|` (chain)
+
+## G --- Guards
+
+| Factory | Purpose |
+|---------|---------|
+| `G.pii(detector=)` | PII detection/redaction |
+| `G.toxicity(threshold=)` | Content safety |
+| `G.length(max=)` | Max response length |
+| `G.schema(model)` | Validate against Pydantic |
+| `G.guard(fn)` | Custom guard function |
+
+Compose: `|` (chain)
+
+## Composition Patterns
+
+| Pattern | Equivalent | Use Case |
+|---------|-----------|----------|
+| `review_loop(worker, reviewer)` | `(w >> r) * until(...)` | Iterative refinement |
+| `cascade(a, b, c)` | `a // b // c` | Cost-optimized fallback |
+| `fan_out_merge(*agents)` | `(a \| b) >> S.merge(...)` | Parallel + combine |
+| `chain(*agents)` | `a >> b >> c` | Sequential with wiring |
+| `conditional(pred, a, b)` | `gate(pred)` | If/else branching |
+| `supervised(worker, supervisor)` | `(w >> s) * until(approved)` | Approval workflow |
+| `map_reduce(mapper, reducer)` | `map_over(key)` | Process list items |
+
+---
+
+:::{seealso}
+- {doc}`concept-map` --- visual map of all concepts
+- {doc}`glossary` --- term definitions
+- {doc}`../generated/api/index` --- full API reference
+:::

--- a/docs/user-guide/comparison.md
+++ b/docs/user-guide/comparison.md
@@ -1,5 +1,13 @@
 # Framework Comparison
 
+:::{admonition} At a Glance
+:class: tip
+
+- adk-fluent vs LangGraph vs CrewAI vs native ADK --- feature matrix and pattern comparison
+- adk-fluent produces native ADK objects; other frameworks have their own runtimes
+- Key differentiator: expression operators + auto-generated builders + zero runtime overhead
+:::
+
 adk-fluent produces **native ADK objects** — not a wrapper, not a new runtime, not a competing framework. Every `.build()` returns the same `LlmAgent`, `SequentialAgent`, or `ParallelAgent` you'd create by hand. The difference is how you get there.
 
 :::{admonition} The key differentiator

--- a/docs/user-guide/concept-map.md
+++ b/docs/user-guide/concept-map.md
@@ -1,0 +1,204 @@
+# Concept Map
+
+:::{admonition} At a Glance
+:class: tip
+
+- Single-page visual map of ALL adk-fluent concepts and how they relate
+- Start anywhere --- follow arrows to discover related concepts
+- Every box links to its dedicated documentation page
+:::
+
+## The Full Picture
+
+```mermaid
+graph TB
+    %% Core
+    AGENT[["Agent Builder<br/><i>The starting point</i>"]]
+    BUILD[".build()<br/>Compile to ADK"]
+
+    %% Composition
+    EXPR["Expression Language<br/>>>, |, *, @, //"]
+    PIPE["Pipeline >>"]
+    FAN["FanOut |"]
+    LOOP["Loop *"]
+    ROUTE["Route(key)"]
+    FALL["Fallback //"]
+
+    %% Data Flow
+    DATA["Data Flow<br/>5 orthogonal concerns"]
+    WRITES[".writes(key)"]
+    READS[".reads(*keys)"]
+    RETURNS[".returns(Schema)"]
+    ACCEPTS[".accepts(Schema)"]
+
+    %% Modules
+    S_MOD["S — State Transforms<br/>S.pick, S.merge, S.rename"]
+    C_MOD["C — Context Engineering<br/>C.none, C.window, C.from_state"]
+    P_MOD["P — Prompt Composition<br/>P.role, P.task, P.constraint"]
+    T_MOD["T — Tool Composition<br/>T.fn, T.agent, T.mcp"]
+    M_MOD["M — Middleware<br/>M.retry, M.log, M.cost"]
+    G_MOD["G — Guards<br/>G.pii, G.length, G.schema"]
+    E_MOD["E — Evaluation<br/>E.case, EvalSuite"]
+    A_MOD["A — Artifacts<br/>A.publish, A.snapshot"]
+    UI_MOD["UI — Agent-to-UI<br/>UI.text, UI.button"]
+
+    %% Quality
+    CALLBACKS["Callbacks<br/>before/after model/agent/tool"]
+    PRESETS["Presets<br/>Reusable config bundles"]
+    TESTING["Testing<br/>contracts, mocks, harness"]
+
+    %% Patterns
+    PATTERNS["Composition Patterns<br/>review_loop, cascade, map_reduce"]
+
+    %% Infrastructure
+    IR["IR Tree<br/>Intermediate Representation"]
+    BACKENDS["Execution Backends<br/>ADK, Temporal, asyncio"]
+    MEMORY["Memory<br/>Persistent state"]
+    TRANSFER["Transfer Control<br/>sub_agent, isolate, stay"]
+
+    %% Advanced
+    A2A["A2A<br/>Remote agents"]
+    A2UI["A2UI<br/>Declarative UI"]
+    SKILLS["Skills<br/>Composable packages"]
+
+    %% Connections
+    AGENT --> BUILD
+    AGENT --> EXPR
+    AGENT --> DATA
+    AGENT --> CALLBACKS
+    AGENT --> PRESETS
+
+    EXPR --> PIPE
+    EXPR --> FAN
+    EXPR --> LOOP
+    EXPR --> ROUTE
+    EXPR --> FALL
+    EXPR --> PATTERNS
+
+    DATA --> WRITES
+    DATA --> READS
+    DATA --> RETURNS
+    DATA --> ACCEPTS
+
+    READS --> C_MOD
+    WRITES --> S_MOD
+    AGENT --> P_MOD
+    AGENT --> T_MOD
+    AGENT --> G_MOD
+
+    CALLBACKS --> M_MOD
+    TESTING --> E_MOD
+    AGENT --> A_MOD
+
+    BUILD --> IR
+    IR --> BACKENDS
+    AGENT --> MEMORY
+    AGENT --> TRANSFER
+
+    TRANSFER --> A2A
+    AGENT --> A2UI
+    AGENT --> SKILLS
+    UI_MOD --> A2UI
+
+    %% Styling
+    style AGENT fill:#e65100,color:#fff
+    style EXPR fill:#e94560,color:#fff
+    style DATA fill:#0ea5e9,color:#fff
+    style S_MOD fill:#10b981,color:#fff
+    style C_MOD fill:#0ea5e9,color:#fff
+    style P_MOD fill:#e94560,color:#fff
+    style T_MOD fill:#06b6d4,color:#fff
+    style M_MOD fill:#64748b,color:#fff
+    style G_MOD fill:#f472b6,color:#fff
+    style E_MOD fill:#a78bfa,color:#fff
+    style A_MOD fill:#f59e0b,color:#fff
+    style UI_MOD fill:#8b5cf6,color:#fff
+    style PATTERNS fill:#e94560,color:#fff
+    style CALLBACKS fill:#f59e0b,color:#fff
+    style IR fill:#64748b,color:#fff
+    style BACKENDS fill:#64748b,color:#fff
+```
+
+---
+
+## Concept Directory
+
+### Foundations
+
+| Concept | Page | One-line summary |
+|---------|------|-----------------|
+| Architecture | {doc}`architecture-and-concepts` | How builders wrap ADK, the three channels |
+| Expression Language | {doc}`expression-language` | Nine operators for composing agent topologies |
+| Builders | {doc}`builders` | Fluent API for configuring agents |
+| Data Flow | {doc}`data-flow` | Five orthogonal concerns: context, input, output, storage, contract |
+
+### Composition & Data
+
+| Concept | Page | One-line summary |
+|---------|------|-----------------|
+| Patterns | {doc}`patterns` | Higher-order constructors (review_loop, cascade, ...) |
+| State Transforms | {doc}`state-transforms` | S module: manipulate state between agents |
+| Context Engineering | {doc}`context-engineering` | C module: control what agents see |
+| Prompts | {doc}`prompts` | P module: structured prompt composition |
+
+### Quality & Lifecycle
+
+| Concept | Page | One-line summary |
+|---------|------|-----------------|
+| Callbacks | {doc}`callbacks` | Lifecycle hooks (before/after model, agent, tool) |
+| Guards | {doc}`guards` | G module: output validation (PII, length, schema) |
+| Middleware | {doc}`middleware` | M module: pipeline-wide retry, logging, cost tracking |
+| Testing | {doc}`testing` | Contract checks, mocks, evaluation |
+| Evaluation | {doc}`evaluation` | E module: quality scoring and regression testing |
+
+### Infrastructure
+
+| Concept | Page | One-line summary |
+|---------|------|-----------------|
+| Presets | {doc}`presets` | Reusable configuration bundles |
+| Transfer Control | {doc}`transfer-control` | Sub-agents, isolation, transfer routing |
+| Memory | {doc}`memory` | Persistent state across sessions |
+| IR & Backends | {doc}`ir-and-backends` | Intermediate representation and compilation |
+| Execution Backends | {doc}`execution-backends` | ADK vs Temporal vs asyncio |
+| Visibility | {doc}`visibility` | Topology visibility control |
+
+### Advanced
+
+| Concept | Page | One-line summary |
+|---------|------|-----------------|
+| A2A | {doc}`a2a` | Remote agent-to-agent communication |
+| A2UI | {doc}`a2ui` | Declarative UI composition |
+| Skills | {doc}`skills` | Composable agent packages |
+| Structured Data | {doc}`structured-data` | Schema validation and contracts |
+
+---
+
+## Learning Paths
+
+```mermaid
+flowchart LR
+    subgraph "Beginner (30 min)"
+        B1["Architecture"] --> B2["Builders"] --> B3["Expression Language"]
+    end
+
+    subgraph "Intermediate (2 hr)"
+        I1["Data Flow"] --> I2["State Transforms"] --> I3["Context Engineering"]
+        I3 --> I4["Patterns"]
+    end
+
+    subgraph "Advanced (4 hr)"
+        A1["Callbacks"] --> A2["Middleware"] --> A3["Guards"]
+        A3 --> A4["Testing"] --> A5["Evaluation"]
+    end
+
+    B3 --> I1
+    I4 --> A1
+```
+
+---
+
+:::{seealso}
+- {doc}`../getting-started` --- 5-minute quickstart
+- {doc}`cheat-sheet` --- one-page API quick reference
+- {doc}`glossary` --- term definitions
+:::

--- a/docs/user-guide/context-engineering.md
+++ b/docs/user-guide/context-engineering.md
@@ -1,27 +1,75 @@
 # Context Engineering
 
-`C` factories return frozen descriptors that control what conversation history and state each agent sees. They compose with `+` (union) and `|` (pipe) and are passed to `Agent.context()`.
+:::{admonition} At a Glance
+:class: tip
+
+- `C` factories control what conversation history and state each agent sees
+- Solves three problems: token budgets, irrelevant history, leaked reasoning
+- Compose with `+` (union) or `|` (pipe), pass to `.context()`
+:::
+
+## The Problem
+
+In multi-agent pipelines, every agent shares the same conversation session. Without context engineering, each agent sees **everything** --- other agents' reasoning, tool-call noise, and irrelevant turns.
+
+```mermaid
+graph LR
+    subgraph "Without Context Engineering"
+        A["Agent A output<br/>Agent B output<br/>Tool calls<br/>User messages<br/>ALL of it"] --> C_ALL["Every agent<br/>sees everything"]
+    end
+
+    subgraph "With Context Engineering"
+        U["User msgs"] --> CLASSIFIER
+        INTENT["state['intent']"] --> HANDLER
+        W3["Last 3 turns"] --> HANDLER
+        CLASSIFIER["Classifier<br/>C.none()"]
+        HANDLER["Handler<br/>C.from_state() + C.window(3)"]
+    end
+
+    style C_ALL fill:#e94560,color:#fff
+    style CLASSIFIER fill:#10b981,color:#fff
+    style HANDLER fill:#0ea5e9,color:#fff
+```
+
+| Problem | Impact | C Module Solution |
+|---------|--------|------------------|
+| **Token budgets** | Full history burns tokens on irrelevant content | `C.window(n)`, `C.budget(max_tokens=)` |
+| **Irrelevant history** | Classifier doesn't need writer's drafts | `C.none()`, `C.from_state()` |
+| **Leaked reasoning** | Agents anchor on prior conclusions | `C.user_only()`, `C.from_agents()` |
+
+---
+
+## What the LLM Actually Sees
+
+```mermaid
+graph TB
+    subgraph "LLM Input Assembly"
+        SYS["System Instruction<br/>(from .instruct() / P module)"]
+        CTX_BLOCK["Context Block<br/>(from C transform)"]
+        HIST["Conversation History<br/>(filtered by include_contents)"]
+    end
+
+    SYS --> LLM["LLM Request"]
+    CTX_BLOCK --> LLM
+    HIST --> LLM
+
+    style SYS fill:#e94560,color:#fff
+    style CTX_BLOCK fill:#0ea5e9,color:#fff
+    style HIST fill:#10b981,color:#fff
+    style LLM fill:#a78bfa,color:#fff
+```
+
+When `.reads("topic")` or `.context(C.from_state("topic"))` is set, the LLM receives:
 
 ```
-Context Visibility Matrix:
+[Your instruction text]
 
-                  ┌──────────────┬────────────────────────────────┐
-                  │  What the    │         C primitive             │
-                  │  LLM sees    │                                 │
-  ┌───────────────┼──────────────┼────────────────────────────────┤
-  │ C.default()   │ everything   │ all history + all state        │
-  │ C.none()      │ instruction  │ no history, no state injection │
-  │ C.user_only() │ user msgs    │ user turns only, no agents     │
-  │ C.window(n)   │ last N turns │ recent history slice           │
-  │ C.from_state()│ state keys   │ named keys injected            │
-  │ C.from_agents │ user + named │ selective agent outputs        │
-  │ C.template()  │ rendered str │ template from state values     │
-  └───────────────┴──────────────┴────────────────────────────────┘
-
-  Composition:
-    C.window(3) + C.from_state("topic")    union: both applied
-    C.window(5) | C.template("{history}")   pipe: output → input
+<conversation_context>
+[topic]: value from state
+</conversation_context>
 ```
+
+---
 
 ## Quick Start
 
@@ -29,230 +77,175 @@ Context Visibility Matrix:
 from adk_fluent import Agent, C
 
 # Suppress all conversation history
-clean_agent = Agent("processor").context(C.none()).instruct("Process input.").build()
+Agent("processor").context(C.none()).instruct("Process input.")
 
 # Only see last 3 turn-pairs + state keys
-focused_agent = (
-    Agent("analyst")
-    .context(C.window(n=3) + C.from_state("topic"))
-    .instruct("Analyze {topic}.")
-    .build()
-)
+Agent("analyst").context(C.window(n=3) + C.from_state("topic")).instruct("Analyze {topic}.")
+
+# Only user messages (no agent/tool noise)
+Agent("reviewer").context(C.user_only()).instruct("Review the request.")
 ```
 
-## The Problem
-
-In multi-agent pipelines, every agent shares the same conversation session. Without context engineering, each agent sees the full history -- including irrelevant turns, other agents' internal reasoning, and tool-call noise. This wastes token budget and degrades output quality.
-
-Context engineering solves three problems:
-
-1. **Token budgets.** LLMs have finite context windows. Passing the full history to every agent burns tokens on content that does not help the current task.
-1. **Irrelevant history.** A classifier agent does not need to see the drafts produced by a writer agent three steps earlier. Passing them in adds noise.
-1. **Leaked reasoning.** When agents see each other's chain-of-thought, they anchor on prior conclusions instead of reasoning independently.
-
-`C` primitives let you declare exactly what each agent should see -- and nothing more.
+---
 
 ## Primitives Reference
 
-| Factory                    | Purpose                             |
-| -------------------------- | ----------------------------------- |
-| `C.none()`                 | Suppress all conversation history   |
-| `C.default()`              | Keep default history (pass-through) |
-| `C.user_only()`            | Include only user messages          |
-| `C.from_state(*keys)`      | Inject state keys into instruction  |
-| `C.from_agents(*names)`    | Include user + named agent outputs  |
-| `C.exclude_agents(*names)` | Exclude named agent outputs         |
-| `C.window(n=)`             | Last N turn-pairs only              |
-| `C.template(str)`          | Render template from state          |
-| `S.capture(key)`           | Capture user message to state       |
-| `C.budget(max_tokens=)`    | Token budget constraint             |
-| `C.priority(tier=)`        | Priority tier for ordering          |
+### Core Primitives
 
-## `C.none()`
+| Factory | LLM Sees | `include_contents` |
+|---------|----------|-------------------|
+| `C.default()` | All history + all state | `"default"` |
+| `C.none()` | Instruction only | `"none"` |
+| `C.user_only()` | User messages only | `"none"` + provider |
+| `C.window(n=)` | Last N turn-pairs | `"none"` + provider |
+| `C.from_state(*keys)` | Named state keys | `"none"` + provider |
+| `C.from_agents(*names)` | User + named agent outputs | `"none"` + provider |
+| `C.exclude_agents(*names)` | Everything except named agents | `"none"` + provider |
+| `C.template(str)` | Rendered template from state | `"none"` + provider |
 
-Suppress all conversation history. The agent sees only its instruction:
+### Filtering & Constraints
 
-```python
-agent = Agent("classifier").context(C.none()).instruct("Classify the input.").build()
+| Factory | Purpose |
+|---------|---------|
+| `C.select(*names)` | Select specific agents |
+| `C.recent(n=)` | Recent messages only |
+| `C.compact()` | Remove redundant messages |
+| `C.dedup()` | Remove duplicate messages |
+| `C.truncate(max_turns=)` | Hard turn limit |
+| `C.budget(max_tokens=)` | Token budget constraint |
+| `C.fresh(max_age=)` | Filter by recency |
+| `C.redact(*patterns)` | Redact sensitive content |
+
+### LLM-Powered
+
+| Factory | Purpose |
+|---------|---------|
+| `C.summarize(scope=)` | LLM-powered summarization |
+| `C.relevant(query_key=)` | Semantic relevance filtering |
+| `C.extract(key=)` | Extract structured data |
+| `C.distill()` | Distill to key points |
+
+### Convenience
+
+| Factory | Purpose |
+|---------|---------|
+| `C.rolling(n=)` | Rolling window with compaction |
+| `C.from_agents_windowed(n=)` | Windowed agent output filtering |
+| `C.user()` | Alias for `C.user_only()` |
+| `C.manus_cascade()` | Manus-style cascading context |
+| `C.notes()` | Attach notes |
+| `C.when(pred, transform)` | Conditional context transform |
+
+---
+
+## `.reads()` vs `.context()` --- When to Use Which
+
+| Method | Effect | Best For |
+|--------|--------|---------|
+| `.reads("topic")` | Suppresses history, injects `state["topic"]` | Stateless utility agents that only need specific state keys |
+| `.context(C.from_state("topic"))` | Same as `.reads()` | When you want to compose with other C transforms |
+| `.context(C.window(3))` | Shows last 3 turns only | Long conversations where recent context matters |
+| `.context(C.none())` | Instruction only, no context | Pure function-like agents |
+| No `.reads()` or `.context()` | Full history (default) | Conversational agents |
+
+```mermaid
+flowchart TD
+    Q1{"Does the agent need<br/>conversation history?"} -->|No| Q2{"Does it need state keys?"}
+    Q1 -->|"Yes, all of it"| DEFAULT[".context(C.default())<br/>or don't call .context()"]
+    Q1 -->|"Yes, but only recent"| WINDOW[".context(C.window(n))"]
+
+    Q2 -->|"Yes"| READS[".reads('key1', 'key2')<br/>or .context(C.from_state('key1'))"]
+    Q2 -->|"No"| NONE[".context(C.none())"]
+
+    style DEFAULT fill:#10b981,color:#fff
+    style WINDOW fill:#0ea5e9,color:#fff
+    style READS fill:#f59e0b,color:#fff
+    style NONE fill:#64748b,color:#fff
 ```
 
-## `C.default()`
+---
 
-Keep the default conversation history. This is the pass-through -- equivalent to not calling `.context()` at all:
+## `.static()` vs `.instruct()` --- Context Caching
 
-```python
-agent = Agent("assistant").context(C.default()).instruct("Help the user.").build()
+```mermaid
+graph LR
+    subgraph "Without .static()"
+        I1["instruction<br/>(system content)<br/>Sent every call"]
+    end
+
+    subgraph "With .static()"
+        S1["static_instruction<br/>(system content, CACHED)"]
+        I2["instruction<br/>(user content, sent fresh)"]
+    end
 ```
 
-## `C.user_only()`
-
-Include only user messages, filtering out all agent and tool responses:
-
-```python
-# The reviewer sees what the user said, not what other agents produced
-agent = Agent("reviewer").context(C.user_only()).instruct("Review the request.").build()
-```
-
-## `C.from_state(*keys)`
-
-Read named keys from session state and inject them as context. Suppresses conversation history by default so the agent works purely from state:
+| Method | Goes To | Cached? | Variable Substitution |
+|--------|---------|---------|----------------------|
+| `.instruct()` alone | System content | No | Yes --- `{key}` replaced |
+| `.static()` | System content | Yes --- context cached | No --- sent as-is |
+| `.instruct()` with `.static()` | User content | No | Yes --- `{key}` replaced |
 
 ```python
-# After a prior agent writes state["topic"] and state["style"]
+# 50-page style guide cached; dynamic instruction sent fresh each turn
 agent = (
-    Agent("writer")
-    .context(C.from_state("topic", "style"))
-    .instruct("Write about {topic} in {style} style.")
-    .build()
+    Agent("editor", "gemini-2.5-flash")
+    .static("Company style guide: [50 pages of text]...")
+    .instruct("Edit this text using the style guide above: {draft}")
 )
 ```
 
-## `C.from_agents(*names)`
+:::{tip}
+Use `.static()` for large, stable prompt sections (style guides, knowledge bases, reference docs). The dynamic `.instruct()` text moves to user content, enabling model-level context caching and reducing per-call token costs.
+:::
 
-Include user messages plus outputs from specific named agents. All other agent outputs are excluded:
-
-```python
-# The editor sees only what the user said and what "writer" produced
-agent = (
-    Agent("editor")
-    .context(C.from_agents("writer"))
-    .instruct("Edit the draft for clarity.")
-    .build()
-)
-```
-
-## `C.exclude_agents(*names)`
-
-Include everything except outputs from the named agents:
-
-```python
-# The summarizer sees the full history but ignores the verbose "researcher" output
-agent = (
-    Agent("summarizer")
-    .context(C.exclude_agents("researcher"))
-    .instruct("Summarize the conversation.")
-    .build()
-)
-```
-
-## `C.window(n=)`
-
-Include only the last N turn-pairs (user message + model response). Useful for long-running conversations where only recent context matters:
-
-```python
-# Only see the last 3 exchanges
-agent = Agent("responder").context(C.window(n=3)).instruct("Continue the conversation.").build()
-```
-
-## `C.template(str)`
-
-Render a template string using state values. Supports `{key}` (required) and `{key?}` (optional, replaced with empty string if missing):
-
-```python
-agent = (
-    Agent("reporter")
-    .context(C.template("Topic: {topic}\nNotes: {notes?}"))
-    .instruct("Write a report from the context above.")
-    .build()
-)
-```
-
-## `S.capture(key)`
-
-Capture the most recent user message into a state key. Used as a pipeline step, not inside `.context()`:
-
-```python
-from adk_fluent import Agent, C, S
-
-pipeline = (
-    S.capture("user_message")
-    >> Agent("handler")
-        .context(C.from_state("user_message"))
-        .instruct("Respond to: {user_message}")
-)
-```
-
-## `C.budget(max_tokens=)`
-
-Declare a token budget constraint on the context. Defaults to 8000 tokens with `truncate_oldest` overflow:
-
-```python
-agent = (
-    Agent("analyst")
-    .context(C.budget(max_tokens=4000))
-    .instruct("Analyze the data.")
-    .build()
-)
-```
-
-## `C.priority(tier=)`
-
-Set a priority tier for context ordering. Lower tier values mean higher priority:
-
-```python
-agent = (
-    Agent("critical")
-    .context(C.priority(tier=1))
-    .instruct("Handle urgent requests.")
-    .build()
-)
-```
+---
 
 ## Composition
 
-Primitives compose with two operators:
+### `+` (union) --- Combine transforms
 
-**`+` (union)** combines transforms. Both are applied to produce the final context:
+Both transforms are applied to produce the final context:
 
 ```python
-# Window + state keys: agent sees last 3 turns AND the topic from state
+# Agent sees last 3 turns AND state["topic"]
 ctx = C.window(n=3) + C.from_state("topic", "style")
-
-agent = Agent("analyst").context(ctx).instruct("Analyze {topic}.").build()
+agent = Agent("analyst").context(ctx).instruct("Analyze {topic}.")
 ```
 
-**`|` (pipe)** feeds the output of one transform into another:
+### `|` (pipe) --- Feed output into next transform
 
 ```python
 # Window output piped through a template
 ctx = C.window(n=5) | C.template("Recent conversation:\n{history}")
-
-agent = Agent("summarizer").context(ctx).instruct("Summarize.").build()
+agent = Agent("summarizer").context(ctx).instruct("Summarize.")
 ```
 
-You can chain multiple unions:
+### Chaining multiple unions
 
 ```python
 ctx = C.window(n=3) + C.from_state("topic") + C.budget(max_tokens=4000)
 ```
 
-## Integration with Agent Builder
+---
 
-Pass any `C` transform to `.context()` on the agent builder. The transform is compiled at `.build()` time into the underlying ADK configuration:
+## Full Example: Multi-Agent Context Flow
 
-```python
-agent = Agent("writer").context(C.from_state("topic")).instruct("Write about {topic}.").build()
-```
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant CAP as S.capture
+    participant CL as Classifier<br/>C.none()
+    participant H as Handler<br/>C.from_state + C.user_only
 
-When `.context()` sets `include_contents="none"`, the agent's conversation history is suppressed and replaced by the context transform's output. The developer instruction is still templated with state variables via `{key}` placeholders.
-
-## Complete Example
-
-A realistic multi-agent pipeline where context engineering keeps each agent focused. Each agent sees only what it needs:
-
-```
-Context flow through a pipeline:
-
-  user msg ──► S.capture("user_message") ──► state["user_message"]
-                                                     │
-                ┌────────────────────────────────────┘
-                ▼
-  classifier ─── C.none() ───────────────── sees: instruction only
-       │                                    writes: state["intent"]
-       ▼
-  handler ────── C.from_state("user_message", "intent")
-              + C.user_only() ───────────── sees: user msg + intent
-                                                 + user history
+    U->>CAP: "I need to book a flight"
+    Note over CAP: state["user_msg"] = "I need to book a flight"
+    CAP->>CL: (pipeline continues)
+    Note over CL: Sees: instruction only<br/>No history, no state injection
+    CL->>CL: Classifies intent
+    Note over CL: state["intent"] = "booking"
+    CL->>H: (pipeline continues)
+    Note over H: Sees: state["user_msg"] + state["intent"]<br/>+ user-only history
+    H->>H: Handles booking request
 ```
 
 ```python
@@ -260,54 +253,128 @@ from adk_fluent import Agent, C, S
 
 pipeline = (
     S.capture("user_message")
-    >> Agent("classifier")
-        .model("gemini-2.5-flash")
+    >> Agent("classifier", "gemini-2.5-flash")
         .instruct("Classify the user's intent.")
-        .context(C.none())  # No history needed
+        .context(C.none())              # No history needed — pure classification
         .writes("intent")
-    >> Agent("handler")
-        .model("gemini-2.5-flash")
-        .instruct("Help the user.")
-        .context(C.from_state("user_message", "intent") + C.user_only())
+    >> Agent("handler", "gemini-2.5-flash")
+        .instruct("Help the user with their {intent} request.")
+        .context(
+            C.from_state("user_message", "intent")  # Structured state
+            + C.user_only()                           # + user conversation context
+        )
 )
 ```
 
-The classifier sees only its instruction -- no history, no prior agent output. The handler sees the original user message and classified intent from state, plus user-only history for conversational continuity. Each agent gets exactly the context it needs.
+The classifier sees only its instruction. The handler sees the original user message and classified intent from state, plus user-only history for conversational continuity.
 
-## What Gets Sent to the LLM
+---
 
-Understanding exactly what the LLM receives helps debug unexpected behavior.
+## Context Budget Planning
 
-### `.reads()` suppresses history
+```mermaid
+graph LR
+    subgraph "Token Budget Allocation"
+        STATIC["Static instruction<br/>(cached, ~0 per-call cost)"]
+        DYNAMIC["Dynamic instruction<br/>(sent every call)"]
+        CONTEXT["Context block<br/>(state keys, history window)"]
+        TOOLS["Tool declarations"]
+        RESPONSE["Response budget"]
+    end
 
-When you use `.reads("topic")`, the agent's `include_contents` is set to `"none"`. This means **no conversation history is sent**. The agent sees only:
+    STATIC -->|"large"| TOTAL["Model Context Window"]
+    DYNAMIC -->|"small"| TOTAL
+    CONTEXT -->|"controlled by C"| TOTAL
+    TOOLS -->|"fixed"| TOTAL
+    RESPONSE -->|"reserved"| TOTAL
 
-1. Its instruction text (with `{template}` variables resolved)
-1. The injected state values as a `<conversation_context>` block
-
-```python
-# This agent sees NO conversation history — only state["topic"]
-Agent("writer").reads("topic").instruct("Write about {topic}.")
+    style STATIC fill:#10b981,color:#fff
+    style CONTEXT fill:#0ea5e9,color:#fff
 ```
 
-### `.context()` controls what history is included
+| Strategy | Method | Token Impact |
+|----------|--------|-------------|
+| Cache large prompts | `.static()` | Near-zero per-call cost |
+| Limit history | `C.window(n=3)` | ~3 turn-pairs |
+| Only state keys | `.reads("k1", "k2")` | Only declared keys |
+| Set hard budget | `C.budget(max_tokens=4000)` | Hard limit |
+| Suppress everything | `C.none()` | Zero context tokens |
 
-Different `C` primitives set different `include_contents` values:
+---
 
-| Primitive             | `include_contents` | What the LLM sees                          |
-| --------------------- | ------------------ | ------------------------------------------ |
-| _(default)_           | `"default"`        | All conversation history                   |
-| `C.none()`            | `"none"`           | Nothing — just the instruction             |
-| `C.user_only()`       | `"none"`           | User messages only (injected via provider) |
-| `C.window(n=3)`       | `"none"`           | Last 3 turns (injected via provider)       |
-| `C.from_state("key")` | `"none"`           | State values (injected via provider)       |
+## Common Mistakes
 
-### Composing preserves the most restrictive setting
+::::{grid} 1
+:gutter: 3
 
-When composing with `+`, the result inherits `include_contents="none"` if **any** component sets it. The combined `instruction_provider` assembles all components.
+:::{grid-item-card} Using `.reads()` when you also need conversation history
+:class-card: sd-border-danger
 
-### Unreferenced state is NOT sent
+```python
+# ❌ .reads() suppresses ALL history
+agent = Agent("helper").reads("topic").instruct("Answer about {topic}.")
+# Agent can't see the user's conversation!
+```
 
-Only state keys explicitly declared in `.reads()` or `{template}` variables are sent to the LLM. All other state keys are invisible to the agent.
+```python
+# ✅ Combine state injection with history window
+agent = Agent("helper").context(
+    C.from_state("topic") + C.window(n=3)
+).instruct("Answer about {topic}.")
+```
+:::
 
-See also: [Data Flow Between Agents](data-flow.md) for the complete picture of all five data-flow concerns.
+:::{grid-item-card} Expecting `C.none()` to still show the user message
+:class-card: sd-border-danger
+
+```python
+# ❌ C.none() means NO context at all — not even the user's message
+Agent("classifier").context(C.none()).instruct("Classify.")
+# Current turn still visible, but no conversation history
+```
+
+```python
+# ✅ If you need the user message, capture it to state first
+S.capture("user_msg") >> Agent("classifier")
+    .context(C.from_state("user_msg"))
+    .instruct("Classify: {user_msg}")
+```
+:::
+
+:::{grid-item-card} Forgetting that `C.from_state()` suppresses history
+:class-card: sd-border-danger
+
+```python
+# ❌ Agent sees state["topic"] but no conversation history
+agent = Agent("helper").context(C.from_state("topic")).instruct("Help.")
+```
+
+```python
+# ✅ Add C.window() or C.user_only() if you need some history
+agent = Agent("helper").context(
+    C.from_state("topic") + C.user_only()
+).instruct("Help with {topic}.")
+```
+:::
+::::
+
+---
+
+## Interplay With Other Concepts
+
+| Combines With | To Achieve | Example |
+|--------------|-----------|---------|
+| [State Transforms](state-transforms.md) | Prepare state keys for injection | `S.rename(old="topic") >> agent.reads("topic")` |
+| [Data Flow](data-flow.md) | Control the "Context" concern | `.reads("k")` = Context concern |
+| [Prompts](prompts.md) | Structured instructions + context | `.instruct(P.role() + P.task()).context(C.window(3))` |
+| [Patterns](patterns.md) | Context isolation in review loops | `review_loop(worker.context(C.none()), ...)` |
+| [Callbacks](callbacks.md) | Dynamic context via `before_model` | `.prepend(fn)` for turn-level injection |
+
+---
+
+:::{seealso}
+- {doc}`data-flow` --- the five orthogonal data flow concerns
+- {doc}`state-transforms` --- S module for preparing state keys
+- {doc}`prompts` --- P module for structured prompt composition
+- {doc}`architecture-and-concepts` --- the three channels of ADK communication
+:::

--- a/docs/user-guide/data-flow.md
+++ b/docs/user-guide/data-flow.md
@@ -1,94 +1,54 @@
 # Data Flow Between Agents
 
-Every data-flow method in adk-fluent maps to exactly one of **five orthogonal concerns**. Understanding these five concerns eliminates all confusion about which method to use.
+:::{admonition} At a Glance
+:class: tip
 
-:::{tip}
-**Visual learner?** Open the [Data Flow Interactive Reference](../data-flow-reference.html){target="_blank"} for SVG diagrams, a confusion matrix, and a decision flowchart.
+- Every data-flow method maps to exactly one of **five orthogonal concerns**: Context, Input, Output, Storage, Contract
+- `.reads()` and `.context()` control what agents see; `.writes()` controls where output goes
+- State flows through pipelines as a shared dict --- use S transforms to clean data between steps
 :::
 
 ## The Five Concerns
 
-```{raw} html
-<div class="arch-diagram-wrapper">
-  <svg viewBox="0 0 720 240" fill="none" xmlns="http://www.w3.org/2000/svg" class="arch-diagram" aria-label="Five orthogonal data flow concerns: Context, Input, Output, Storage, and Contract">
-    <defs>
-      <marker id="df-arr" viewBox="0 0 10 8" refX="9" refY="4" markerWidth="7" markerHeight="5" orient="auto">
-        <path d="M0 0 L10 4 L0 8Z" fill="#64748b"/>
-      </marker>
-    </defs>
+```mermaid
+graph LR
+    subgraph "Before LLM Call"
+        CTX["CONTEXT<br/>.reads() / .context()<br/>What agent SEES"]
+        INP["INPUT<br/>.accepts()<br/>Tool-mode schema"]
+    end
 
-    <!-- Title -->
-    <text x="360" y="18" text-anchor="middle" fill="#64748b" font-family="'IBM Plex Sans', sans-serif" font-size="10" font-weight="700" letter-spacing="0.12em">FIVE ORTHOGONAL CONCERNS</text>
-    <line x1="60" y1="26" x2="660" y2="26" stroke="#1e2d4a" stroke-width="0.5"/>
+    subgraph "During LLM Call"
+        OUT["OUTPUT<br/>.returns() / @ Schema<br/>Response SHAPE"]
+    end
 
-    <!-- Context box -->
-    <g transform="translate(30, 40)">
-      <rect width="130" height="100" rx="10" fill="#0ea5e90a" stroke="#0ea5e9" stroke-width="1.5"/>
-      <text x="65" y="22" text-anchor="middle" fill="#0ea5e9" font-family="'IBM Plex Sans', sans-serif" font-size="11" font-weight="700">CONTEXT</text>
-      <text x="65" y="40" text-anchor="middle" fill="#94a3b8" font-family="'IBM Plex Sans', sans-serif" font-size="8">What the agent</text>
-      <text x="65" y="52" text-anchor="middle" fill="#0ea5e9" font-family="'IBM Plex Sans', sans-serif" font-size="9" font-weight="700">SEES</text>
-      <line x1="15" y1="62" x2="115" y2="62" stroke="#0ea5e930" stroke-width="0.5"/>
-      <text x="65" y="78" text-anchor="middle" fill="#38bdf8" font-family="'JetBrains Mono', monospace" font-size="8">.reads()</text>
-      <text x="65" y="92" text-anchor="middle" fill="#38bdf8" font-family="'JetBrains Mono', monospace" font-size="8">.context()</text>
-    </g>
+    subgraph "After LLM Call"
+        STO["STORAGE<br/>.writes()<br/>Where response STORED"]
+    end
 
-    <!-- Input box -->
-    <g transform="translate(180, 40)">
-      <rect width="130" height="100" rx="10" fill="#f59e0b0a" stroke="#f59e0b" stroke-width="1.5"/>
-      <text x="65" y="22" text-anchor="middle" fill="#f59e0b" font-family="'IBM Plex Sans', sans-serif" font-size="11" font-weight="700">INPUT</text>
-      <text x="65" y="40" text-anchor="middle" fill="#94a3b8" font-family="'IBM Plex Sans', sans-serif" font-size="8">What the agent</text>
-      <text x="65" y="52" text-anchor="middle" fill="#f59e0b" font-family="'IBM Plex Sans', sans-serif" font-size="9" font-weight="700">ACCEPTS</text>
-      <line x1="15" y1="62" x2="115" y2="62" stroke="#f59e0b30" stroke-width="0.5"/>
-      <text x="65" y="78" text-anchor="middle" fill="#fbbf24" font-family="'JetBrains Mono', monospace" font-size="8">.accepts()</text>
-    </g>
+    subgraph "Build Time Only"
+        CON["CONTRACT<br/>.produces() / .consumes()<br/>Static annotations"]
+    end
 
-    <!-- Output box -->
-    <g transform="translate(410, 40)">
-      <rect width="130" height="100" rx="10" fill="#a78bfa0a" stroke="#a78bfa" stroke-width="1.5"/>
-      <text x="65" y="22" text-anchor="middle" fill="#a78bfa" font-family="'IBM Plex Sans', sans-serif" font-size="11" font-weight="700">OUTPUT</text>
-      <text x="65" y="40" text-anchor="middle" fill="#94a3b8" font-family="'IBM Plex Sans', sans-serif" font-size="8">Response</text>
-      <text x="65" y="52" text-anchor="middle" fill="#a78bfa" font-family="'IBM Plex Sans', sans-serif" font-size="9" font-weight="700">SHAPE</text>
-      <line x1="15" y1="62" x2="115" y2="62" stroke="#a78bfa30" stroke-width="0.5"/>
-      <text x="65" y="78" text-anchor="middle" fill="#c4b5fd" font-family="'JetBrains Mono', monospace" font-size="8">.returns()</text>
-      <text x="65" y="92" text-anchor="middle" fill="#c4b5fd" font-family="'JetBrains Mono', monospace" font-size="8">@ Model</text>
-    </g>
+    CTX --> OUT
+    INP --> OUT
+    OUT --> STO
 
-    <!-- Storage box -->
-    <g transform="translate(560, 40)">
-      <rect width="130" height="100" rx="10" fill="#10b9810a" stroke="#10b981" stroke-width="1.5"/>
-      <text x="65" y="22" text-anchor="middle" fill="#10b981" font-family="'IBM Plex Sans', sans-serif" font-size="11" font-weight="700">STORAGE</text>
-      <text x="65" y="40" text-anchor="middle" fill="#94a3b8" font-family="'IBM Plex Sans', sans-serif" font-size="8">Where response</text>
-      <text x="65" y="52" text-anchor="middle" fill="#10b981" font-family="'IBM Plex Sans', sans-serif" font-size="9" font-weight="700">is STORED</text>
-      <line x1="15" y1="62" x2="115" y2="62" stroke="#10b98130" stroke-width="0.5"/>
-      <text x="65" y="78" text-anchor="middle" fill="#34d399" font-family="'JetBrains Mono', monospace" font-size="8">.writes()</text>
-    </g>
-
-    <!-- Arrows showing flow direction -->
-    <text x="170" y="170" fill="#64748b" font-family="'IBM Plex Sans', sans-serif" font-size="8" font-weight="600">◀── BEFORE LLM call</text>
-    <text x="490" y="170" fill="#64748b" font-family="'IBM Plex Sans', sans-serif" font-size="8" font-weight="600">AFTER LLM call ──▶</text>
-    <line x1="155" y1="165" x2="555" y2="165" stroke="#1e2d4a" stroke-width="0.5" stroke-dasharray="4,3"/>
-
-    <!-- Contract box (spanning center) -->
-    <g transform="translate(200, 186)">
-      <rect width="320" height="40" rx="8" fill="#64748b08" stroke="#64748b" stroke-width="1" stroke-dasharray="4,3"/>
-      <text x="160" y="18" text-anchor="middle" fill="#64748b" font-family="'IBM Plex Sans', sans-serif" font-size="9" font-weight="700">CONTRACT</text>
-      <text x="160" y="32" text-anchor="middle" fill="#94a3b8" font-family="'JetBrains Mono', monospace" font-size="8">.produces() / .consumes() — static annotations, no runtime effect</text>
-    </g>
-  </svg>
-</div>
+    style CTX fill:#0ea5e9,color:#fff
+    style INP fill:#f59e0b,color:#fff
+    style OUT fill:#a78bfa,color:#fff
+    style STO fill:#10b981,color:#fff
+    style CON fill:#64748b,color:#fff
 ```
 
-| Concern      | Method                        | What it controls                        | ADK field                            |
-| ------------ | ----------------------------- | --------------------------------------- | ------------------------------------ |
-| **Context**  | `.reads()` / `.context()`     | What the agent SEES                     | `include_contents` + `instruction`\* |
-| **Input**    | `.accepts()`                  | What input the agent ACCEPTS as a tool  | `input_schema`                       |
-| **Output**   | `.returns()` / `@ Model`      | What SHAPE the response takes           | `output_schema`                      |
-| **Storage**  | `.writes()`                   | Where the response is STORED            | `output_key`                         |
-| **Contract** | `.produces()` / `.consumes()` | Checker ANNOTATIONS (no runtime effect) | _(extension fields)_                 |
+| Concern | Method | What It Controls | ADK Field |
+|---------|--------|-----------------|-----------|
+| **Context** | `.reads()` / `.context()` | What the agent SEES | `include_contents` + `instruction` |
+| **Input** | `.accepts()` | Schema validation as a tool | `input_schema` |
+| **Output** | `.returns()` / `@ Model` | Response shape (structured JSON) | `output_schema` |
+| **Storage** | `.writes()` | Where response is saved in state | `output_key` |
+| **Contract** | `.produces()` / `.consumes()` | Static annotations (no runtime effect) | _(extension fields)_ |
 
-\* Context compiles into the `instruction` field itself (as an async callable), not a separate `instruction_provider` field.
-
-### Recommended builder chain
+### Recommended Builder Chain
 
 ```python
 from adk_fluent import Agent
@@ -105,65 +65,94 @@ class Intent(BaseModel):
 classifier = (
     Agent("classifier", "gemini-2.0-flash")
     .instruct("Classify the user query: {query}")
-    .reads("query")              # CONTEXT: I see state["query"]
-    .accepts(SearchQuery)        # INPUT:   Tool-mode validation
-    .returns(Intent)             # OUTPUT:  Structured JSON response
-    .writes("intent")            # STORAGE: Save to state["intent"]
+    .reads("query")              # CONTEXT: sees state["query"] only
+    .accepts(SearchQuery)        # INPUT:   tool-mode validation
+    .returns(Intent)             # OUTPUT:  structured JSON response
+    .writes("intent")            # STORAGE: save to state["intent"]
 )
 ```
 
 Each line maps to exactly one ADK field. Each verb is unambiguous.
 
-______________________________________________________________________
+---
+
+## State Flow Through a Pipeline
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant A as Agent A<br/>.writes("plan")
+    participant S as S.pick("plan")
+    participant B as Agent B<br/>.reads("plan")
+
+    Note over U: state = {query: "..."}
+    U->>A: "Plan a trip to London"
+    Note over A: Sees full history +<br/>state via {query} template
+    A->>A: LLM produces plan
+    Note over A: state = {query: "...", plan: "Day 1: ..."}
+
+    A->>S: Pipeline continues
+    Note over S: state = {plan: "Day 1: ..."}
+    Note over S: S.pick removed "query"
+
+    S->>B: Pipeline continues
+    Note over B: Sees state["plan"]<br/>via .reads(), no history
+    B->>B: LLM uses plan
+    Note over B: state = {plan: "Day 1: ...", result: "..."}
+```
+
+### State Snapshots at Each Stage
+
+| Stage | `state` contents | What changed |
+|-------|-----------------|-------------|
+| Start | `{query: "Plan a trip to London"}` | User input |
+| After Agent A | `{query: "...", plan: "Day 1: ..."}` | `.writes("plan")` stored output |
+| After S.pick | `{plan: "Day 1: ..."}` | `S.pick("plan")` kept only "plan" |
+| After Agent B | `{plan: "...", result: "Itinerary: ..."}` | `.writes("result")` stored output |
+
+---
 
 ## The Three Composition Modules: P, C, S
 
-adk-fluent provides three orthogonal composition namespaces for declarative agent construction:
+Three modules control what goes into and comes out of the LLM:
 
-```
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                        P · C · S  MODULES                                  │
-│                                                                             │
-│  ┌──────────────────┐  ┌──────────────────┐  ┌──────────────────┐          │
-│  │   P = Prompt     │  │   C = Context    │  │   S = State      │          │
-│  │   _prompt.py     │  │   _context.py    │  │   _transforms.py │          │
-│  │                  │  │                  │  │                  │          │
-│  │  WHAT the LLM    │  │  WHAT the agent  │  │  HOW state flows │          │
-│  │  is told to do   │  │  can see         │  │  between agents  │          │
-│  │                  │  │                  │  │                  │          │
-│  │  Frozen          │  │  Frozen          │  │  Callable        │          │
-│  │  Descriptors     │  │  Descriptors     │  │  Transforms      │          │
-│  │                  │  │                  │  │                  │          │
-│  │  P.role()        │  │  C.window(n)     │  │  S.pick(*keys)   │          │
-│  │  P.task()        │  │  C.from_state()  │  │  S.rename()      │          │
-│  │  P.constraint()  │  │  C.user_only()   │  │  S.merge()       │          │
-│  │  P.format()      │  │  C.none()        │  │  S.default()     │          │
-│  │  P.example()     │  │  C.summarize()   │  │  S.transform()   │          │
-│  │  P.when()        │  │  C.relevant()    │  │  S.guard()       │          │
-│  │  ...17 factories │  │  ...29 factories │  │  ...14 factories │          │
-│  └────────┬─────────┘  └────────┬─────────┘  └────────┬─────────┘          │
-│           │                     │                      │                    │
-│           ▼                     ▼                      ▼                    │
-│     .instruct(P...)       .context(C...)         >> S.xxx() >>             │
-│           │                     │                      │                    │
-│           ▼                     ▼                      ▼                    │
-│    ADK instruction       ADK include_contents    FnAgent step              │
-│    (str or callable)     + instruction            in pipeline              │
-│                          (async callable)                                   │
-└─────────────────────────────────────────────────────────────────────────────┘
+```mermaid
+graph TB
+    subgraph "P — Prompt"
+        P1["What the LLM<br/>is TOLD to do"]
+        P2[".instruct(P.role() + P.task())"]
+    end
+
+    subgraph "C — Context"
+        C1["What the agent<br/>can SEE"]
+        C2[".context(C.window(5))"]
+    end
+
+    subgraph "S — State"
+        S1["How state FLOWS<br/>between agents"]
+        S2[">> S.pick('k') >>"]
+    end
+
+    P1 --> LLM["LLM Request"]
+    C1 --> LLM
+    S1 -.->|"feeds"| C1
+    S1 -.->|"feeds"| P1
+
+    style P1 fill:#e94560,color:#fff
+    style C1 fill:#0ea5e9,color:#fff
+    style S1 fill:#10b981,color:#fff
+    style LLM fill:#a78bfa,color:#fff
 ```
 
-### Composition operators
-
-All three modules support composition, but with different operators:
-
-| Operator | P (Prompt)       | C (Context)      | S (State)          |
-| -------- | ---------------- | ---------------- | ------------------ |
-| `+`      | Union (merge)    | Union (merge)    | Combine (run both) |
-| `\|`     | Pipe (transform) | Pipe (transform) | —                  |
-| `>>`     | —                | —                | Chain (sequential) |
+| Operator | P (Prompt) | C (Context) | S (State) |
+|----------|-----------|-------------|-----------|
+| `+` | Union (merge sections) | Union (merge specs) | Combine (run both) |
+| `\|` | Pipe (transform) | Pipe (transform) | --- |
+| `>>` | --- | --- | Chain (sequential) |
 
 ```python
+from adk_fluent import P, C, S
+
 # P: compose prompt sections
 prompt = P.role("Expert coder") + P.task("Review code") + P.constraint("Be brief")
 
@@ -174,36 +163,28 @@ context = C.window(n=3) + C.from_state("topic")
 transform = S.pick("a", "b") >> S.rename(a="x") >> S.default(y=1)
 ```
 
-______________________________________________________________________
+---
 
 ## What Gets Sent to the LLM
 
-When an agent runs, ADK assembles the request through a **sequential processor pipeline**. The following diagram shows the exact order:
-
 ```mermaid
 flowchart TB
-    subgraph build["BUILD TIME (agent.build())"]
+    subgraph build["BUILD TIME (.build())"]
         direction TB
-        B1["P transforms compile"]
-        B2["C transforms compile"]
-        B3["Config assembled"]
-        B1 --> B3
-        B2 --> B3
+        B1["P transforms compile"] --> B3["Config assembled"]
+        B2["C transforms compile"] --> B3
     end
 
-    subgraph runtime["RUNTIME (agent.ask() / pipeline step)"]
+    subgraph runtime["RUNTIME (.ask() / pipeline step)"]
         direction TB
-
-        subgraph proc["ADK Request Processors (sequential)"]
-            direction TB
-            P1["① instructions processor"]
-            P2["② contents processor"]
-            P3["③ output_schema processor"]
+        subgraph proc["ADK Request Processors"]
+            P1["1. Instructions processor"]
+            P2["2. Contents processor"]
+            P3["3. Output schema processor"]
             P1 --> P2 --> P3
         end
 
         subgraph llm_req["Final LLM Request"]
-            direction TB
             SYS["system_instruction"]
             HIST["contents (history)"]
             TOOLS["tools"]
@@ -223,98 +204,51 @@ flowchart TB
 
 ### Processor 1: Instruction Assembly
 
-The instructions processor builds the system message from three fields, in this order:
+Three fields combine into the system message, in order:
 
-```
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                    INSTRUCTION ASSEMBLY ORDER                               │
-│                                                                             │
-│  ① global_instruction                                                       │
-│     │  (root agent only, deprecated)                                        │
-│     │  State variables {key} injected                                       │
-│     ▼                                                                       │
-│  ┌─────────────────────────────────────────┐                                │
-│  │         system_instruction              │                                │
-│  └─────────────────────────────────────────┘                                │
-│     ▲                                                                       │
-│     │                                                                       │
-│  ② static_instruction                                                       │
-│     │  (cached, no variable substitution)                                   │
-│     │                                                                       │
-│     └──── if set, forces ③ to become user content ─────┐                   │
-│                                                         │                   │
-│  ③ instruction                                          │                   │
-│     │  (main instruction from .instruct() / P / C)      │                   │
-│     │  State variables {key} injected                   │                   │
-│     │                                                    │                   │
-│     ├── if static NOT set ─► system_instruction          │                   │
-│     │                                                    │                   │
-│     └── if static IS set ──► user content ◄──────────────┘                  │
-│                              (enables context caching)                      │
-│                                                                             │
-└─────────────────────────────────────────────────────────────────────────────┘
-```
+| Field | Source | Variable Substitution |
+|-------|--------|----------------------|
+| `global_instruction` | `.global_instruct()` on root agent | Yes --- `{key}` replaced |
+| `static_instruction` | `.static()` | No --- cached as-is |
+| `instruction` | `.instruct()` / P module | Yes --- `{key}` replaced |
 
-**Key insight:** When `static_instruction` is set, the dynamic `instruction` moves from system to user content. This enables context caching — the static part is cached by the model provider, while the dynamic part is sent fresh each time.
-
-Template variables like `{query}` are replaced with `state["query"]` at runtime (unless `bypass_state_injection=True`).
+:::{note}
+When `.static()` is set, the dynamic `.instruct()` text moves from **system** to **user** content. This enables context caching --- the static part is cached by the model provider, while the dynamic part is sent fresh each turn.
+:::
 
 ### Processor 2: Conversation History
 
 Controlled by `include_contents`:
 
-- **`"default"`** (the default) — full conversation history is included, filtered to:
+| Value | Behavior | Set By |
+|-------|----------|--------|
+| `"default"` | Full conversation history (filtered, rearranged) | Default behavior |
+| `"none"` | Current turn only (latest user input + active tool calls) | `.reads()`, `.context(C.none())` |
 
-  - Remove empty events (no text, no function calls)
-  - Remove framework-internal events (auth, confirmations)
-  - Rearrange function call/response pairs for proper pairing
-  - Multi-agent: other agents' messages reformatted as `[agent_name] said: ...`
-
-- **`"none"`** — conversation history is suppressed, but the **current turn is still included**:
-
-  - Latest user input (or the invoking agent's message)
-  - Current turn's tool calls and responses
-
-**Important:** `.reads()` sets `include_contents="none"`. When you use `.reads("topic")`, the agent does **not** see conversation history — but it still sees the current user input and any in-progress tool interactions.
+:::{warning}
+`.reads()` sets `include_contents="none"`. When you use `.reads("topic")`, the agent does **not** see conversation history --- but it still sees the current user input and any in-progress tool interactions.
+:::
 
 ### Processor 3: Output Schema
 
-When `output_schema` is set (via `.returns(Model)` or `@ Model`):
-
-```
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                    OUTPUT SCHEMA + TOOLS BEHAVIOR                           │
-│                                                                             │
-│  ┌─── output_schema set? ───┐                                              │
-│  │                           │                                              │
-│  No                         Yes                                             │
-│  │                           │                                              │
-│  ▼                           ├─── tools defined? ───┐                       │
-│  Free-form text              │                       │                      │
-│  Tools enabled               No                    Yes                      │
-│                              │                       │                      │
-│                              ▼                       ├── model supports     │
-│                          response_schema             │   both natively?     │
-│                          set directly                │                      │
-│                          (pure JSON mode)           Yes                No   │
-│                                                      │                 │    │
-│                                                      ▼                 ▼    │
-│                                                  Both enabled     Workaround│
-│                                                  natively        tool added │
-│                                                                 (set_model_ │
-│                                                                  response)  │
-│                                                                             │
-└─────────────────────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    Q1{output_schema set?}
+    Q1 -->|No| FREE["Free-form text<br/>Tools enabled"]
+    Q1 -->|Yes| Q2{Tools defined?}
+    Q2 -->|No| PURE["response_schema set<br/>Pure JSON mode"]
+    Q2 -->|Yes| Q3{Model supports both?}
+    Q3 -->|Yes| BOTH["Both enabled natively"]
+    Q3 -->|No| WORK["Workaround tool added<br/>(set_model_response)"]
 ```
 
-**Note:** Tools are NOT unconditionally disabled when `output_schema` is set. ADK checks model capabilities:
+:::{tip}
+Tools are NOT unconditionally disabled when `output_schema` is set. ADK checks model capabilities. For models that don't support both, ADK injects a `set_model_response` workaround tool.
+:::
 
-- If the model supports both tools and structured output natively → both work
-- If not → ADK injects a `set_model_response` workaround tool, allowing the agent to use other tools during reasoning but requiring the final answer as structured JSON via that tool
+### Context Injection with `.reads()`
 
-### Context Injection
-
-When `.reads("topic", "tone")` is set (or `.context(C.from_state("topic", "tone"))`), state values are injected into the instruction as a `<conversation_context>` block:
+When `.reads("topic", "tone")` is set, state values are injected into the instruction:
 
 ```
 [Your instruction text]
@@ -325,452 +259,90 @@ When `.reads("topic", "tone")` is set (or `.context(C.from_state("topic", "tone"
 </conversation_context>
 ```
 
-This is delivered by compiling the context spec into an async callable that replaces the `instruction` field at build time. At runtime, that callable resolves state variables and assembles the combined instruction + context block.
-
-### Full LLM Request Assembly
-
-```
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                  WHAT THE LLM ACTUALLY RECEIVES                             │
-│                                                                             │
-│  ┌── config.system_instruction ──────────────────────────────────────────┐  │
-│  │                                                                       │  │
-│  │  [global_instruction, if root agent has one]                          │  │
-│  │  [static_instruction, if set]                                         │  │
-│  │  [instruction, if no static_instruction]                              │  │
-│  │                                                                       │  │
-│  └───────────────────────────────────────────────────────────────────────┘  │
-│                                                                             │
-│  ┌── contents[] ─────────────────────────────────────────────────────────┐  │
-│  │                                                                       │  │
-│  │  if include_contents="default":                                       │  │
-│  │    [Full conversation history — filtered, branch-matched, rearranged] │  │
-│  │                                                                       │  │
-│  │  if include_contents="none":                                          │  │
-│  │    [Current turn only — latest user input + active tool calls]        │  │
-│  │                                                                       │  │
-│  │  [instruction as user content, if static_instruction was set]         │  │
-│  │                                                                       │  │
-│  └───────────────────────────────────────────────────────────────────────┘  │
-│                                                                             │
-│  ┌── config.tools[] ─────────────────────────────────────────────────────┐  │
-│  │  [Function declarations for all registered tools]                     │  │
-│  │  [+ set_model_response tool, if output_schema workaround needed]     │  │
-│  └───────────────────────────────────────────────────────────────────────┘  │
-│                                                                             │
-│  ┌── config.response_schema ─────────────────────────────────────────────┐  │
-│  │  [JSON schema from output_schema, if set and no workaround needed]   │  │
-│  │  config.response_mime_type = "application/json"                       │  │
-│  └───────────────────────────────────────────────────────────────────────┘  │
-│                                                                             │
-└─────────────────────────────────────────────────────────────────────────────┘
-```
-
 ### What Does NOT Get Sent
 
-| Not sent                               | Why                                                       |
-| -------------------------------------- | --------------------------------------------------------- |
-| State keys not in `.reads()`           | Only explicitly declared keys are injected                |
-| State keys not in `{template}`         | Only template variables in the instruction are resolved   |
-| `.produces()` / `.consumes()`          | Contract annotations — never sent to the LLM              |
-| `.writes()` target key                 | Only used AFTER the LLM responds                          |
-| `.accepts()` schema                    | Only validated at tool-call time, not sent to LLM         |
-| History when `include_contents="none"` | Conversation history is suppressed (current turn remains) |
-
-### After the LLM Responds
-
-1. Response text is captured
-1. If `output_key` is set (`.writes()`), `state[key] = response_text`
-1. If `output_schema` is set and using `.ask()`, response is parsed to a Pydantic model
-1. `after_model_callback` / `after_agent_callback` hooks run
-
-______________________________________________________________________
-
-## P Module: Prompt Composition
-
-The P module declaratively composes prompt sections using frozen dataclasses. Each `P.xxx()` factory returns a `PTransform` descriptor that compiles at build time.
-
-### Section ordering
-
-P enforces a canonical section order:
-
-```
-┌────────────────────────────────────────────────────┐
-│              PROMPT SECTION ORDER                   │
-│                                                     │
-│  ① role        "You are a senior engineer."         │
-│  ② context     "Context: ..."                       │
-│  ③ task        "Task: Review the code."             │
-│  ④ constraint  "Constraints: Be concise."           │
-│  ⑤ format      "Output Format: Return markdown."    │
-│  ⑥ example     "Examples: ..."                      │
-│  ⑦ (custom)    Any P.section("name", "...")         │
-│                                                     │
-└────────────────────────────────────────────────────┘
-```
-
-Multiple sections of the same kind are concatenated. Custom sections appear after the standard ones.
-
-### All P factories
-
-| Phase             | Methods                                                                               | Purpose                       |
-| ----------------- | ------------------------------------------------------------------------------------- | ----------------------------- |
-| **Core Sections** | `role()`, `context()`, `task()`, `constraint()`, `format()`, `example()`, `section()` | Define prompt structure       |
-| **Dynamic**       | `when()`, `from_state()`, `template()`                                                | Conditional + state-dependent |
-| **Structural**    | `reorder()`, `only()`, `without()`                                                    | Post-process section ordering |
-| **LLM-Powered**   | `compress()`, `adapt()`                                                               | Smart prompt optimization     |
-| **Sugar**         | `scaffolded()`, `versioned()`                                                         | Defensive wrapping + tagging  |
-
-### Compilation paths
-
-```
-┌─────────────────────────────────────────────────────────────────────────┐
-│                    P COMPILATION PATHS                                   │
-│                                                                         │
-│  PTransform                                                             │
-│     │                                                                   │
-│     ├── all static? (role, task, constraint, format, example, section)  │
-│     │   │                                                               │
-│     │   Yes ──► _compile_prompt_spec_static()                           │
-│     │           │                                                       │
-│     │           ▼                                                       │
-│     │       returns str ──► ADK instruction (string)                    │
-│     │                                                                   │
-│     └── has dynamic blocks? (when, from_state, template, compress, adapt)│
-│         │                                                               │
-│         Yes ──► returns async _prompt_provider(ctx)                     │
-│                 │                                                       │
-│                 ▼                                                       │
-│             At runtime: resolves state, evaluates conditions,           │
-│             calls LLM transforms ──► ADK instruction (callable)        │
-│                                                                         │
-└─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Usage
-
-```python
-from adk_fluent import Agent, P
-
-agent = Agent("reviewer").instruct(
-    P.role("You are a senior code reviewer.")
-    + P.task("Review the provided code for bugs and style issues.")
-    + P.constraint("Be concise.", "Focus on correctness.")
-    + P.format("Return a bulleted list of findings.")
-    + P.example(
-        input="x = eval(user_input)",
-        output="- Security: injection risk via eval()"
-    )
-)
-
-# Compiles to:
-# You are a senior code reviewer.
-#
-# Task:
-# Review the provided code for bugs and style issues.
-#
-# Constraints:
-# Be concise.
-# Focus on correctness.
-#
-# Output Format:
-# Return a bulleted list of findings.
-#
-# Examples:
-# Input: x = eval(user_input)
-# Output: - Security: injection risk via eval()
-```
-
-______________________________________________________________________
-
-## C Module: Context Engineering
-
-The C module declaratively controls what conversation history and state each agent can see. Each `C.xxx()` factory returns a `CTransform` descriptor.
-
-### How C compiles
-
-Every C transform compiles to two ADK knobs:
-
-```
-┌─────────────────────────────────────────────────────────────────────────┐
-│                    C COMPILATION                                        │
-│                                                                         │
-│  CTransform                                                             │
-│     │                                                                   │
-│     ├── include_contents ──► "default" or "none"                        │
-│     │   (all C transforms except C.default() set "none")                │
-│     │                                                                   │
-│     └── instruction_provider ──► async callable or None                 │
-│         │                                                               │
-│         ▼                                                               │
-│     _compile_context_spec() combines:                                   │
-│                                                                         │
-│     ┌───────────────────────────────────────────────────────────────┐   │
-│     │  async def combined_provider(ctx):                            │   │
-│     │      instruction = resolve(developer_instruction)             │   │
-│     │      instruction = inject_state_vars(instruction, ctx.state)  │   │
-│     │      context = await spec.instruction_provider(ctx)           │   │
-│     │      return f"{instruction}\n\n<conversation_context>\n"      │   │
-│     │             f"{context}\n</conversation_context>"             │   │
-│     └───────────────────────────────────────────────────────────────┘   │
-│         │                                                               │
-│         ▼                                                               │
-│     Overwrites ADK instruction field with this async callable           │
-│                                                                         │
-└─────────────────────────────────────────────────────────────────────────┘
-```
-
-### All C factories
-
-| Category        | Methods                                                                                                                   | Purpose                       |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
-| **Primitives**  | `none()`, `default()`, `user_only()`                                                                                      | Suppress / keep all / users   |
-| **Selection**   | `from_state()`, `from_agents()`, `exclude_agents()`, `window()`, `last_n_turns()`, `template()`                           | Select what to include        |
-| **Filtering**   | `select()`, `recent()`, `compact()`, `dedup()`, `truncate()`, `project()`                                                 | Smart filtering               |
-| **Constraints** | `budget()`, `priority()`, `fit()`, `fresh()`, `redact()`                                                                  | Token budgets + freshness     |
-| **LLM-Powered** | `summarize()`, `relevant()`, `extract()`, `distill()`                                                                     | Intelligent context selection |
-| **Sugar**       | `rolling()`, `from_agents_windowed()`, `user()`, `manus_cascade()`, `notes()`, `write_notes()`, `validate()`, `capture()` | Convenience patterns          |
-
-### Default: Full history
-
-By default, an agent sees the entire conversation history from all agents. No `.reads()` or `.context()` needed.
-
-### `.reads()`: Selective state injection
-
-```python
-Agent("writer").reads("topic", "tone")
-```
-
-This does two things:
-
-1. Sets `include_contents="none"` — conversation history is **suppressed**
-1. Injects `state["topic"]` and `state["tone"]` as a `<conversation_context>` block
-
-### `.context()`: Advanced context control
-
-```python
-from adk_fluent import C
-
-Agent("writer").context(C.window(n=3))      # Last 3 turns only
-Agent("writer").context(C.user_only())       # User messages only
-Agent("writer").context(C.none())            # No context at all
-```
-
-### Composing context
-
-`.context()` and `.reads()` compose additively with the `+` operator:
-
-```python
-Agent("writer")
-    .context(C.window(n=3))   # Include last 3 turns
-    .reads("topic")           # AND inject state["topic"]
-```
-
-______________________________________________________________________
-
-## S Module: State Transforms
-
-The S module transforms session state between pipeline steps using callable `STransform` wrappers. Unlike P and C (frozen descriptors), S transforms are callable and execute at runtime.
-
-### Two kinds of state change
-
-```
-┌─────────────────────────────────────────────────────────────────────────┐
-│                    STATE TRANSFORM TYPES                                 │
-│                                                                         │
-│  ┌─────────────────────────────┐  ┌─────────────────────────────────┐  │
-│  │     StateReplacement        │  │        StateDelta               │  │
-│  │                             │  │                                 │  │
-│  │  Replaces session-scoped    │  │  Additive merge: only           │  │
-│  │  keys. Unmentioned keys     │  │  specified keys updated.        │  │
-│  │  set to None.               │  │  Existing keys preserved.       │  │
-│  │                             │  │                                 │  │
-│  │  S.pick(*keys)              │  │  S.default(**kv)                │  │
-│  │  S.drop(*keys)              │  │  S.merge(*keys, into=, fn=)    │  │
-│  │  S.rename(**mapping)        │  │  S.transform(key, fn)          │  │
-│  │                             │  │  S.compute(**factories)         │  │
-│  │                             │  │  S.set(**values)               │  │
-│  └─────────────────────────────┘  └─────────────────────────────────┘  │
-│                                                                         │
-│  Conditional: S.when(), S.branch()                                      │
-│  Inspection:  S.guard(), S.log(), S.identity(), S.capture()            │
-│                                                                         │
-│  Conflict rule: Replacement + Delta ──► Replacement wins               │
-│                                                                         │
-└─────────────────────────────────────────────────────────────────────────┘
-```
-
-### Usage in pipelines
-
-S transforms appear as steps between agents using the `>>` operator:
-
-```python
-from adk_fluent import Agent, S
-
-pipeline = (
-    Agent("researcher").writes("findings")
-    >> S.pick("findings")                  # Keep only "findings"
-    >> S.rename(findings="input")          # Rename for next agent
-    >> S.default(depth="comprehensive")    # Add default value
-    >> Agent("writer").reads("input")
-)
-```
-
-______________________________________________________________________
-
-## Input: What the Agent Accepts (Tool Mode)
-
-### `.accepts(Model)`: Schema validation at tool-call time
-
-```python
-class SearchQuery(BaseModel):
-    query: str
-
-Agent("searcher").accepts(SearchQuery)
-```
-
-When another agent invokes this agent via `AgentTool`, the input is validated against this schema. **This has no effect for top-level agents** — only for agents used as tools.
-
-______________________________________________________________________
-
-## Output: What Shape the Response Takes
-
-### Default: Plain text
-
-Without `.returns()`, the agent responds in free-form text and **can use tools**.
-
-### `.returns(Model)`: Structured JSON
-
-```python
-class Intent(BaseModel):
-    category: str
-    confidence: float
-
-Agent("classifier").returns(Intent)
-```
-
-Forces the LLM to respond with JSON matching the schema. The `@` operator is shorthand: `Agent("classifier") @ Intent`
-
-**Tool interaction:** When `output_schema` is set, whether tools remain available depends on model capabilities. For models that don't natively support both, ADK injects a `set_model_response` workaround tool so the agent can still reason with tools but must deliver its final answer as structured JSON.
-
-### Using `.ask()` with structured output
-
-```python
-result = await Agent("classifier").returns(Intent).ask_async("Classify this query")
-# result is an Intent instance (automatically parsed)
-```
-
-______________________________________________________________________
-
-## Storage: Where the Response Goes
-
-### `.writes(key)`: Store raw text in state
-
-```python
-Agent("researcher").writes("findings")
-```
-
-After the agent runs, `state["findings"]` holds the **raw text response** (not a parsed Pydantic model).
-
-### Template variables
-
-Downstream agents reference stored values with `{key}` placeholders:
-
-```python
-pipeline = (
-    Agent("researcher").writes("findings")
-    >> Agent("writer").instruct("Summarize: {findings}")
-)
-```
-
-______________________________________________________________________
-
-## Contracts: Static Annotations
-
-### `.produces(Model)` / `.consumes(Model)`
-
-These have **no runtime effect**. They are annotations for the contract checker:
-
-```python
-Agent("classifier").produces(Intent).consumes(SearchQuery)
-```
-
-The contract checker uses these to verify data flow between agents at build time.
-
-______________________________________________________________________
-
-## End-to-End Compilation: From Builder to LLM Call
-
-This diagram traces a complete example from fluent builder calls through compilation to the final LLM request:
+| Not Sent | Why |
+|----------|-----|
+| State keys not in `.reads()` | Only declared keys are injected |
+| State keys not in `{template}` | Only template variables are resolved |
+| `.produces()` / `.consumes()` | Contract annotations --- never sent to LLM |
+| `.writes()` target key | Only used AFTER the LLM responds |
+| `.accepts()` schema | Only validated at tool-call time |
+| History when `.reads()` is set | `include_contents` set to `"none"` |
+
+---
+
+## Data Flow in Pipeline vs FanOut vs Loop
 
 ```mermaid
-flowchart LR
-    subgraph fluent["Fluent Builder API"]
-        direction TB
-        F1[".instruct(P.role + P.task)"]
-        F2[".context(C.from_state + C.window)"]
-        F3[".writes('feedback')"]
+graph TB
+    subgraph "Pipeline (>>)"
+        PA["A<br/>writes 'x'"] -->|"state flows"| PB["B<br/>reads 'x', writes 'y'"] -->|"state flows"| PC["C<br/>reads 'y'"]
     end
 
-    subgraph compile["Build Time"]
-        direction TB
-        C1["_compile_prompt_spec()
-        → str or callable"]
-        C2["_compile_context_spec()
-        → include_contents + instruction"]
-        C3["output_key = 'feedback'"]
+    subgraph "FanOut (|)"
+        START((" ")) --> FA["A<br/>writes 'web'"]
+        START --> FB["B<br/>writes 'docs'"]
+        FA --> MERGE["S.merge<br/>into='all'"]
+        FB --> MERGE
     end
 
-    subgraph adk["ADK LlmAgent Config"]
-        direction TB
-        A1["instruction = async combined_provider"]
-        A2["include_contents = 'none'"]
-        A3["output_key = 'feedback'"]
+    subgraph "Loop (*)"
+        LW["Writer<br/>writes 'draft'"] -->|"state"| LR["Reviewer<br/>writes 'score'"]
+        LR -.->|"score < 0.8"| LW
     end
-
-    subgraph llm["LLM Receives"]
-        direction TB
-        L1["system_instruction:
-        'You are a code reviewer...'"]
-        L2["contents:
-        [current turn only]"]
-        L3["conversation_context block:
-        code: ..., last 3 turns: ..."]
-    end
-
-    F1 --> C1
-    F2 --> C2
-    F3 --> C3
-    C1 --> A1
-    C2 --> A1
-    C2 --> A2
-    C3 --> A3
-    A1 --> L1
-    A1 --> L3
-    A2 --> L2
-
-    style fluent fill:#1a1a2e,stroke:#e94560,color:#fff
-    style compile fill:#16213e,stroke:#0f3460,color:#fff
-    style adk fill:#0f3460,stroke:#e94560,color:#fff
-    style llm fill:#533483,stroke:#e94560,color:#fff
 ```
 
-### Build-time compilation order
+| Topology | State Behavior | Key Pattern |
+|----------|---------------|-------------|
+| **Pipeline** `>>` | State accumulates --- each step adds keys | `.writes("k")` → `{k}` template in next step |
+| **FanOut** `\|` | Branches write to separate keys | `.writes("web")`, `.writes("docs")` → `S.merge()` |
+| **Loop** `*` | State persists across iterations | Writer overwrites `"draft"`, reviewer overwrites `"score"` |
 
-Within `_prepare_build_config()`, the compilation happens in this order:
+:::{warning}
+**FanOut state race conditions:** If two parallel branches write to the same key, the last branch to finish wins. Always use distinct `.writes()` keys in parallel branches, then merge with `S.merge()`.
+:::
 
-1. Run IR contract checks
-1. Extract internal directives (`_context_spec`, `_prompt_spec`, `_output_schema`)
-1. Strip internal fields
-1. **Context spec compiles first** → sets `include_contents` + creates instruction provider
-1. **Prompt spec compiles second** → can override the instruction from step 4
-1. Assemble final config dict for ADK `LlmAgent` instantiation
+---
 
-______________________________________________________________________
+## Template Variable Resolution
+
+`{key}` placeholders in instructions are resolved from session state at runtime:
+
+```mermaid
+graph LR
+    INST["instruction:<br/>'Summarize: {findings}'"] --> RESOLVE["inject_session_state()"]
+    STATE["state['findings']:<br/>'The data shows...'"] --> RESOLVE
+    RESOLVE --> FINAL["'Summarize: The data shows...'"]
+
+    style INST fill:#e94560,color:#fff
+    style STATE fill:#10b981,color:#fff
+    style RESOLVE fill:#f59e0b,color:#fff
+    style FINAL fill:#a78bfa,color:#fff
+```
+
+| Syntax | Behavior |
+|--------|----------|
+| `{key}` | Replaced with `state["key"]` or empty string if missing |
+| `{key}` in `.static()` | **Not replaced** --- static text is cached |
+| `{key}` in `.instruct()` | Replaced every invocation |
+
+---
+
+## After the LLM Responds
+
+1. Response text is captured
+2. If `.writes(key)` is set → `state[key] = response_text`
+3. If `.returns(Schema)` is set and using `.ask()` → response is parsed to Pydantic model
+4. `after_model_callback` / `after_agent_callback` hooks run
+
+---
 
 ## Inspecting Data Flow
 
-### `.data_flow()`: Five-concern snapshot
+Three introspection methods show exactly what's happening:
+
+### `.data_flow()` --- Five-concern snapshot
 
 ```python
 agent = Agent("classifier").reads("query").returns(Intent).writes("intent")
@@ -778,12 +350,12 @@ print(agent.data_flow())
 # Data Flow:
 #   reads:    C.from_state('query') — state keys only
 #   accepts:  (not set — accepts any input as tool)
-#   returns:  structured JSON → Intent (tools disabled)
+#   returns:  structured JSON → Intent
 #   writes:   state['intent']
 #   contract: (not set)
 ```
 
-### `.llm_anatomy()`: What the LLM will see
+### `.llm_anatomy()` --- What the LLM will see
 
 ```python
 print(agent.llm_anatomy())
@@ -791,98 +363,157 @@ print(agent.llm_anatomy())
 #   1. System:     "Classify the user query: {query}"
 #   2. History:    SUPPRESSED
 #   3. Context:    state["query"] injected
-#   4. Tools:      DISABLED (output_schema is set)
-#   5. Constraint: must return Intent {category: ..., confidence: ...}
+#   4. Tools:      depends on model capabilities
+#   5. Constraint: must return Intent {category, confidence}
 #   6. After:      response stored → state["intent"]
 ```
 
-### `.explain()`: Full builder state
+### `.explain()` --- Full builder state
 
 ```python
 print(agent.explain())
+# Shows: model, instruction, data flow, tools, callbacks, children, contract issues
 ```
 
-Shows model, instruction, data flow (five concerns), tools, callbacks, children, and contract issues.
+---
 
-______________________________________________________________________
+## Data Flow Cheat Sheet
+
+| I Want To... | Method | Example |
+|-------------|--------|---------|
+| Store agent output in state | `.writes(key)` | `.writes("findings")` |
+| Read state keys in agent | `.reads(*keys)` | `.reads("topic", "tone")` |
+| Use state in instruction | `{key}` template | `.instruct("About {topic}")` |
+| Constrain output to JSON | `.returns(Model)` or `@ Model` | `.returns(Intent)` |
+| Validate tool-mode input | `.accepts(Model)` | `.accepts(SearchQuery)` |
+| Annotate for contract checker | `.produces()` / `.consumes()` | `.produces(Intent)` |
+| Suppress conversation history | `.context(C.none())` | `.context(C.none())` |
+| Show last N turns only | `.context(C.window(n))` | `.context(C.window(5))` |
+| Transform state between agents | `>> S.xxx() >>` | `>> S.pick("k") >>` |
+
+---
 
 ## Common Patterns
 
-### Classify then route
+### Classify Then Route
 
 ```python
+from adk_fluent import Agent
+from adk_fluent._routing import Route
+
 pipeline = (
-    Agent("classifier")
+    Agent("classifier", "gemini-2.5-flash")
     .instruct("Classify the query.")
     .returns(Intent)
     .writes("intent")
-    >> Agent("handler")
-    .reads("intent")
-    .instruct("Handle the {intent} query.")
-    .writes("response")
+    >> Route("intent")
+    .eq("booking", Agent("booker").instruct("Book flights."))
+    .eq("info", Agent("info").instruct("Provide info."))
 )
 ```
 
-### Fan-out research with merge
+### Fan-Out Research with Merge
 
 ```python
 from adk_fluent import Agent, FanOut, S
 
-research = (
-    FanOut("research")
-    .branch(Agent("web").writes("web_results"))
-    .branch(Agent("docs").writes("doc_results"))
-    >> S.merge("web_results", "doc_results", into="all_results")
-    >> Agent("synthesizer").reads("all_results").writes("synthesis")
+pipeline = (
+    (   Agent("web", "gemini-2.5-flash").instruct("Search web.").writes("web")
+      | Agent("docs", "gemini-2.5-flash").instruct("Search docs.").writes("docs")
+    )
+    >> S.merge("web", "docs", into="all_results")
+    >> Agent("synth", "gemini-2.5-flash").reads("all_results").writes("synthesis")
 )
 ```
 
-### Review loop
+### Review Loop
 
 ```python
 from adk_fluent.patterns import review_loop
 
 pipeline = review_loop(
     worker=Agent("writer").instruct("Write a draft."),
-    reviewer=Agent("reviewer").instruct("Review the draft."),
+    reviewer=Agent("reviewer").instruct("Score the draft 0-1."),
     quality_key="review_score",
     target=0.8,
     max_rounds=3,
 )
 ```
 
-______________________________________________________________________
+---
 
-## T Module: Tool Composition
+## Common Mistakes
 
-The T module provides a compositional namespace for tool construction. Compose with `|` (chain).
+::::{grid} 1
+:gutter: 3
 
-```python
-from adk_fluent import Agent, T
-
-agent = Agent("assistant").tools(
-    T.google_search()
-    | T.fn(my_func)
-    | T.agent(specialist_agent)
-)
-```
-
-See the [CLAUDE.md T namespace reference](../../CLAUDE.md) for all T factories.
-
-______________________________________________________________________
-
-## A Module: Artifact Operations
-
-The A module handles artifact publishing, snapshotting, and transformations. Used with `.artifacts()` or `>>`.
+:::{grid-item-card} Using `.reads()` when you also need conversation history
+:class-card: sd-border-danger
 
 ```python
-from adk_fluent import Agent, A
-
-agent = (
-    Agent("generator")
-    .writes("report_text")
-    .artifacts(A.publish("report.md", from_key="report_text"))
-)
+# ❌ .reads() suppresses ALL history — agent can't see user's question
+agent = Agent("helper").instruct("Answer: {topic}").reads("topic")
 ```
 
-See the [CLAUDE.md A namespace reference](../../CLAUDE.md) for all A factories.
+```python
+# ✅ Use .context() to combine state injection with history
+agent = Agent("helper").instruct("Answer about the topic.").context(
+    C.from_state("topic") + C.window(n=3)
+)
+```
+:::
+
+:::{grid-item-card} Expecting `.writes()` to produce structured data
+:class-card: sd-border-danger
+
+```python
+# ❌ .writes() stores raw text, not a parsed Pydantic model
+agent = Agent("classifier").returns(Intent).writes("intent")
+# state["intent"] is a string like '{"category": "booking", "confidence": 0.9}'
+```
+
+```python
+# ✅ Use .returns() with .ask() for parsed output, .writes() for raw text in pipelines
+result = await Agent("classifier").returns(Intent).ask_async("Classify this")
+# result is an Intent instance
+```
+:::
+
+:::{grid-item-card} Forgetting that FanOut branches share state
+:class-card: sd-border-danger
+
+```python
+# ❌ Both branches write to "result" — last writer wins
+(Agent("a").writes("result") | Agent("b").writes("result"))
+```
+
+```python
+# ✅ Use distinct keys, then merge
+(Agent("a").writes("a_result") | Agent("b").writes("b_result"))
+>> S.merge("a_result", "b_result", into="result")
+```
+:::
+::::
+
+---
+
+## Interplay With Other Concepts
+
+| Combines With | To Achieve | Example |
+|--------------|-----------|---------|
+| [Expression Language](expression-language.md) | Compose agents into pipelines | `a >> b \| c` |
+| [State Transforms](state-transforms.md) | Clean/reshape data between steps | `>> S.pick("k") >> S.rename(k="v") >>` |
+| [Context Engineering](context-engineering.md) | Fine-grained history control | `.context(C.window(3) + C.from_state("k"))` |
+| [Prompts](prompts.md) | Structured instructions with state | `.instruct(P.role("...") + P.task("..."))` |
+| [Structured Data](structured-data.md) | Schema-constrained output | `.returns(Model)` / `@ Model` |
+| [Callbacks](callbacks.md) | Post-processing after output | `.after_model(validate_fn)` |
+
+---
+
+:::{seealso}
+- {doc}`state-transforms` --- full S module reference with before/after diagrams
+- {doc}`context-engineering` --- C module for controlling what agents see
+- {doc}`prompts` --- P module for structured prompt composition
+- {doc}`structured-data` --- schema validation and contracts
+- {doc}`architecture-and-concepts` --- the three channels of ADK communication
+:::

--- a/docs/user-guide/design-philosophy.md
+++ b/docs/user-guide/design-philosophy.md
@@ -1,0 +1,100 @@
+# Design Philosophy
+
+:::{admonition} At a Glance
+:class: tip
+
+- Why fluent builders? Why immutable operators? Why auto-generated code?
+- The "why" behind the "what" --- understanding these principles helps you use adk-fluent effectively
+:::
+
+## Core Principles
+
+### 1. Builders are configuration, not abstraction
+
+adk-fluent doesn't abstract ADK --- it makes ADK **easier to configure**. Every `.build()` returns an identical native ADK object. There is no adk-fluent runtime, no custom execution engine, no behavior changes. If you can do it with ADK, you can do it with adk-fluent. If adk-fluent can't express it, use `.native()` as an escape hatch.
+
+### 2. Compile-time over runtime
+
+Catch errors at `.build()` time, not when an LLM call fails in production. Typo detection, contract verification, and data flow analysis all happen before any tokens are spent. The IR tree is a static artifact you can inspect, test, and validate --- cheaply and deterministically.
+
+### 3. Immutable operators
+
+All expression operators (`>>`, `|`, `*`, `@`, `//`) produce **new** objects. Sub-expressions are safely reusable:
+
+```python
+review = agent_a >> agent_b    # Define once
+pipeline_1 = review >> agent_c  # Reuse freely
+pipeline_2 = review >> agent_d  # No interference
+```
+
+This follows the same principle as functional data structures: composition without fear of mutation.
+
+### 4. Orthogonal concerns
+
+The five data flow concerns (Context, Input, Output, Storage, Contract) are independent. Setting `.writes("intent")` doesn't affect what the agent sees. Setting `.context(C.none())` doesn't affect where the agent stores its output. This orthogonality makes pipelines predictable and debuggable.
+
+### 5. Auto-generated, always in sync
+
+The 132 builders are auto-generated from the installed ADK version by a codegen pipeline (scan → seed → generate). This means:
+
+- Every ADK class has a corresponding builder
+- Every ADK field is accessible (via explicit methods or `__getattr__` forwarding)
+- Upgrades to ADK automatically surface new builders and fields
+
+You never wait for adk-fluent to "support" a new ADK feature.
+
+### 6. Progressive disclosure
+
+The API has three complexity levels:
+
+| Level | API | Example |
+|-------|-----|---------|
+| **Simple** | `Agent("name", "model").instruct("...").build()` | 1-3 lines |
+| **Compositional** | `a >> b \| c * 3` | Operators |
+| **Advanced** | `.context(C.window(3) + C.from_state("k"))` | Module composition |
+
+You never need the advanced features to get started. Each level builds on the previous one.
+
+---
+
+## Why Fluent Builders?
+
+ADK's `LlmAgent` takes 15+ keyword arguments. In a pipeline with 5 agents, that's 75+ kwargs to manage. Fluent builders solve this with:
+
+1. **Autocomplete** --- IDE shows available methods
+2. **Typo detection** --- misspelled fields caught at definition time
+3. **Chainability** --- each method returns `self`, reads naturally
+4. **Discoverability** --- `.explain()`, `.data_flow()`, `.llm_anatomy()` for introspection
+
+## Why Expression Operators?
+
+The `>>` and `|` syntax isn't sugar for its own sake. It encodes **topology** --- the shape of your agent graph. When you read `a >> b | c`, you immediately see: "a runs first, then b and c in parallel." The equivalent native ADK code (nested `SequentialAgent` and `ParallelAgent` constructors) obscures this shape in boilerplate.
+
+## Why Modules (S, C, P, A, M, T, E, G)?
+
+Each module owns one orthogonal concern. They compose independently:
+
+- `S` transforms state between agents
+- `C` controls what agents see
+- `P` structures the prompt
+- `M` adds pipeline-wide middleware
+
+This separation means you can change your context strategy (`C`) without touching your state flow (`S`) or your prompt structure (`P`). Concerns don't leak across boundaries.
+
+## Why Auto-Generation?
+
+Hand-maintaining 132 builders would be:
+
+1. **Error-prone** --- miss a field, introduce a typo
+2. **Always stale** --- ADK updates faster than manual wrappers
+3. **Incomplete** --- easy to skip edge cases
+
+Auto-generation from `manifest.json` ensures every ADK class, field, and type annotation is covered. The codegen pipeline is the single source of truth.
+
+---
+
+:::{seealso}
+- {doc}`architecture-and-concepts` --- system architecture
+- {doc}`../contributing/codegen-pipeline` --- how auto-generation works
+- {doc}`concept-map` --- visual map of all concepts
+:::

--- a/docs/user-guide/error-reference.md
+++ b/docs/user-guide/error-reference.md
@@ -1,5 +1,13 @@
 # Error Reference
 
+:::{admonition} At a Glance
+:class: tip
+
+- Complete catalog of adk-fluent errors with causes, examples, and fixes
+- Every error includes a code, message, and suggested resolution
+- Use `.validate()` and `check_contracts()` to catch errors early at build time
+:::
+
 This page documents every error you may encounter when using adk-fluent,
 explains why it happens, and shows how to fix it.
 

--- a/docs/user-guide/evaluation.md
+++ b/docs/user-guide/evaluation.md
@@ -1,5 +1,13 @@
 # Evaluation
 
+:::{admonition} At a Glance
+:class: tip
+
+- E module provides three tiers: inline `.eval()`, `EvalSuite` for batch, `ComparisonReport` for A/B testing
+- Custom criteria with `E.criterion()`, LLM-as-judge scoring, tool trajectory checks
+- Use eval to catch quality regressions before they reach production
+:::
+
 adk-fluent wraps Google ADK's evaluation framework with a fluent `E` module, consistent with the other namespace modules (P, C, S, M, T, A). It provides three tiers of evaluation — inline, suite, and comparison — all composable with the `|` operator.
 
 ## Quick Start

--- a/docs/user-guide/execution-backends.md
+++ b/docs/user-guide/execution-backends.md
@@ -1,5 +1,13 @@
 # Execution Backends
 
+:::{admonition} At a Glance
+:class: tip
+
+- Three backends: ADK (stable, production), Temporal (in dev, durable), asyncio (in dev, zero-dep)
+- Same builder code works across all backends --- only `.engine()` call changes
+- Default is ADK --- you don't need to choose a backend to get started
+:::
+
 adk-fluent decouples **what** your agent does (builders, operators, namespaces) from **how** it runs (the execution engine). The same builder definition can compile to different backends with different durability, scheduling, and deployment characteristics.
 
 :::{admonition} Backend maturity

--- a/docs/user-guide/execution.md
+++ b/docs/user-guide/execution.md
@@ -1,5 +1,13 @@
 # One-Shot Execution
 
+:::{admonition} At a Glance
+:class: tip
+
+- `.ask()` / `.ask_async()` for one-shot execution, `.stream()` for streaming, `.session()` for multi-turn
+- Sync methods (`.ask`, `.map`) raise RuntimeError inside async event loops --- use async variants in Jupyter/FastAPI
+- `.mock(responses)` replaces LLM with canned responses for testing
+:::
+
 adk-fluent provides execution helpers that eliminate Runner and Session boilerplate. These methods let you go from builder to result in a single call.
 
 :::{admonition} Execution backend awareness

--- a/docs/user-guide/expression-language.md
+++ b/docs/user-guide/expression-language.md
@@ -1,182 +1,167 @@
 # Expression Language
 
-Nine operators compose any agent topology. All operators are **immutable** -- sub-expressions can be safely reused across different pipelines.
+:::{admonition} At a Glance
+:class: tip
 
-```{raw} html
-<div class="arch-diagram-wrapper">
-  <svg viewBox="0 0 740 340" fill="none" xmlns="http://www.w3.org/2000/svg" class="arch-diagram" aria-label="Operator visual reference showing all 9 operators">
-    <defs>
-      <marker id="el-arr" viewBox="0 0 10 8" refX="9" refY="4" markerWidth="7" markerHeight="5" orient="auto">
-        <path d="M0 0 L10 4 L0 8Z" fill="#e94560"/>
-      </marker>
-      <marker id="el-arr-blue" viewBox="0 0 10 8" refX="9" refY="4" markerWidth="7" markerHeight="5" orient="auto">
-        <path d="M0 0 L10 4 L0 8Z" fill="#0ea5e9"/>
-      </marker>
-      <marker id="el-arr-green" viewBox="0 0 10 8" refX="9" refY="4" markerWidth="7" markerHeight="5" orient="auto">
-        <path d="M0 0 L10 4 L0 8Z" fill="#10b981"/>
-      </marker>
-      <marker id="el-arr-purple" viewBox="0 0 10 8" refX="9" refY="4" markerWidth="7" markerHeight="5" orient="auto">
-        <path d="M0 0 L10 4 L0 8Z" fill="#a78bfa"/>
-      </marker>
-      <marker id="el-arr-pink" viewBox="0 0 10 8" refX="9" refY="4" markerWidth="7" markerHeight="5" orient="auto">
-        <path d="M0 0 L10 4 L0 8Z" fill="#f472b6"/>
-      </marker>
-    </defs>
+- Nine operators compose any agent topology using familiar Python syntax
+- All operators are **immutable** --- sub-expressions can be safely reused
+- Every expression compiles to native ADK objects (`SequentialAgent`, `ParallelAgent`, `LoopAgent`)
+:::
 
-    <!-- Title -->
-    <text x="370" y="20" text-anchor="middle" fill="#64748b" font-family="'IBM Plex Sans', sans-serif" font-size="10" font-weight="700" letter-spacing="0.12em">OPERATOR VISUAL REFERENCE</text>
-    <line x1="60" y1="28" x2="680" y2="28" stroke="#1e2d4a" stroke-width="0.5"/>
+## Operator Algebra at a Glance
 
-    <!-- >> Sequence -->
-    <g transform="translate(20, 48)">
-      <text x="0" y="12" fill="#e94560" font-family="'JetBrains Mono', monospace" font-size="14" font-weight="700">&gt;&gt;</text>
-      <text x="30" y="12" fill="#94a3b8" font-family="'IBM Plex Sans', sans-serif" font-size="10" font-weight="600">Sequence</text>
-      <rect x="110" y="0" width="44" height="20" rx="6" fill="#e9456018" stroke="#e94560" stroke-width="1"/>
-      <text x="132" y="14" text-anchor="middle" fill="#e94560" font-family="'IBM Plex Sans', sans-serif" font-size="9" font-weight="600">a</text>
-      <line x1="160" y1="10" x2="188" y2="10" stroke="#e94560" stroke-width="1.2" marker-end="url(#el-arr)"/>
-      <rect x="196" y="0" width="44" height="20" rx="6" fill="#e9456018" stroke="#e94560" stroke-width="1"/>
-      <text x="218" y="14" text-anchor="middle" fill="#e94560" font-family="'IBM Plex Sans', sans-serif" font-size="9" font-weight="600">b</text>
-      <line x1="246" y1="10" x2="274" y2="10" stroke="#e94560" stroke-width="1.2" marker-end="url(#el-arr)"/>
-      <rect x="282" y="0" width="44" height="20" rx="6" fill="#e9456018" stroke="#e94560" stroke-width="1"/>
-      <text x="304" y="14" text-anchor="middle" fill="#e94560" font-family="'IBM Plex Sans', sans-serif" font-size="9" font-weight="600">c</text>
-      <text x="360" y="13" fill="#64748b" font-family="'IBM Plex Sans', sans-serif" font-size="8">SequentialAgent</text>
-    </g>
+| Operator | Symbol | Meaning | ADK Type | Example |
+|----------|--------|---------|----------|---------|
+| Sequence | `>>` | Run in order | `SequentialAgent` | `a >> b >> c` |
+| Function step | `>> fn` | Zero-cost transform | `FnAgent` | `a >> my_func >> b` |
+| Parallel | `\|` | Run concurrently | `ParallelAgent` | `a \| b \| c` |
+| Loop (fixed) | `* n` | Repeat n times | `LoopAgent` | `(a >> b) * 3` |
+| Loop (conditional) | `* until(...)` | Repeat until predicate | `LoopAgent` + check | `(a >> b) * until(pred)` |
+| Typed output | `@` | Constrain to schema | `output_schema` | `a @ MyModel` |
+| Fallback | `//` | First success wins | Fallback chain | `fast // strong` |
+| Route | `Route(key)` | Deterministic branch | Custom agent | `Route("k").eq(...)` |
+| State transform | `S.xxx()` | Dict operations | `FnAgent` | `>> S.pick("k") >>` |
 
-    <!-- | Parallel -->
-    <g transform="translate(20, 88)">
-      <text x="0" y="22" fill="#0ea5e9" font-family="'JetBrains Mono', monospace" font-size="14" font-weight="700">|</text>
-      <text x="30" y="22" fill="#94a3b8" font-family="'IBM Plex Sans', sans-serif" font-size="10" font-weight="600">Parallel</text>
-      <line x1="120" y1="22" x2="148" y2="2" stroke="#0ea5e9" stroke-width="1.2"/>
-      <line x1="120" y1="22" x2="148" y2="22" stroke="#0ea5e9" stroke-width="1.2"/>
-      <line x1="120" y1="22" x2="148" y2="42" stroke="#0ea5e9" stroke-width="1.2"/>
-      <rect x="152" y="-6" width="44" height="18" rx="5" fill="#0ea5e918" stroke="#0ea5e9" stroke-width="1"/>
-      <text x="174" y="8" text-anchor="middle" fill="#0ea5e9" font-family="'IBM Plex Sans', sans-serif" font-size="9" font-weight="600">a</text>
-      <rect x="152" y="14" width="44" height="18" rx="5" fill="#0ea5e918" stroke="#0ea5e9" stroke-width="1"/>
-      <text x="174" y="28" text-anchor="middle" fill="#0ea5e9" font-family="'IBM Plex Sans', sans-serif" font-size="9" font-weight="600">b</text>
-      <rect x="152" y="34" width="44" height="18" rx="5" fill="#0ea5e918" stroke="#0ea5e9" stroke-width="1"/>
-      <text x="174" y="48" text-anchor="middle" fill="#0ea5e9" font-family="'IBM Plex Sans', sans-serif" font-size="9" font-weight="600">c</text>
-      <line x1="200" y1="2" x2="228" y2="22" stroke="#0ea5e9" stroke-width="1.2"/>
-      <line x1="200" y1="22" x2="228" y2="22" stroke="#0ea5e9" stroke-width="1.2"/>
-      <line x1="200" y1="42" x2="228" y2="22" stroke="#0ea5e9" stroke-width="1.2"/>
-      <circle cx="120" cy="22" r="3" fill="#0ea5e9"/>
-      <circle cx="228" cy="22" r="3" fill="#0ea5e9"/>
-      <text x="360" y="25" fill="#64748b" font-family="'IBM Plex Sans', sans-serif" font-size="8">ParallelAgent</text>
-    </g>
+## Which Operator Do I Need?
 
-    <!-- * Loop -->
-    <g transform="translate(20, 156)">
-      <text x="0" y="14" fill="#10b981" font-family="'JetBrains Mono', monospace" font-size="14" font-weight="700">*</text>
-      <text x="30" y="14" fill="#94a3b8" font-family="'IBM Plex Sans', sans-serif" font-size="10" font-weight="600">Loop</text>
-      <rect x="110" y="2" width="80" height="20" rx="6" fill="#10b98118" stroke="#10b981" stroke-width="1"/>
-      <text x="150" y="16" text-anchor="middle" fill="#10b981" font-family="'IBM Plex Sans', sans-serif" font-size="9" font-weight="600">body</text>
-      <path d="M195 12 Q220 12 220 -2 Q220 -12 150 -12 Q105 -12 105 -2 Q105 2 110 5" stroke="#10b981" stroke-width="1" fill="none" stroke-dasharray="3,2"/>
-      <text x="158" y="-5" text-anchor="middle" fill="#10b981" font-family="'JetBrains Mono', monospace" font-size="7" font-weight="600">n times</text>
-      <text x="360" y="15" fill="#64748b" font-family="'IBM Plex Sans', sans-serif" font-size="8">LoopAgent</text>
-    </g>
+```mermaid
+flowchart TD
+    START{What should happen?} -->|"Steps run one after another"| SEQ[">> (Sequence)"]
+    START -->|"Steps run at the same time"| PAR["| (Parallel)"]
+    START -->|"Repeat until done"| LOOP_Q{Fixed count?}
+    LOOP_Q -->|Yes| FIXED["* n (Fixed loop)"]
+    LOOP_Q -->|No| COND["* until(pred) (Conditional)"]
+    START -->|"Try cheap model first"| FALL["// (Fallback)"]
+    START -->|"Branch on a state value"| ROUTE["Route(key)"]
+    START -->|"Force JSON output"| TYPED["@ Schema"]
+    START -->|"Transform state between agents"| STRANS[">> S.xxx() >>"]
 
-    <!-- @ Schema -->
-    <g transform="translate(20, 196)">
-      <text x="0" y="14" fill="#f59e0b" font-family="'JetBrains Mono', monospace" font-size="14" font-weight="700">@</text>
-      <text x="30" y="14" fill="#94a3b8" font-family="'IBM Plex Sans', sans-serif" font-size="10" font-weight="600">Typed</text>
-      <rect x="110" y="2" width="50" height="20" rx="6" fill="#f59e0b18" stroke="#f59e0b" stroke-width="1"/>
-      <text x="135" y="16" text-anchor="middle" fill="#f59e0b" font-family="'IBM Plex Sans', sans-serif" font-size="9" font-weight="600">agent</text>
-      <text x="172" y="16" fill="#f59e0b" font-family="'JetBrains Mono', monospace" font-size="10" font-weight="700">→</text>
-      <rect x="186" y="0" width="80" height="24" rx="6" fill="#f59e0b10" stroke="#f59e0b" stroke-width="1" stroke-dasharray="4,2"/>
-      <text x="226" y="16" text-anchor="middle" fill="#f59e0b" font-family="'JetBrains Mono', monospace" font-size="9" font-weight="600">Schema{}</text>
-      <text x="360" y="15" fill="#64748b" font-family="'IBM Plex Sans', sans-serif" font-size="8">output_schema</text>
-    </g>
-
-    <!-- // Fallback -->
-    <g transform="translate(20, 236)">
-      <text x="0" y="14" fill="#a78bfa" font-family="'JetBrains Mono', monospace" font-size="14" font-weight="700">//</text>
-      <text x="30" y="14" fill="#94a3b8" font-family="'IBM Plex Sans', sans-serif" font-size="10" font-weight="600">Fallback</text>
-      <rect x="110" y="2" width="44" height="20" rx="6" fill="#a78bfa18" stroke="#a78bfa" stroke-width="1"/>
-      <text x="132" y="16" text-anchor="middle" fill="#a78bfa" font-family="'IBM Plex Sans', sans-serif" font-size="9" font-weight="600">a</text>
-      <line x1="158" y1="12" x2="170" y2="12" stroke="#e94560" stroke-width="1.2"/>
-      <text x="174" y="16" fill="#e94560" font-family="'IBM Plex Sans', sans-serif" font-size="10" font-weight="700">✗</text>
-      <line x1="182" y1="12" x2="194" y2="12" stroke="#a78bfa" stroke-width="1.2" marker-end="url(#el-arr-purple)"/>
-      <rect x="202" y="2" width="44" height="20" rx="6" fill="#a78bfa18" stroke="#a78bfa" stroke-width="1"/>
-      <text x="224" y="16" text-anchor="middle" fill="#a78bfa" font-family="'IBM Plex Sans', sans-serif" font-size="9" font-weight="600">b</text>
-      <line x1="250" y1="12" x2="262" y2="12" stroke="#e94560" stroke-width="1.2"/>
-      <text x="266" y="16" fill="#e94560" font-family="'IBM Plex Sans', sans-serif" font-size="10" font-weight="700">✗</text>
-      <line x1="274" y1="12" x2="286" y2="12" stroke="#a78bfa" stroke-width="1.2" marker-end="url(#el-arr-purple)"/>
-      <rect x="294" y="2" width="44" height="20" rx="6" fill="#a78bfa18" stroke="#a78bfa" stroke-width="1"/>
-      <text x="316" y="16" text-anchor="middle" fill="#a78bfa" font-family="'IBM Plex Sans', sans-serif" font-size="9" font-weight="600">c</text>
-      <text x="360" y="15" fill="#64748b" font-family="'IBM Plex Sans', sans-serif" font-size="8">first success</text>
-    </g>
-
-    <!-- Route -->
-    <g transform="translate(20, 278)">
-      <text x="0" y="18" fill="#f472b6" font-family="'JetBrains Mono', monospace" font-size="11" font-weight="700">Route</text>
-      <text x="46" y="18" fill="#94a3b8" font-family="'IBM Plex Sans', sans-serif" font-size="10" font-weight="600">Branch</text>
-      <rect x="110" y="4" width="64" height="24" rx="6" fill="#f472b618" stroke="#f472b6" stroke-width="1"/>
-      <text x="142" y="20" text-anchor="middle" fill="#f472b6" font-family="'JetBrains Mono', monospace" font-size="8" font-weight="600">state[key]</text>
-      <line x1="178" y1="10" x2="220" y2="0" stroke="#f472b6" stroke-width="1" marker-end="url(#el-arr-pink)"/>
-      <line x1="178" y1="22" x2="220" y2="32" stroke="#f472b6" stroke-width="1" marker-end="url(#el-arr-pink)"/>
-      <text x="230" y="4" fill="#f472b6" font-family="'JetBrains Mono', monospace" font-size="8">"a" → handler_a</text>
-      <text x="230" y="38" fill="#f472b6" font-family="'JetBrains Mono', monospace" font-size="8">"b" → handler_b</text>
-      <text x="360" y="20" fill="#64748b" font-family="'IBM Plex Sans', sans-serif" font-size="8">deterministic routing</text>
-    </g>
-  </svg>
-</div>
+    style START fill:#e94560,color:#fff
+    style SEQ fill:#e94560,color:#fff
+    style PAR fill:#0ea5e9,color:#fff
+    style FIXED fill:#10b981,color:#fff
+    style COND fill:#10b981,color:#fff
+    style FALL fill:#a78bfa,color:#fff
+    style ROUTE fill:#f472b6,color:#fff
+    style TYPED fill:#f59e0b,color:#fff
+    style STRANS fill:#10b981,color:#fff
 ```
 
-## Operator Summary
+## Operator Precedence
 
-| Operator                       | Meaning            | ADK Type                 |
-| ------------------------------ | ------------------ | ------------------------ |
-| `a >> b`                       | Sequence           | `SequentialAgent`        |
-| `a >> fn`                      | Function step      | Zero-cost transform      |
-| `a \| b`                       | Parallel           | `ParallelAgent`          |
-| `a * 3`                        | Loop (fixed)       | `LoopAgent`              |
-| `a * until(pred)`              | Loop (conditional) | `LoopAgent` + checkpoint |
-| `a @ Schema`                   | Typed output       | `output_schema`          |
-| `a // b`                       | Fallback           | First-success chain      |
-| `Route("key").eq(...)`         | Branch             | Deterministic routing    |
-| `S.pick(...)`, `S.rename(...)` | State transforms   | Dict operations via `>>` |
+Operators follow Python's standard precedence. Use parentheses to override.
+
+| Priority | Operator | Associativity |
+|----------|----------|--------------|
+| 1 (highest) | `@` (typed output) | Left |
+| 2 | `*` (loop) | Left |
+| 3 | `\|` (parallel) | Left |
+| 4 | `>>` (sequence) | Left |
+| 5 (lowest) | `//` (fallback) | Left |
+
+:::{tip}
+When in doubt, add parentheses. `(a >> b) | (c >> d)` is clearer than relying on precedence.
+:::
+
+---
 
 ## Immutability
 
-All operators produce new expression objects. Sub-expressions can be safely reused:
+All operators produce **new** expression objects. Sub-expressions can be safely reused:
 
 ```python
-review = agent_a >> agent_b
-pipeline_1 = review >> agent_c  # Independent
-pipeline_2 = review >> agent_d  # Independent
+review = agent_a >> agent_b         # Reusable sub-expression
+pipeline_1 = review >> agent_c      # Independent copy
+pipeline_2 = review >> agent_d      # Independent copy
 ```
 
-## `>>` -- Pipeline (Sequential)
+---
 
-The `>>` operator chains agents into a sequential pipeline. Each agent runs after the previous one completes:
+## `>>` --- Sequence (Pipeline)
+
+Chains agents into a sequential pipeline. Each agent runs after the previous one completes.
+
+```mermaid
+graph LR
+    A["Agent A"] -->|then| B["Agent B"] -->|then| C["Agent C"]
+    style A fill:#e94560,color:#fff
+    style B fill:#e94560,color:#fff
+    style C fill:#e94560,color:#fff
+```
+
+### Quick Start
 
 ```python
 from adk_fluent import Agent
 
 pipeline = (
-    Agent("extractor", "gemini-2.5-flash").instruct("Extract entities.").writes("entities")
-    >> Agent("enricher", "gemini-2.5-flash").instruct("Enrich {entities}.")
-    >> Agent("formatter", "gemini-2.5-flash").instruct("Format output.")
+    Agent("a", "gemini-2.5-flash").instruct("Step 1.").writes("result")
+    >> Agent("b", "gemini-2.5-flash").instruct("Step 2 using {result}.")
 ).build()
 ```
 
-This produces the same `SequentialAgent` as the builder-style `Pipeline("name").step(...).step(...).build()`.
+### Equivalent Builder API
 
-## `>> fn` -- Function Steps
+```python
+from adk_fluent import Pipeline, Agent
+
+pipeline = (
+    Pipeline("flow")
+    .step(Agent("a", "gemini-2.5-flash").instruct("Step 1.").writes("result"))
+    .step(Agent("b", "gemini-2.5-flash").instruct("Step 2 using {result}."))
+    .build()
+)
+```
+
+---
+
+## `>> fn` --- Function Steps
 
 Plain Python functions compose with `>>` as zero-cost workflow nodes (no LLM call):
 
+```mermaid
+graph LR
+    A["Agent A"] -->|state| F["merge_research(state)"]:::fn -->|state| B["Agent B"]
+    style A fill:#e94560,color:#fff
+    style B fill:#e94560,color:#fff
+    classDef fn fill:#10b981,color:#fff
+```
+
 ```python
 def merge_research(state):
+    """Combine web + papers into single key."""
     return {"research": state["web"] + "\n" + state["papers"]}
 
 pipeline = web_agent >> merge_research >> writer_agent
 ```
 
-Functions receive the session state dict and return a dict of state updates. They are useful for data transformations between agent steps.
+Functions receive the session state dict and return a dict of state updates.
 
-## `|` -- Parallel (Fan-Out)
+:::{tip}
+For common transforms like picking keys or renaming, use `S` module factories instead of writing custom functions: `>> S.pick("web", "papers") >> S.merge("web", "papers", into="research") >>`.
+:::
 
-The `|` operator runs agents in parallel:
+---
+
+## `|` --- Parallel (Fan-Out)
+
+Runs agents concurrently. All branches execute simultaneously.
+
+```mermaid
+graph LR
+    START((" ")) --> A["Agent A"]
+    START --> B["Agent B"]
+    START --> C["Agent C"]
+    A --> END((" "))
+    B --> END
+    C --> END
+
+    style A fill:#0ea5e9,color:#fff
+    style B fill:#0ea5e9,color:#fff
+    style C fill:#0ea5e9,color:#fff
+```
+
+### Quick Start
 
 ```python
 from adk_fluent import Agent
@@ -184,17 +169,45 @@ from adk_fluent import Agent
 fanout = (
     Agent("web", "gemini-2.5-flash").instruct("Search web.").writes("web_results")
     | Agent("papers", "gemini-2.5-pro").instruct("Search papers.").writes("paper_results")
-    | Agent("internal", "gemini-2.5-flash").instruct("Search internal docs.").writes("internal_results")
+    | Agent("internal", "gemini-2.5-flash").instruct("Search docs.").writes("internal_results")
 ).build()
 ```
 
-This produces the same `ParallelAgent` as the builder-style `FanOut("name").branch(...).branch(...).build()`.
+### Equivalent Builder API
 
-## `*` -- Loop
+```python
+from adk_fluent import FanOut, Agent
+
+fanout = (
+    FanOut("parallel")
+    .branch(Agent("web", "gemini-2.5-flash").instruct("Search web.").writes("web_results"))
+    .branch(Agent("papers", "gemini-2.5-pro").instruct("Search papers.").writes("paper_results"))
+    .build()
+)
+```
+
+:::{warning}
+Each parallel branch writes to a **separate** state key via `.writes()`. If two branches write to the same key, the last one to finish wins. Always use distinct keys, then merge with `S.merge()`.
+:::
+
+---
+
+## `*` --- Loop
 
 ### Fixed Count
 
 Multiply an expression by an integer to loop a fixed number of times:
+
+```mermaid
+graph LR
+    subgraph "Repeats 3x"
+        A["Writer"] --> B["Reviewer"]
+    end
+    B -.->|"loop back"| A
+
+    style A fill:#10b981,color:#fff
+    style B fill:#10b981,color:#fff
+```
 
 ```python
 loop = (
@@ -205,22 +218,24 @@ loop = (
 
 ### Conditional Loop with `until()`
 
-`* until(pred)` loops until a predicate on session state is satisfied:
+Loop until a predicate on session state is satisfied:
 
 ```python
 from adk_fluent import until
 
 loop = (
-    Agent("writer").model("gemini-2.5-flash").instruct("Write.").writes("quality")
-    >> Agent("reviewer").model("gemini-2.5-flash").instruct("Review.")
+    Agent("writer", "gemini-2.5-flash").instruct("Write.").writes("quality")
+    >> Agent("reviewer", "gemini-2.5-flash").instruct("Review.")
 ) * until(lambda s: s.get("quality") == "good", max=5)
 ```
 
-The `max` parameter sets a safety limit on the number of iterations.
+The `max` parameter sets a safety limit on iterations.
 
-## `@` -- Typed Output
+---
 
-`@` binds a Pydantic schema as the agent's output contract:
+## `@` --- Typed Output
+
+Binds a Pydantic schema as the agent's output contract:
 
 ```python
 from pydantic import BaseModel
@@ -228,77 +243,138 @@ from pydantic import BaseModel
 class Report(BaseModel):
     title: str
     body: str
+    confidence: float
 
-agent = Agent("writer").model("gemini-2.5-flash").instruct("Write.") @ Report
+agent = Agent("writer", "gemini-2.5-flash").instruct("Write.") @ Report
 ```
 
-The agent's output is validated against the schema, ensuring structured, typed responses.
+Equivalent to `.returns(Report)`. The LLM is constrained to produce JSON matching the schema.
 
-## `//` -- Fallback Chain
+:::{note}
+When `output_schema` is set, tool availability depends on model capabilities. For models that don't natively support both, ADK injects a `set_model_response` workaround tool.
+:::
 
-`//` tries each agent in order. The first agent to succeed wins:
+---
+
+## `//` --- Fallback Chain
+
+Tries each agent in order. The first to succeed wins:
+
+```mermaid
+graph LR
+    A["Fast Model"] -->|"fails"| B["Strong Model"] -->|"fails"| C["Expert Model"]
+    A -->|"succeeds"| OUT["Result"]
+    B -->|"succeeds"| OUT
+    C -->|"succeeds"| OUT
+
+    style A fill:#a78bfa,color:#fff
+    style B fill:#a78bfa,color:#fff
+    style C fill:#a78bfa,color:#fff
+    style OUT fill:#10b981,color:#fff
+```
 
 ```python
 answer = (
-    Agent("fast").model("gemini-2.0-flash").instruct("Quick answer.")
-    // Agent("thorough").model("gemini-2.5-pro").instruct("Detailed answer.")
+    Agent("fast", "gemini-2.0-flash").instruct("Quick answer.")
+    // Agent("thorough", "gemini-2.5-pro").instruct("Detailed answer.")
 )
 ```
 
-This is useful for cost optimization: try a cheaper, faster model first and fall back to a more capable model only if needed.
+:::{tip}
+Use fallback chains for **cost optimization**: try a cheaper, faster model first and fall back to a more capable (expensive) model only if needed.
+:::
 
-## `Route("key").eq(...)` -- Deterministic Routing
+---
 
-Route on session state without LLM calls:
+## `Route("key")` --- Deterministic Routing
+
+Route on session state values without LLM calls:
+
+```mermaid
+flowchart LR
+    CL["Classifier<br/>.writes('intent')"] --> R{"Route('intent')"}
+    R -->|"booking"| BK["Booker"]
+    R -->|"info"| IN["Info Agent"]
+    R -->|"otherwise"| DF["Default"]
+
+    style CL fill:#e94560,color:#fff
+    style R fill:#f472b6,color:#fff
+    style BK fill:#0ea5e9,color:#fff
+    style IN fill:#0ea5e9,color:#fff
+    style DF fill:#64748b,color:#fff
+```
 
 ```python
 from adk_fluent import Agent
 from adk_fluent._routing import Route
 
-classifier = Agent("classify").model("gemini-2.5-flash").instruct("Classify intent.").writes("intent")
-booker = Agent("booker").model("gemini-2.5-flash").instruct("Book flights.")
-info = Agent("info").model("gemini-2.5-flash").instruct("Provide info.")
+classifier = Agent("classify", "gemini-2.5-flash").instruct("Classify intent.").writes("intent")
 
-# Route on exact match — zero LLM calls for routing
-pipeline = classifier >> Route("intent").eq("booking", booker).eq("info", info)
-
-# Dict shorthand
-pipeline = classifier >> {"booking": booker, "info": info}
-```
-
-The dict shorthand `>> {"key": agent}` is equivalent to `Route` with `.eq()` for each key-value pair.
-
-## Conditional Gating
-
-`.proceed_if()` gates an agent's execution based on a state predicate:
-
-```python
-enricher = (
-    Agent("enricher")
-    .model("gemini-2.5-flash")
-    .instruct("Enrich the data.")
-    .proceed_if(lambda s: s.get("valid") == "yes")
+pipeline = classifier >> (
+    Route("intent")
+    .eq("booking", Agent("booker").instruct("Book flights."))
+    .eq("info", Agent("info").instruct("Provide info."))
+    .otherwise(Agent("default").instruct("General help."))
 )
 ```
 
-The agent only runs if the predicate returns a truthy value.
+### Route Methods
 
-## Full Composition
+| Method | Match Type | Example |
+|--------|-----------|---------|
+| `.eq(value, agent)` | Exact match | `.eq("VIP", vip_agent)` |
+| `.contains(sub, agent)` | Substring | `.contains("error", error_agent)` |
+| `.gt(n, agent)` | Greater than | `.gt(100, premium_agent)` |
+| `.lt(n, agent)` | Less than | `.lt(0, negative_agent)` |
+| `.when(pred, agent)` | Custom predicate | `.when(lambda v: v > 0.8, high_agent)` |
+| `.otherwise(agent)` | Default fallback | `.otherwise(default_agent)` |
 
-All operators compose into a single expression. The following example combines every operator:
+### Dict Shorthand
 
+```python
+# These are equivalent:
+pipeline = classifier >> Route("intent").eq("booking", booker).eq("info", info)
+pipeline = classifier >> {"booking": booker, "info": info}
 ```
-Full composition topology:
 
-  ┬─ web ────┐
-  └─ scholar ┘  (|)
-       │
-  S.merge(into="research")
-       │
-  writer @ Report // writer_b @ Report  (//)
-       │
-  ┌──► critic ──► reviser ──┐
-  └── until(confidence≥0.85) ┘  (*)
+---
+
+## Full Composition Example
+
+All operators compose into a single expression:
+
+```mermaid
+graph TB
+    subgraph "Fan-Out (|)"
+        W["web"] & SC["scholar"]
+    end
+
+    subgraph "State Transform"
+        SM["S.merge into='research'"]
+    end
+
+    subgraph "Fallback (//)"
+        WR1["writer @ Report"] -.->|"fails"| WR2["writer_b @ Report"]
+    end
+
+    subgraph "Loop (* until)"
+        CR["critic"] --> RV["reviser"]
+        RV -.->|"confidence < 0.85"| CR
+    end
+
+    W --> SM
+    SC --> SM
+    SM --> WR1
+    WR2 --> CR
+    WR1 -->|"succeeds"| CR
+
+    style W fill:#0ea5e9,color:#fff
+    style SC fill:#0ea5e9,color:#fff
+    style SM fill:#10b981,color:#fff
+    style WR1 fill:#f59e0b,color:#fff
+    style WR2 fill:#f59e0b,color:#fff
+    style CR fill:#10b981,color:#fff
+    style RV fill:#10b981,color:#fff
 ```
 
 ```python
@@ -311,37 +387,179 @@ class Report(BaseModel):
     confidence: float
 
 pipeline = (
-    (   Agent("web").model("gemini-2.5-flash").instruct("Search web.")
-      | Agent("scholar").model("gemini-2.5-flash").instruct("Search papers.")
+    # Fan-out: parallel research
+    (   Agent("web", "gemini-2.5-flash").instruct("Search web.").writes("web")
+      | Agent("scholar", "gemini-2.5-flash").instruct("Search papers.").writes("scholar")
     )
+    # State transform: merge results
     >> S.merge("web", "scholar", into="research")
-    >> Agent("writer").model("gemini-2.5-flash").instruct("Write.") @ Report
-       // Agent("writer_b").model("gemini-2.5-pro").instruct("Write.") @ Report
+    # Fallback: try fast model, fall back to strong
+    >> Agent("writer", "gemini-2.5-flash").instruct("Write.") @ Report
+       // Agent("writer_b", "gemini-2.5-pro").instruct("Write.") @ Report
+    # Loop: refine until quality threshold
     >> (
-        Agent("critic").model("gemini-2.5-flash").instruct("Score.").writes("confidence")
-        >> Agent("reviser").model("gemini-2.5-flash").instruct("Improve.")
+        Agent("critic", "gemini-2.5-flash").instruct("Score.").writes("confidence")
+        >> Agent("reviser", "gemini-2.5-flash").instruct("Improve.")
     ) * until(lambda s: s.get("confidence", 0) >= 0.85, max=4)
 )
 ```
 
-This expression combines parallel fan-out (`|`), state transforms (`S.merge`), typed output (`@ Report`), fallback (`//`), and conditional loops (`* until`).
+---
+
+## Expression vs Builder vs Native ADK
+
+Three ways to express the same pipeline:
+
+::::{tab-set}
+:::{tab-item} Expression Operators
+```python
+from adk_fluent import Agent
+
+pipeline = (
+    Agent("a", "gemini-2.5-flash").instruct("Step 1.").writes("result")
+    >> Agent("b", "gemini-2.5-flash").instruct("Step 2 using {result}.")
+).build()
+```
+:::
+:::{tab-item} Builder API
+```python
+from adk_fluent import Pipeline, Agent
+
+pipeline = (
+    Pipeline("flow")
+    .step(Agent("a", "gemini-2.5-flash").instruct("Step 1.").writes("result"))
+    .step(Agent("b", "gemini-2.5-flash").instruct("Step 2 using {result}."))
+    .build()
+)
+```
+:::
+:::{tab-item} Native ADK
+```python
+from google.adk.agents import LlmAgent, SequentialAgent
+
+a = LlmAgent(name="a", model="gemini-2.5-flash", instruction="Step 1.", output_key="result")
+b = LlmAgent(name="b", model="gemini-2.5-flash", instruction="Step 2 using {result}.")
+
+pipeline = SequentialAgent(name="flow", sub_agents=[a, b])
+```
+:::
+::::
+
+All three produce the **same** `SequentialAgent` at runtime.
+
+---
+
+## Composition Matrix
+
+Which operators can nest inside which? Every combination works.
+
+| Outer ↓ / Inner → | `>>` | `\|` | `*` | `@` | `//` | `Route` |
+|---|---|---|---|---|---|---|
+| **`>>`** (sequence) | Flatten | Nest | Nest | Nest | Nest | Nest |
+| **`\|`** (parallel) | Nest | Flatten | Nest | Nest | Nest | Nest |
+| **`*`** (loop) | Nest | Nest | Nest | Nest | Nest | Nest |
+| **`//`** (fallback) | Nest | Nest | Nest | Nest | Chain | Nest |
+
+**Flatten** means `a >> (b >> c)` is equivalent to `a >> b >> c`. **Nest** means the inner expression becomes a single node in the outer topology.
+
+---
 
 ## Backend Compatibility
 
-All expression operators work identically across backends. The *definition* is the same — only execution semantics change:
+All expression operators work identically across backends. The definition is the same --- only execution semantics change:
 
 | Operator | ADK (default) | Temporal (in dev) | asyncio (in dev) |
 |----------|--------------|-------------------|------------------|
-| `>>` (sequence) | Sequential agents | Sequential activities | Sequential coroutines |
-| `\|` (parallel) | Parallel agents | `asyncio.gather()` over activities | `asyncio.gather()` |
-| `*` (loop) | Loop agent | Checkpointed `while` loop | `while` loop |
-| `//` (fallback) | Fallback agent | try/except over activities | try/except |
-| `@ Schema` | output_schema | Same (schema on activity) | Same |
+| `>>` | Sequential agents | Sequential activities | Sequential coroutines |
+| `\|` | Parallel agents | `asyncio.gather()` over activities | `asyncio.gather()` |
+| `*` | Loop agent | Checkpointed `while` loop | `while` loop |
+| `//` | Fallback agent | try/except over activities | try/except |
+| `@ Schema` | `output_schema` | Same (schema on activity) | Same |
 | `Route(...)` | Custom agent | Inline deterministic code | Inline |
 
-When using Temporal, deterministic operators (`>>`, `Route`, `S.*`) become replay-safe workflow code, while non-deterministic operators (anything involving an LLM call) become cached activities. See [Temporal Guide](temporal-guide.md) for details.
+---
+
+## Common Mistakes
+
+::::{grid} 1
+:gutter: 3
+
+:::{grid-item-card} Nesting `>>` inside `|` without wrapping
+:class-card: sd-border-danger
+
+```python
+# ❌ Ambiguous — does b run in parallel with a, or after a?
+result = a >> b | c
+```
+
+```python
+# ✅ Clear — parallel between (a >> b) and c
+result = (a >> b) | c
+```
+:::
+
+:::{grid-item-card} Forgetting max on `until()`
+:class-card: sd-border-danger
+
+```python
+# ❌ Risky — could loop forever if predicate never satisfied
+loop = (writer >> reviewer) * until(lambda s: s.get("done"))
+```
+
+```python
+# ✅ Safe — always set a max iteration limit
+loop = (writer >> reviewer) * until(lambda s: s.get("done"), max=5)
+```
+:::
+
+:::{grid-item-card} Building sub-expressions prematurely
+:class-card: sd-border-danger
+
+```python
+# ❌ Wrong — .build() converts to ADK object, can't compose further
+step = Agent("a").instruct("...").build()
+pipeline = step >> Agent("b")  # Error!
+```
+
+```python
+# ✅ Correct — keep as builder until final composition
+step = Agent("a").instruct("...")
+pipeline = (step >> Agent("b")).build()  # Build at the end
+```
+:::
+::::
+
+---
+
+## Interplay With Other Concepts
+
+| Combines With | To Achieve | Example |
+|--------------|-----------|---------|
+| [State Transforms](state-transforms.md) | Clean data between agents | `agent >> S.pick("key") >> agent_b` |
+| [Patterns](patterns.md) | Named higher-order topologies | `review_loop(worker, reviewer)` |
+| [Data Flow](data-flow.md) | Explicit agent I/O contracts | `agent.writes("k") >> agent.reads("k")` |
+| [Callbacks](callbacks.md) | Logging and guardrails in pipelines | `agent.before_model(log_fn) >> agent_b` |
+| [Typed Output](structured-data.md) | Schema-constrained responses | `agent @ Report >> validator` |
+
+---
+
+## API Quick Reference
+
+| Primitive | Import | Purpose |
+|-----------|--------|---------|
+| `until(pred, max=)` | `from adk_fluent import until` | Loop condition for `*` |
+| `tap(fn)` | `from adk_fluent import tap` | Side-effect observer (no mutation) |
+| `expect(pred, msg=)` | `from adk_fluent import expect` | State assertion |
+| `map_over(key)` | `from adk_fluent import map_over` | Map agent over list items |
+| `gate(pred)` | `from adk_fluent import gate` | Conditional skip |
+| `race(*agents)` | `from adk_fluent import race` | First-to-complete wins |
+| `dispatch(name=)` | `from adk_fluent import dispatch` | Background task |
+| `join()` | `from adk_fluent import join` | Wait for background tasks |
 
 :::{seealso}
-- [Execution Backends](execution-backends.md) — backend selection and capability matrix
-- [Temporal Guide](temporal-guide.md) — how operators map to Temporal concepts
+- {doc}`data-flow` --- how state flows through expressions
+- {doc}`patterns` --- higher-order composition patterns
+- {doc}`state-transforms` --- S module for data manipulation
+- {doc}`execution-backends` --- how operators map to different backends
+- {doc}`temporal-guide` --- operators in Temporal workflows
 :::

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -1,0 +1,216 @@
+# FAQ
+
+:::{admonition} At a Glance
+:class: tip
+
+Top 20 questions about adk-fluent with direct answers and links.
+:::
+
+## General
+
+### What is adk-fluent?
+
+A fluent builder API for Google's Agent Development Kit (ADK). It reduces agent creation from 22+ lines to 1-3 lines while producing **identical native ADK objects**. Every `.build()` returns a real ADK object compatible with `adk web`, `adk run`, and `adk deploy`.
+
+### Does adk-fluent add runtime overhead?
+
+No. Builders exist only at definition time. After `.build()`, adk-fluent is gone --- you have a pure ADK object. Zero runtime overhead.
+
+### Can I mix adk-fluent with native ADK code?
+
+Yes. `.build()` returns a native ADK object. You can pass it to any ADK function, use it with `adk web`, or mix fluent and native agents in the same pipeline.
+
+### Which models does adk-fluent support?
+
+Any model that ADK supports. Use `gemini-2.5-flash` for fast/cheap, `gemini-2.5-pro` for quality. Model names are passed as strings to `.model()` or as the second positional arg to `Agent()`.
+
+---
+
+## Building Agents
+
+### When do I call `.build()`?
+
+Call `.build()` on the **outermost** builder only. Sub-builders inside `Pipeline`, `FanOut`, `Loop`, or expression operators are auto-built:
+
+```python
+# ✅ Correct --- .build() on the pipeline only
+pipeline = (Agent("a") >> Agent("b")).build()
+
+# ❌ Wrong --- don't build sub-builders
+Pipeline("p").step(Agent("a").build()).build()
+```
+
+### What's the difference between `.instruct()` and `.describe()`?
+
+- `.instruct()` sets the **system prompt** --- what the LLM is told to do
+- `.describe()` sets **metadata** for transfer routing --- NOT sent to the LLM
+
+### What's the difference between `.sub_agent()` and `.agent_tool()`?
+
+- `.sub_agent()`: The LLM decides when to hand off (transfer-based). Control transfers to the child.
+- `.agent_tool()`: The parent LLM invokes the child like a tool (stays in control).
+
+Use `.agent_tool()` by default. Use `.sub_agent()` when the child needs full conversational control. See {doc}`transfer-control`.
+
+### How do I add multiple tools?
+
+```python
+# One at a time
+agent = Agent("a").tool(fn1).tool(fn2)
+
+# All at once
+agent = Agent("a").tools([fn1, fn2])
+
+# T module composition
+agent = Agent("a").tools(T.fn(fn1) | T.fn(fn2) | T.google_search())
+```
+
+---
+
+## Data Flow
+
+### How do I pass data between agents?
+
+Use `.writes()` to store output in state, and `.reads()` or `{key}` templates to access it:
+
+```python
+pipeline = (
+    Agent("a").writes("result")                # Store output
+    >> Agent("b").instruct("Use {result}.")    # Template access
+)
+```
+
+See {doc}`data-flow`.
+
+### What's the difference between `.reads()` and `.context()`?
+
+Both control what the agent sees. `.reads("key")` is a shorthand that:
+1. Injects `state["key"]` into the prompt
+2. Suppresses conversation history
+
+`.context(C.xxx())` gives fine-grained control (window, user-only, budget, etc.). You can combine them. See {doc}`context-engineering`.
+
+### Why does my agent see the same data twice?
+
+ADK has three independent channels: conversation history, session state, and instruction templating. When you use `.writes("intent")`, the text appears in **both** conversation history (Channel 1) and state (Channel 2). Use `.reads("intent")` on downstream agents to suppress history and use only state.
+
+See {doc}`architecture-and-concepts` for the full explanation.
+
+### What's the difference between `.writes()` and `.returns()`?
+
+- `.writes(key)` stores the **raw text** response in `state[key]` (for downstream agents)
+- `.returns(Schema)` constrains the LLM to produce **structured JSON** matching a Pydantic model
+
+They're orthogonal --- you can use both on the same agent.
+
+---
+
+## Operators
+
+### What's the difference between `>>` and `|`?
+
+- `>>` (sequence): Agents run one after another. `a >> b >> c`
+- `|` (parallel): Agents run concurrently. `a | b | c`
+
+### Can I combine operators?
+
+Yes, all operators compose:
+
+```python
+pipeline = (
+    (Agent("web") | Agent("papers"))          # Parallel research
+    >> S.merge("web", "papers", into="all")   # Merge results
+    >> Agent("writer") @ Report               # Write with schema
+    >> (Agent("critic") >> Agent("reviser"))   # Review loop
+    * until(lambda s: s.get("score") >= 0.8, max=3)
+)
+```
+
+### What does `@` do?
+
+`Agent("a") @ Schema` is equivalent to `Agent("a").returns(Schema)`. It constrains the LLM to produce JSON matching the Pydantic model.
+
+---
+
+## Testing
+
+### How do I test without making LLM calls?
+
+Use `mock_backend()` and `AgentHarness`:
+
+```python
+from adk_fluent.testing import AgentHarness, mock_backend
+
+harness = AgentHarness(
+    my_pipeline,
+    backend=mock_backend({"agent_a": "mocked response"})
+)
+response = await harness.send("test")
+```
+
+See {doc}`testing`.
+
+### How do I catch data flow bugs?
+
+Use `check_contracts()` --- it's free (no LLM calls) and catches the most common bugs:
+
+```python
+from adk_fluent.testing import check_contracts
+issues = check_contracts(my_pipeline.to_ir())
+assert not issues
+```
+
+---
+
+## Async / Sync
+
+### I get RuntimeError in Jupyter / FastAPI. Why?
+
+The sync methods (`.ask()`, `.map()`) raise `RuntimeError` inside an async event loop. Use the async variants:
+
+```python
+# ❌ In Jupyter/FastAPI
+result = agent.ask("hello")  # RuntimeError!
+
+# ✅ Use async variants
+result = await agent.ask_async("hello")
+```
+
+---
+
+## Advanced
+
+### How do I use Temporal for durable execution?
+
+```python
+pipeline = (Agent("a") >> Agent("b")).engine("temporal", client=client, task_queue="my-queue")
+```
+
+See {doc}`temporal-guide`.
+
+### Can I use MCP tools?
+
+Yes, via the T module:
+
+```python
+agent = Agent("helper").tools(T.mcp(my_mcp_server))
+```
+
+### How do I inject dependencies (DB clients, API keys)?
+
+Use `.inject()` --- injected params are hidden from the LLM tool schema:
+
+```python
+agent = Agent("lookup").tool(search_db).inject(db=my_database)
+# LLM sees: search_db(query: str)
+# At runtime: db=my_database injected
+```
+
+---
+
+:::{seealso}
+- {doc}`../getting-started` --- 5-minute quickstart
+- {doc}`cheat-sheet` --- one-page API reference
+- {doc}`glossary` --- term definitions
+- {doc}`troubleshooting` --- error → cause → fix
+:::

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -1,0 +1,176 @@
+# Glossary
+
+:::{admonition} At a Glance
+:class: tip
+
+Term definitions for adk-fluent concepts. If a term confuses you, find it here.
+:::
+
+## A
+
+**A2A (Agent-to-Agent)**
+: Remote agent communication protocol. Allows agents to call other agents over HTTP. See {doc}`a2a`.
+
+**A2UI (Agent-to-UI)**
+: Declarative UI composition for agents. Agents can generate UI surfaces. See {doc}`a2ui`.
+
+**ADK (Agent Development Kit)**
+: Google's framework for building AI agents. adk-fluent is a builder layer on top of ADK. Every `.build()` returns a native ADK object.
+
+**Agent**
+: The core builder. Configures an `LlmAgent` via fluent method calls. `Agent("name", "model")` is the starting point for everything.
+
+**AgentTool**
+: An agent wrapped as a callable tool. The parent LLM invokes the child like any function. Created via `.agent_tool(agent)`. Compare with sub-agent (transfer-based).
+
+**Artifact**
+: A file or blob managed by the A module. Published from state, loaded back into state. See A module in {doc}`data-flow`.
+
+## B
+
+**Backend**
+: The execution engine that runs compiled IR trees. Options: ADK (default, stable), Temporal (in dev), asyncio (in dev). See {doc}`execution-backends`.
+
+**Builder**
+: A fluent configuration object that compiles to a native ADK object via `.build()`. 132 builders across 9 modules.
+
+**Build time**
+: When `.build()` is called. Contracts are checked, IR is compiled, and the native ADK object is created. No LLM calls happen at build time.
+
+## C
+
+**C module (Context)**
+: Namespace for controlling what conversation history and state each agent sees. `C.none()`, `C.window(n)`, `C.from_state()`, etc. See {doc}`context-engineering`.
+
+**Callback**
+: A function attached to an agent's lifecycle (before/after model, agent, tool). Additive in adk-fluent --- multiple calls stack. See {doc}`callbacks`.
+
+**Contract**
+: A static annotation (`.produces()`, `.consumes()`) that declares what state keys an agent reads and writes. Verified at build time by `check_contracts()`. No runtime effect.
+
+**Context caching**
+: When `.static()` is set, the static prompt is cached by the model provider. Dynamic `.instruct()` text moves to user content.
+
+## D
+
+**Data flow**
+: The five orthogonal concerns: Context, Input, Output, Storage, Contract. Each controlled by a separate builder method. See {doc}`data-flow`.
+
+**Delta transform**
+: An S transform that only updates specified keys, preserving everything else. Examples: `S.default()`, `S.merge()`, `S.transform()`.
+
+## E
+
+**E module (Evaluation)**
+: Namespace for quality assessment. `E.case()`, `E.criterion()`, `EvalSuite`. See {doc}`evaluation`.
+
+**Expression operators**
+: Python operators (`>>`, `|`, `*`, `@`, `//`) overloaded to compose agent topologies. See {doc}`expression-language`.
+
+## F
+
+**FanOut**
+: Parallel execution builder. Runs branches concurrently. `FanOut("name").branch(a).branch(b).build()` or `a | b`. Compiles to `ParallelAgent`.
+
+**Fallback**
+: Try agents in order; first success wins. `a // b // c`. See {doc}`expression-language`.
+
+**FnAgent**
+: A zero-cost agent that executes a Python function (no LLM call). S transforms compile to FnAgent nodes.
+
+## G
+
+**G module (Guards)**
+: Namespace for output validation. `G.pii()`, `G.length()`, `G.schema()`. Guards compile to `after_model` callbacks. See {doc}`guards`.
+
+**Guard**
+: A validation function that checks LLM output. Raises `GuardViolation` on failure. Composed with `|`.
+
+## I
+
+**Immutability**
+: All expression operators produce new objects. Sub-expressions can be safely reused across different pipelines.
+
+**IR (Intermediate Representation)**
+: A frozen dataclass tree that represents the agent topology. Created by `.to_ir()`. Backends compile IR into executable code. See {doc}`ir-and-backends`.
+
+**`include_contents`**
+: ADK's binary switch for conversation history. `"default"` (full history) or `"none"` (current turn only). adk-fluent's C module provides finer control.
+
+## L
+
+**Loop**
+: Iterative execution builder. `Loop("name").step(a).max_iterations(3).build()` or `(a >> b) * 3`. Compiles to `LoopAgent`.
+
+## M
+
+**M module (Middleware)**
+: Namespace for pipeline-wide cross-cutting concerns. `M.retry()`, `M.log()`, `M.cost()`. Applied to entire pipelines, not individual agents. See {doc}`middleware`.
+
+**Memory**
+: Persistent state across sessions. `.memory()` attaches memory tools. See {doc}`memory`.
+
+**Mock backend**
+: A test backend that returns canned responses without LLM calls. Created via `mock_backend()`. See {doc}`testing`.
+
+## O
+
+**`output_key`**
+: ADK field that stores the LLM's text response in session state. Set via `.writes()` in adk-fluent. It's a duplication mechanism --- the text also remains in conversation history.
+
+**`output_schema`**
+: ADK field that constrains the LLM to produce JSON matching a Pydantic model. Set via `.returns()` or `@ Schema`.
+
+## P
+
+**P module (Prompt)**
+: Namespace for structured prompt composition. `P.role()`, `P.task()`, `P.constraint()`. Sections are ordered and composable. See {doc}`prompts`.
+
+**Pipeline**
+: Sequential execution builder. `Pipeline("name").step(a).step(b).build()` or `a >> b`. Compiles to `SequentialAgent`.
+
+**Preset**
+: A reusable configuration bundle applied with `.use()`. Bundles model, instructions, tools, callbacks. See {doc}`presets`.
+
+## R
+
+**Replacement transform**
+: An S transform that replaces session-scoped keys. Unmentioned keys become `None`. Examples: `S.pick()`, `S.drop()`, `S.rename()`.
+
+**Route**
+: Deterministic state-based routing without LLM calls. `Route("key").eq("value", agent)`. See {doc}`expression-language`.
+
+## S
+
+**S module (State)**
+: Namespace for state transforms between agent steps. `S.pick()`, `S.merge()`, `S.rename()`. Compile to zero-cost FnAgent nodes. See {doc}`state-transforms`.
+
+**Session state**
+: Flat dictionary at `session.state`. Scoped: unprefixed (session), `app:`, `user:`, `temp:`. The primary data channel between agents.
+
+**Sub-agent**
+: An agent added as a transfer target via `.sub_agent()`. The LLM decides when to hand off. Compare with AgentTool (tool-based invocation).
+
+## T
+
+**T module (Tools)**
+: Namespace for tool composition. `T.fn()`, `T.agent()`, `T.mcp()`. Compose with `|`. See CLAUDE.md reference.
+
+**Transfer control**
+: Mechanisms for routing between agents: `.sub_agent()` (LLM decides), `.agent_tool()` (parent stays in control), `.isolate()` (no transfers). See {doc}`transfer-control`.
+
+## U
+
+**UI module (Agent-to-UI)**
+: Namespace for declarative UI composition. `UI.text()`, `UI.button()`, `UI.form()`. Compose with `|` (row) and `>>` (column). See {doc}`a2ui`.
+
+**`until(pred, max=)`**
+: Loop condition for the `*` operator. Loops until `pred(state)` is true, with a safety limit. `(a >> b) * until(pred, max=5)`.
+
+---
+
+:::{seealso}
+- {doc}`concept-map` --- visual map of all concepts
+- {doc}`cheat-sheet` --- one-page API reference
+- {doc}`architecture-and-concepts` --- system architecture
+:::

--- a/docs/user-guide/guards.md
+++ b/docs/user-guide/guards.md
@@ -1,6 +1,29 @@
 # Guards (G Module)
 
-The G module provides a declarative composition surface for safety, validation, and policy guards. Guards compile into ADK `before_model_callback` and `after_model_callback` hooks automatically — you declare *what* to enforce, not *where* to enforce it.
+:::{admonition} At a Glance
+:class: tip
+
+- Guards validate and transform LLM output --- PII detection, length limits, schema validation
+- Compose with `|`: `G.pii("redact") | G.length(max=500) | G.schema(Model)`
+- Compile to `before_model` / `after_model` callbacks automatically
+:::
+
+```mermaid
+flowchart LR
+    LLM["LLM Response"] --> G1["G.pii()"]
+    G1 -->|pass| G2["G.length()"]
+    G2 -->|pass| G3["G.schema()"]
+    G3 -->|pass| OUT["Output"]
+    G1 -->|"fail"| BLOCK["GuardViolation"]
+    G2 -->|"fail"| BLOCK
+    G3 -->|"fail"| BLOCK
+
+    style LLM fill:#a78bfa,color:#fff
+    style OUT fill:#10b981,color:#fff
+    style BLOCK fill:#e94560,color:#fff
+```
+
+The G module provides a declarative composition surface for safety, validation, and policy guards. Guards compile into ADK `before_model_callback` and `after_model_callback` hooks automatically --- you declare *what* to enforce, not *where* to enforce it.
 
 ## Quick Start
 
@@ -142,9 +165,54 @@ ir = agent.to_ir()
 print(ir.guard_specs)  # Tuple of GGuard instances
 ```
 
-## See Also
+## Common Mistakes
 
-- [Cookbook: Guards](../../examples/cookbook/12_guards.py) — Legacy + G namespace examples
-- [Cookbook: G Module](../../examples/cookbook/67_g_module_guards.py) — Comprehensive G namespace examples
-- [Middleware](middleware.md) — M module for resilience (retry, circuit breaker)
-- [Callbacks](callbacks.md) — Low-level before/after hooks
+::::{grid} 1
+:gutter: 3
+
+:::{grid-item-card} Using guards for retry logic
+:class-card: sd-border-danger
+
+```python
+# ❌ Guards are for safety/validation, not resilience
+agent.guard(my_retry_logic)
+```
+
+```python
+# ✅ Use middleware for retry
+pipeline.middleware(M.retry(3))
+```
+:::
+
+:::{grid-item-card} Mixing guard and callback for the same concern
+:class-card: sd-border-danger
+
+```python
+# ❌ Redundant --- guard already compiles to after_model
+agent.guard(G.length(max=500)).after_model(check_length)
+```
+
+```python
+# ✅ Use guard alone for validation
+agent.guard(G.length(max=500))
+```
+:::
+::::
+
+## Interplay With Other Concepts
+
+| Combines With | To Achieve | Example |
+|--------------|-----------|---------|
+| [Callbacks](callbacks.md) | Guards compile to callbacks | `.guard(G.pii())` → `after_model_callback` |
+| [Middleware](middleware.md) | Guards are per-agent; middleware is pipeline-wide | Guard for PII, middleware for retry |
+| [Testing](testing.md) | Verify guards are attached in IR | `assert ir.guard_specs` |
+| [Structured Data](structured-data.md) | Schema validation | `G.schema(MyModel)` |
+
+---
+
+:::{seealso}
+- {doc}`callbacks` --- low-level before/after hooks
+- {doc}`middleware` --- pipeline-wide resilience (retry, circuit breaker)
+- {doc}`testing` --- verifying guards in IR
+:::
+

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -93,6 +93,43 @@ Production concerns.
 Start with ADK. If you need durability, see [Execution Backends](execution-backends.md).
 :::
 
+## Quick Reference
+
+New to adk-fluent? Use this flowchart to find the right page:
+
+```mermaid
+flowchart TD
+    START{"What do you need?"} -->|"Understand the system"| ARCH["Architecture & Concepts"]
+    START -->|"Build my first agent"| BUILD["Builders"]
+    START -->|"Compose agents into workflows"| EXPR["Expression Language"]
+    START -->|"Pass data between agents"| DATA["Data Flow"]
+    START -->|"Quick API lookup"| CHEAT["Cheat Sheet"]
+    START -->|"Fix an error"| TROUBLE["Troubleshooting"]
+    START -->|"See all concepts"| MAP["Concept Map"]
+    START -->|"Find a term"| GLOSS["Glossary"]
+
+    click ARCH "architecture-and-concepts.html"
+    click BUILD "builders.html"
+    click EXPR "expression-language.html"
+    click DATA "data-flow.html"
+    click CHEAT "cheat-sheet.html"
+    click TROUBLE "troubleshooting.html"
+    click MAP "concept-map.html"
+    click GLOSS "glossary.html"
+
+    style START fill:#e94560,color:#fff
+```
+
+| Resource | Description |
+|---|---|
+| [Concept Map](concept-map.md) | Visual map of ALL concepts and how they relate |
+| [Cheat Sheet](cheat-sheet.md) | One-page quick reference for all operators, modules, and methods |
+| [Glossary](glossary.md) | Term definitions |
+| [FAQ](faq.md) | Top 20 questions with direct answers |
+| [Troubleshooting](troubleshooting.md) | Error → cause → fix lookup table |
+| [Performance](performance.md) | Token budgets, model selection, pipeline optimization |
+| [Design Philosophy](design-philosophy.md) | Why fluent? Why immutable? Why auto-generated? |
+
 ## Reference
 
 | Resource | Description |
@@ -134,6 +171,13 @@ a2a
 a2ui
 skills
 error-reference
+concept-map
+cheat-sheet
+glossary
+faq
+troubleshooting
+performance
+design-philosophy
 adk-samples/index
 ```
 

--- a/docs/user-guide/ir-and-backends.md
+++ b/docs/user-guide/ir-and-backends.md
@@ -1,5 +1,13 @@
 # IR and Backends
 
+:::{admonition} At a Glance
+:class: tip
+
+- The IR tree is a frozen dataclass representation of your agent topology
+- Backends compile IR to engine-specific runnables (ADK, Temporal, asyncio)
+- `.to_ir()` for inspection, `.to_app()` for compilation, `.to_mermaid()` for visualization
+:::
+
 The Intermediate Representation (IR) decouples the fluent builder API from execution engines. Builders compile to a tree of frozen dataclasses, which backends then compile to engine-specific runnables.
 
 :::{admonition} Multiple execution backends

--- a/docs/user-guide/memory.md
+++ b/docs/user-guide/memory.md
@@ -1,5 +1,13 @@
 # Memory
 
+:::{admonition} At a Glance
+:class: tip
+
+- `.memory()` attaches memory tools for persistent state across sessions
+- Three modes: preload (inject at start), tool-based (agent decides), auto-save (save after execution)
+- Use for agents that need to remember previous conversations
+:::
+
 `.memory()` adds ADK memory tools to an agent for long-term recall across sessions. Without memory, each session starts fresh -- the agent has no knowledge of past interactions. With memory, the agent can retrieve relevant past conversations automatically.
 
 ## When to Use Memory

--- a/docs/user-guide/middleware.md
+++ b/docs/user-guide/middleware.md
@@ -1,5 +1,28 @@
 # Middleware
 
+:::{admonition} At a Glance
+:class: tip
+
+- Middleware provides **pipeline-wide** cross-cutting behavior (retry, logging, cost tracking)
+- Compose with `|`: `M.retry(3) | M.log() | M.cost()`
+- Use middleware for infrastructure; use callbacks for per-agent behavior
+:::
+
+```mermaid
+graph LR
+    subgraph "Middleware Stack (onion model)"
+        direction LR
+        R["M.retry()"] --> L["M.log()"] --> C["M.cost()"]
+        C --> AGENT["Agent Execution"]
+        AGENT --> C2["M.cost()"] --> L2["M.log()"] --> R2["M.retry()"]
+    end
+
+    style R fill:#e94560,color:#fff
+    style L fill:#0ea5e9,color:#fff
+    style C fill:#10b981,color:#fff
+    style AGENT fill:#a78bfa,color:#fff
+```
+
 Middleware provides app-global cross-cutting behavior. Unlike [callbacks](callbacks.md) which are per-agent, middleware applies to the entire execution across all agents. Unlike [presets](presets.md) which share config across agents, middleware operates at the *pipeline* level.
 
 ## When to Use Middleware vs. Callbacks vs. Presets vs. Guards
@@ -255,6 +278,41 @@ See [Testing](testing.md).
 3. **Use `M.scope()` for agent-specific middleware.** Not all agents need the same middleware -- scope expensive operations (caching, circuit breaker) to agents that benefit
 4. **Use `M.when()` for environment-specific behavior.** Don't branch in your pipeline code -- let middleware handle it
 5. **Middleware is for infrastructure, not business logic.** Retry, logging, tracing, caching -- these are middleware concerns. Routing, classification, data transformation -- these are agent/function concerns
+
+## Common Mistakes
+
+::::{grid} 1
+:gutter: 3
+
+:::{grid-item-card} Adding retry logic to individual agents
+:class-card: sd-border-danger
+
+```python
+# ❌ Repeating retry on every agent
+agent_a = Agent("a").on_model_error(retry_fn)
+agent_b = Agent("b").on_model_error(retry_fn)
+```
+
+```python
+# ✅ Use middleware once for the pipeline
+pipeline = (Agent("a") >> Agent("b")).middleware(M.retry(3))
+```
+:::
+
+:::{grid-item-card} Wrong middleware order
+:class-card: sd-border-danger
+
+```python
+# ❌ Logging inside retry — retried calls not logged correctly
+stack = M.log() | M.retry(3)
+```
+
+```python
+# ✅ Retry outermost — wraps everything including logging
+stack = M.retry(3) | M.log()
+```
+:::
+::::
 
 ## Backend Awareness
 

--- a/docs/user-guide/patterns.md
+++ b/docs/user-guide/patterns.md
@@ -1,31 +1,128 @@
 # Composition Patterns
 
-Higher-order constructors from `adk_fluent.patterns` that compose agents into common architectures. Each pattern is a function that returns a ready-to-use builder.
+:::{admonition} At a Glance
+:class: tip
+
+- Higher-order constructors that compose agents into common architectures
+- Each pattern returns a ready-to-use builder --- call `.build()` or chain with `>>`
+- All patterns work identically across execution backends (ADK, Temporal, asyncio)
+:::
+
+## Pattern Gallery
+
+```mermaid
+graph TB
+    subgraph "review_loop"
+        RL_W["Worker"] --> RL_R["Reviewer"]
+        RL_R -.->|"score < target"| RL_W
+    end
+
+    subgraph "cascade"
+        CA["Fast"] -.->|fail| CB["Strong"] -.->|fail| CC["Fallback"]
+    end
+
+    subgraph "fan_out_merge"
+        FO_A["Agent A"] --> FO_M["Merge"]
+        FO_B["Agent B"] --> FO_M
+        FO_C["Agent C"] --> FO_M
+    end
+
+    subgraph "map_reduce"
+        MR_I["Items"] --> MR_A["Mapper"] --> MR_R["Reducer"]
+        MR_I --> MR_B["Mapper"] --> MR_R
+    end
+
+    subgraph "conditional"
+        CO_P{"Predicate?"} -->|yes| CO_T["Then"]
+        CO_P -->|no| CO_F["Else"]
+    end
+
+    subgraph "supervised"
+        SU_W["Worker"] --> SU_S["Supervisor"]
+        SU_S -.->|"revise"| SU_W
+    end
+
+    style RL_W fill:#e94560,color:#fff
+    style RL_R fill:#0ea5e9,color:#fff
+    style CA fill:#a78bfa,color:#fff
+    style CB fill:#a78bfa,color:#fff
+    style CC fill:#a78bfa,color:#fff
+    style FO_A fill:#0ea5e9,color:#fff
+    style FO_B fill:#0ea5e9,color:#fff
+    style FO_C fill:#0ea5e9,color:#fff
+    style FO_M fill:#10b981,color:#fff
+    style MR_A fill:#f59e0b,color:#fff
+    style MR_B fill:#f59e0b,color:#fff
+    style MR_R fill:#10b981,color:#fff
+    style SU_W fill:#e94560,color:#fff
+    style SU_S fill:#0ea5e9,color:#fff
+```
+
+## Pattern Quick Reference
+
+| Pattern | Operator Equivalent | Use Case |
+|---------|-------------------|----------|
+| `review_loop` | `(worker >> reviewer) * until(...)` | Iterative refinement |
+| `cascade` | `a // b // c` | Cost-optimized fallback |
+| `fan_out_merge` | `(a \| b) >> S.merge(...)` | Parallel research + combine |
+| `chain` | `a >> b >> c` | Sequential with auto-wiring |
+| `conditional` | `gate(pred)` + routing | If/else branching |
+| `supervised` | `(worker >> supervisor) * until(approved)` | Approval workflows |
+| `map_reduce` | `map_over(key) >> reducer` | Process list items |
 
 ```python
-from adk_fluent.patterns import review_loop, cascade, fan_out_merge, chain, conditional, supervised, map_reduce
+from adk_fluent.patterns import (
+    review_loop, cascade, fan_out_merge,
+    chain, conditional, supervised, map_reduce,
+)
 ```
 
+---
+
+## Which Pattern Do I Need?
+
+```mermaid
+flowchart TD
+    START{What's the workflow shape?} -->|"Refine until quality met"| RL["review_loop"]
+    START -->|"Try cheap, fall back to expensive"| CA["cascade"]
+    START -->|"Gather from multiple sources"| FOM["fan_out_merge"]
+    START -->|"Simple A then B then C"| CH["chain"]
+    START -->|"Different paths based on condition"| CO["conditional"]
+    START -->|"Worker needs approval"| SU["supervised"]
+    START -->|"Same task on each list item"| MR["map_reduce"]
+
+    style START fill:#e94560,color:#fff
+    style RL fill:#10b981,color:#fff
+    style CA fill:#a78bfa,color:#fff
+    style FOM fill:#0ea5e9,color:#fff
+    style CH fill:#e94560,color:#fff
+    style CO fill:#f59e0b,color:#fff
+    style SU fill:#f472b6,color:#fff
+    style MR fill:#f59e0b,color:#fff
 ```
-Pattern Quick Reference:
 
-  review_loop    ( worker >> reviewer ) * until(score >= target)
-  cascade        agent_a // agent_b // agent_c
-  fan_out_merge  ( a | b | c ) >> S.merge(into="combined")
-  chain          a >> b >> c  (with .writes()/.reads() wiring)
-  conditional    pred? ─┬─ true_branch
-                        └─ false_branch
-  supervised     ( worker >> supervisor ) * until(approved)
-  map_reduce     items ──┬─ mapper(item_0)
-                         ├─ mapper(item_1) ──>> reducer
-                         └─ mapper(item_n)
-```
+---
 
-______________________________________________________________________
-
-## `review_loop` — Refinement Loop
+## `review_loop` --- Iterative Refinement
 
 A worker produces output, a reviewer scores it, and the loop repeats until quality meets the target.
+
+```mermaid
+sequenceDiagram
+    participant W as Worker
+    participant R as Reviewer
+    participant S as State
+
+    W->>S: writes draft
+    S->>R: reads draft
+    R->>S: writes score = 0.5
+    Note over S: score < 0.8 → loop
+    S->>W: reads feedback
+    W->>S: writes improved draft
+    S->>R: reads draft
+    R->>S: writes score = 0.85
+    Note over S: score >= 0.8 → done
+```
 
 ```python
 pipeline = review_loop(
@@ -37,30 +134,33 @@ pipeline = review_loop(
 )
 ```
 
-```
-    ┌──────────────────────────────────────────────┐
-    │             ┌──────────┐    ┌──────────┐     │
-    │  ──────────►│  worker  │───►│ reviewer │──┐  │
-    │  │          └──────────┘    └──────────┘  │  │
-    │  │                          score >= 0.8? │  │
-    │  └── no ──────────────────────────────────┘  │
-    │                               │ yes          │
-    └───────────────────────────────┼──────────────┘
-                                    ▼ done
-```
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `worker` | Builder | Agent that produces output |
+| `reviewer` | Builder | Agent that scores output |
+| `quality_key` | str | State key for the score |
+| `target` | float | Score threshold to exit |
+| `max_rounds` | int | Safety limit on iterations |
 
-**Data flow:**
+---
 
-1. Worker runs, stores output in `{quality_key}_draft`
-1. Reviewer reads the draft, stores score in `{quality_key}`
-1. Loop checks if score >= target
-1. If not, worker runs again with reviewer feedback
-
-______________________________________________________________________
-
-## `cascade` — Fallback Chain
+## `cascade` --- Fallback Chain
 
 Tries each agent in order. First successful response wins.
+
+```mermaid
+graph LR
+    A["Fast<br/>gemini-2.0-flash"] -->|"fails"| B["Smart<br/>gemini-2.5-pro"]
+    B -->|"fails"| C["Fallback<br/>safe default"]
+    A -->|"succeeds"| OUT["Done"]
+    B -->|"succeeds"| OUT
+    C --> OUT
+
+    style A fill:#a78bfa,color:#fff
+    style B fill:#a78bfa,color:#fff
+    style C fill:#a78bfa,color:#fff
+    style OUT fill:#10b981,color:#fff
+```
 
 ```python
 pipeline = cascade(
@@ -70,21 +170,34 @@ pipeline = cascade(
 )
 ```
 
-```
-    fast ──► success? ─── yes ──► done
-              │ no
-    smart ──► success? ─── yes ──► done
-              │ no
-    fallback ──────────────────── done
-```
+:::{tip}
+Use cascade for **cost optimization**: try a cheap, fast model first and fall back to expensive models only when needed.
+:::
 
-**Data flow:** Each agent receives the same input. The first agent that succeeds provides the response.
+---
 
-______________________________________________________________________
-
-## `fan_out_merge` — Parallel Research + Merge
+## `fan_out_merge` --- Parallel Research + Merge
 
 Run multiple agents in parallel, then merge their outputs.
+
+```mermaid
+graph LR
+    subgraph "Parallel"
+        A["web_search<br/>.writes('web')"]
+        B["doc_search<br/>.writes('docs')"]
+        C["expert<br/>.writes('expert')"]
+    end
+
+    A --> M["merge_fn"]
+    B --> M
+    C --> M
+    M --> OUT["state['combined']"]
+
+    style A fill:#0ea5e9,color:#fff
+    style B fill:#0ea5e9,color:#fff
+    style C fill:#0ea5e9,color:#fff
+    style M fill:#10b981,color:#fff
+```
 
 ```python
 pipeline = fan_out_merge(
@@ -96,23 +209,11 @@ pipeline = fan_out_merge(
 )
 ```
 
-```
-    ┌─ web_search ──► state["web"]  ─┐
-    ├─ doc_search ──► state["docs"] ─┼──► merge_fn ──► state["combined"]
-    └─ expert ──────► state["expert"]─┘
-```
+---
 
-**Data flow:**
+## `chain` --- Sequential Composition
 
-1. All agents run in parallel (FanOut)
-1. Each writes to its own state key
-1. Merge function combines results into `state[merge_key]`
-
-______________________________________________________________________
-
-## `chain` — Sequential Composition
-
-Compose a list of steps into a Pipeline.
+Compose a list of steps into a Pipeline with explicit data flow:
 
 ```python
 pipeline = chain(
@@ -122,13 +223,30 @@ pipeline = chain(
 )
 ```
 
-**Data flow:** Each agent runs in sequence. State propagates between steps via `.writes()` and `.reads()`.
+```mermaid
+graph LR
+    A["Researcher<br/>→ findings"] -->|state| B["Writer<br/>→ draft"] -->|state| C["Editor<br/>→ final"]
 
-______________________________________________________________________
+    style A fill:#e94560,color:#fff
+    style B fill:#e94560,color:#fff
+    style C fill:#e94560,color:#fff
+```
 
-## `conditional` — If/Else Branching
+---
 
-Route to different agents based on a predicate.
+## `conditional` --- If/Else Branching
+
+Route to different agents based on a state predicate:
+
+```mermaid
+flowchart LR
+    P{"category == 'technical'?"} -->|yes| T["Tech Support"]
+    P -->|no| G["General Support"]
+
+    style P fill:#f59e0b,color:#fff
+    style T fill:#0ea5e9,color:#fff
+    style G fill:#0ea5e9,color:#fff
+```
 
 ```python
 pipeline = conditional(
@@ -138,19 +256,11 @@ pipeline = conditional(
 )
 ```
 
-```
-                    ┌─ yes ──► tech_support
-    state ──► pred? ─┤
-                    └─ no  ──► general_support
-```
+---
 
-**Data flow:** The predicate reads from state. Only one branch executes.
+## `supervised` --- Approval Workflow
 
-______________________________________________________________________
-
-## `supervised` — Approval Workflow
-
-A worker produces output, a supervisor approves or requests revisions.
+A worker produces output, a supervisor approves or requests revisions:
 
 ```python
 pipeline = supervised(
@@ -161,13 +271,30 @@ pipeline = supervised(
 )
 ```
 
-**Data flow:** Similar to `review_loop` but with approval semantics. The supervisor marks `state[approval_key]` as approved or requests changes.
+Similar to `review_loop` but with approval semantics: the supervisor marks `state[approval_key]` as approved or requests changes.
 
-______________________________________________________________________
+---
 
-## `map_reduce` — Fan-Out Over Items
+## `map_reduce` --- Fan-Out Over Items
 
-Apply a mapper agent to each item, then reduce results.
+Apply a mapper agent to each item in a list, then reduce results:
+
+```mermaid
+graph LR
+    ITEMS["state['items']<br/>[item_0, item_1, ..., item_n]"] --> M0["Mapper(item_0)"]
+    ITEMS --> M1["Mapper(item_1)"]
+    ITEMS --> MN["Mapper(item_n)"]
+    M0 --> R["Reducer"]
+    M1 --> R
+    MN --> R
+    R --> OUT["Output"]
+
+    style ITEMS fill:#f59e0b,color:#fff
+    style M0 fill:#0ea5e9,color:#fff
+    style M1 fill:#0ea5e9,color:#fff
+    style MN fill:#0ea5e9,color:#fff
+    style R fill:#10b981,color:#fff
+```
 
 ```python
 pipeline = map_reduce(
@@ -177,69 +304,149 @@ pipeline = map_reduce(
 )
 ```
 
+---
+
+## Patterns vs Operators
+
+When should you use a named pattern vs raw operators?
+
+| Use Pattern When... | Use Operators When... |
+|--------------------|-----------------------|
+| You want well-tested, named abstractions | You want maximum flexibility |
+| You want clear semantic intent | You're doing something custom |
+| You want auto-wired data flow | You want explicit control over every detail |
+| You're explaining architecture to a team | You're prototyping quickly |
+
+```python
+# Pattern: clear intent, auto-wired
+pipeline = review_loop(worker, reviewer, quality_key="score", target=0.8)
+
+# Operators: same result, explicit control
+pipeline = (worker >> reviewer) * until(lambda s: s.get("score", 0) >= 0.8, max=5)
 ```
-    state["items"] ──┬─ mapper("item_0") ─┐
-                     ├─ mapper("item_1") ─┼──► reducer ──► output
-                     └─ mapper("item_n") ─┘
+
+---
+
+## Composability Rules
+
+Patterns nest inside each other and compose with operators:
+
+```python
+# review_loop inside a pipeline
+pipeline = (
+    Agent("classifier").writes("intent")
+    >> review_loop(
+        worker=Agent("writer"),
+        reviewer=Agent("reviewer"),
+        quality_key="score",
+        target=0.8,
+    )
+    >> Agent("publisher")
+)
+
+# fan_out_merge feeding into a review_loop
+pipeline = (
+    fan_out_merge(web_agent, docs_agent, merge_key="research")
+    >> review_loop(writer, reviewer, quality_key="score", target=0.8)
+)
 ```
 
-**Data flow:**
+---
 
-1. Reads `state[items_key]` (a list)
-1. Runs mapper on each item in parallel
-1. Reducer combines all mapper outputs
+## Backend Compatibility
 
-## Durable Execution
-
-All patterns above work with any execution backend. The definition is identical — only the engine selection changes:
+All patterns work identically across backends:
 
 ::::{tab-set}
 :::{tab-item} ADK (default)
 ```python
-pipeline = review_loop(
-    worker=Agent("writer").instruct("Write."),
-    reviewer=Agent("reviewer").instruct("Review."),
-    quality_key="score",
-    target=0.8,
-)
+pipeline = review_loop(worker, reviewer, quality_key="score", target=0.8)
 response = pipeline.ask("Write about AI safety")
 ```
 :::
 :::{tab-item} Temporal (in dev)
 ```python
-from temporalio.client import Client
-client = await Client.connect("localhost:7233")
-
-# Same pattern — each review iteration is checkpointed
-pipeline = review_loop(
-    worker=Agent("writer").instruct("Write."),
-    reviewer=Agent("reviewer").instruct("Review."),
-    quality_key="score",
-    target=0.8,
-).engine("temporal", client=client, task_queue="quality")
-
-# If crash occurs mid-loop, completed iterations replay from cache
-response = await pipeline.ask_async("Write about AI safety")
-```
-:::
-:::{tab-item} asyncio (in dev)
-```python
-pipeline = review_loop(
-    worker=Agent("writer").instruct("Write."),
-    reviewer=Agent("reviewer").instruct("Review."),
-    quality_key="score",
-    target=0.8,
-).engine("asyncio")
-
+# Same pattern --- each iteration is checkpointed
+pipeline = review_loop(worker, reviewer, quality_key="score", target=0.8)
+    .engine("temporal", client=client, task_queue="quality")
 response = await pipeline.ask_async("Write about AI safety")
 ```
 :::
 ::::
 
-Patterns with natural checkpoint boundaries (each step in `chain`, each iteration in `review_loop`) are especially well-suited for durable execution. See [Temporal Guide](temporal-guide.md) for details.
+---
+
+## Common Mistakes
+
+::::{grid} 1
+:gutter: 3
+
+:::{grid-item-card} Using review_loop without `.writes()` on the reviewer
+:class-card: sd-border-danger
+
+```python
+# ❌ Reviewer doesn't write the score to state
+review_loop(
+    worker=Agent("writer"),
+    reviewer=Agent("reviewer").instruct("Score 0-1."),
+    quality_key="score",
+    target=0.8,
+)
+```
+
+```python
+# ✅ The pattern handles wiring internally, but ensure your reviewer
+# instruction clearly asks for a numeric score in the quality_key
+review_loop(
+    worker=Agent("writer").instruct("Write a draft."),
+    reviewer=Agent("reviewer").instruct("Score the draft 0-1 for quality."),
+    quality_key="score",
+    target=0.8,
+)
+```
+:::
+
+:::{grid-item-card} Using fan_out_merge with duplicate write keys
+:class-card: sd-border-danger
+
+```python
+# ❌ Both write to the same key --- last writer wins
+fan_out_merge(
+    Agent("a").writes("result"),
+    Agent("b").writes("result"),
+    merge_key="merged",
+)
+```
+
+```python
+# ✅ Each branch writes to a unique key
+fan_out_merge(
+    Agent("a").writes("a_result"),
+    Agent("b").writes("b_result"),
+    merge_key="merged",
+)
+```
+:::
+::::
+
+---
+
+## Interplay With Other Concepts
+
+| Combines With | To Achieve | Example |
+|--------------|-----------|---------|
+| [Expression Language](expression-language.md) | Inline operator equivalents | `(a >> b) * until(pred)` instead of `review_loop` |
+| [State Transforms](state-transforms.md) | Data cleaning between pattern steps | `fan_out_merge(...) >> S.pick("merged")` |
+| [Callbacks](callbacks.md) | Logging each iteration | `review_loop(worker.before_model(log), ...)` |
+| [Middleware](middleware.md) | Retry and cost tracking | `.middleware(M.retry() \| M.cost())` |
+| [Execution Backends](execution-backends.md) | Durable execution | `.engine("temporal")` |
+
+---
 
 :::{seealso}
-- [Execution Backends](execution-backends.md) — backend selection and capability matrix
-- [Temporal Guide](temporal-guide.md) — durable execution patterns and constraints
-- [Expression Language](expression-language.md) — the operator equivalents of these patterns
+- {doc}`expression-language` --- operator equivalents of these patterns
+- {doc}`data-flow` --- how state flows through pattern steps
+- {doc}`execution-backends` --- backend selection for patterns
+- {doc}`temporal-guide` --- durable execution with Temporal
+- [Cookbook: Deep Research](../cookbook/hero-workflows/deep-research.md) --- real-world pattern composition
 :::

--- a/docs/user-guide/performance.md
+++ b/docs/user-guide/performance.md
@@ -1,0 +1,161 @@
+# Performance
+
+:::{admonition} At a Glance
+:class: tip
+
+- adk-fluent has zero runtime overhead --- builders exist only at definition time
+- Token budgets are the primary cost lever: use `.static()`, `.reads()`, and `C.window()` aggressively
+- Use `gemini-2.5-flash` for throughput, `gemini-2.5-pro` for quality-critical steps
+:::
+
+## Where Costs Come From
+
+```mermaid
+graph LR
+    subgraph "Zero Cost (build time)"
+        BUILD["Builder configuration<br/>.instruct() .tool() .writes()"]
+        IR["IR compilation<br/>.build() .to_ir()"]
+    end
+
+    subgraph "Token Cost (runtime)"
+        INST["System instruction<br/>(per-call)"]
+        HIST["Conversation history<br/>(per-call, accumulates)"]
+        TOOLS["Tool declarations<br/>(per-call, fixed)"]
+        RESP["Response generation<br/>(per-call)"]
+    end
+
+    BUILD --> IR
+    IR --> INST
+    IR --> HIST
+    IR --> TOOLS
+
+    style BUILD fill:#10b981,color:#fff
+    style IR fill:#10b981,color:#fff
+    style INST fill:#f59e0b,color:#fff
+    style HIST fill:#e94560,color:#fff
+    style TOOLS fill:#f59e0b,color:#fff
+    style RESP fill:#f59e0b,color:#fff
+```
+
+The biggest cost lever is **conversation history**. In a multi-agent pipeline, history accumulates with every step. Without context engineering, downstream agents pay for all upstream agents' output.
+
+---
+
+## Token Budget Strategies
+
+### 1. Use `.static()` for large, stable prompts
+
+```python
+# ❌ Sent fresh every call (tokens charged each time)
+agent = Agent("editor").instruct(f"Style guide: {fifty_page_guide}\n\nEdit: {{draft}}")
+
+# ✅ Cached by model provider (near-zero per-call cost)
+agent = (
+    Agent("editor")
+    .static(fifty_page_guide)            # Cached
+    .instruct("Edit this text: {draft}")  # Sent fresh (small)
+)
+```
+
+### 2. Suppress irrelevant history with `.reads()` or `C.none()`
+
+```python
+# ❌ Classifier sees all prior conversation (wasteful)
+classifier = Agent("classify").instruct("Classify intent.")
+
+# ✅ Classifier sees only its instruction (minimal tokens)
+classifier = Agent("classify").instruct("Classify intent.").context(C.none())
+```
+
+### 3. Window history for long conversations
+
+```python
+# ❌ Agent sees entire 50-turn conversation
+agent = Agent("helper").instruct("Help the user.")
+
+# ✅ Agent sees only last 3 turns
+agent = Agent("helper").instruct("Help the user.").context(C.window(n=3))
+```
+
+### 4. Set explicit token budgets
+
+```python
+agent = Agent("analyst").context(C.budget(max_tokens=4000)).instruct("Analyze.")
+```
+
+---
+
+## Model Selection
+
+| Model | Best For | Cost |
+|-------|---------|------|
+| `gemini-2.0-flash` | Simple classification, routing | Cheapest |
+| `gemini-2.5-flash` | Most tasks, good quality/speed balance | Low |
+| `gemini-2.5-pro` | Complex reasoning, quality-critical output | Higher |
+
+### Cascade for cost optimization
+
+Try a cheap model first, fall back to expensive only when needed:
+
+```python
+from adk_fluent.patterns import cascade
+
+agent = cascade(
+    Agent("fast").model("gemini-2.0-flash").instruct("Answer."),
+    Agent("strong").model("gemini-2.5-pro").instruct("Answer thoroughly."),
+)
+```
+
+---
+
+## Pipeline Optimization
+
+### Use S transforms instead of LLM agents for data manipulation
+
+```python
+# ❌ Using an LLM to merge two strings (wasteful)
+Agent("merger").instruct("Combine these results: {web} and {papers}")
+
+# ✅ Zero-cost state transform (no LLM call)
+S.merge("web", "papers", into="research")
+```
+
+### Minimize parallel branch output
+
+```python
+# ❌ Each parallel branch writes verbose output
+(Agent("a").instruct("Write a full analysis...").writes("a_result")
+ | Agent("b").instruct("Write a full analysis...").writes("b_result"))
+
+# ✅ Ask parallel branches to be concise; let the synthesizer expand
+(Agent("a").instruct("List key findings in bullet points.").writes("a_result")
+ | Agent("b").instruct("List key findings in bullet points.").writes("b_result"))
+```
+
+### Use `.isolate()` on specialist agents
+
+```python
+# Prevents unnecessary transfers and reduces token overhead
+specialist = Agent("math").instruct("Solve math problems.").isolate()
+```
+
+---
+
+## Monitoring Token Usage
+
+Use the M module to track costs:
+
+```python
+from adk_fluent._middleware import M
+
+pipeline = (Agent("a") >> Agent("b")).middleware(M.cost())
+# Logs token usage per agent after execution
+```
+
+---
+
+:::{seealso}
+- {doc}`context-engineering` --- control what agents see (biggest cost lever)
+- {doc}`middleware` --- M.cost() for token tracking
+- {doc}`patterns` --- cascade pattern for cost optimization
+:::

--- a/docs/user-guide/presets.md
+++ b/docs/user-guide/presets.md
@@ -1,5 +1,13 @@
 # Presets
 
+:::{admonition} At a Glance
+:class: tip
+
+- Presets bundle multiple builder settings (model, instruction, tools, callbacks) into reusable objects
+- Apply with `.use(preset)` --- settings are merged into the builder
+- Use presets for team-wide standards (production model config, observability, safety)
+:::
+
 Presets are reusable configuration bundles that can be applied to any builder via `.use()`. They solve a specific problem: when 10 agents in a pipeline all need the same model, the same logging callbacks, and the same safety checks, you shouldn't repeat that configuration 10 times.
 
 ## When to Use Presets vs. Middleware vs. Callbacks

--- a/docs/user-guide/prompts.md
+++ b/docs/user-guide/prompts.md
@@ -1,5 +1,13 @@
 # Prompt Builder
 
+:::{admonition} At a Glance
+:class: tip
+
+- P module composes structured prompts from sections: role, task, constraint, format, example
+- Compose with `+` (union) or `|` (pipe). Section order is enforced automatically
+- Pass to `.instruct(P.role() + P.task())` --- compiles to ADK instruction string or callable
+:::
+
 The `P` namespace provides structured, composable prompt construction using frozen dataclasses and algebraic operators.
 
 ## Basic Usage
@@ -314,3 +322,26 @@ agent = (
 ```
 
 Each `.prepend()` call accumulates. The function receives the callback context and returns a string that gets prepended as content before the LLM processes the request.
+
+## Section Ordering
+
+The P module enforces a canonical section order regardless of composition order:
+
+```{mermaid}
+graph LR
+    A[role] --> B[context]
+    B --> C[task]
+    C --> D[constraint]
+    D --> E[format]
+    E --> F[example]
+    F --> G["custom sections"]
+```
+
+Sections are always emitted in this order when compiled. Use `P.reorder()` to override.
+
+:::{seealso}
+- [Agent Builder](agents.md) --- `.instruct()` method that accepts P compositions
+- [Context Engineering](context-engineering.md) --- C module for controlling conversation history
+- [State Transforms](state-transforms.md) --- S module for data flow between agents
+- [Expression Operators](expressions.md) --- using P compositions within pipelines
+:::

--- a/docs/user-guide/skills.md
+++ b/docs/user-guide/skills.md
@@ -1,5 +1,13 @@
 # Skills -- Composable Agent Packages
 
+:::{admonition} At a Glance
+:class: tip
+
+- Skills are composable agent packages defined by SKILL.md files
+- Load with `T.skill()` or `SkillRegistry` for dynamic discovery
+- Use skills to package domain expertise, reusable tools, and complete agent capabilities
+:::
+
 **Skills** turn YAML + Markdown into executable agent graphs. Instead of writing Python code for every agent topology, you declare agents and their wiring in a `SKILL.md` file and load it with `Skill("path/")`. The same file that documents your agent system for humans and coding agents also runs as a live adk-fluent pipeline.
 
 ## When Skills Make Life Easy

--- a/docs/user-guide/state-transforms.md
+++ b/docs/user-guide/state-transforms.md
@@ -1,208 +1,252 @@
 # State Transforms
 
-`S` factories return dict transforms that compose with `>>` as zero-cost workflow nodes. They manipulate session state between agent steps without making LLM calls.
+:::{admonition} At a Glance
+:class: tip
 
-```
-State Transform Pipeline:
+- `S` factories return zero-cost dict transforms that compose with `>>` between agent steps
+- No LLM calls --- transforms compile to `FnAgent` nodes that manipulate session state directly
+- Compose with `>>` (chain sequentially) or `+` (combine on same state)
+:::
 
-  { web: "...", scholar: "...", _debug: true }    ← input state
-       │
-  S.drop("_debug")           { web, scholar }
-       │
-  S.merge("web","scholar",   { web, scholar, research }
-         into="research")
-       │
-  S.default(confidence=0.0)  { web, scholar, research, confidence }
-       │
-  S.rename(research="input") { web, scholar, input, confidence }
-       │
-  S.pick("input",            { input, confidence }                ← output state
-         "confidence")
+## How State Transforms Work
 
-  Composition:
-    S.drop() >> S.merge()         chain: run in sequence
-    S.default() + S.rename()      combine: apply to same state
+```mermaid
+graph LR
+    A["Agent A<br/>.writes('findings')"] --> S1["S.pick('findings')"]:::transform
+    S1 --> S2["S.rename(findings='input')"]:::transform
+    S2 --> B["Agent B<br/>.reads('input')"]
+
+    classDef transform fill:#10b981,color:#fff
+    style A fill:#e94560,color:#fff
+    style B fill:#0ea5e9,color:#fff
 ```
 
-## Basic Usage
+S transforms operate exclusively on **session state** (Channel 2). They don't touch conversation history or instruction templating. Each compiles to a `FnAgent` --- zero LLM cost, zero events yielded.
 
 ```python
-from adk_fluent import S
+from adk_fluent import Agent, S
 
 pipeline = (
-    (web_agent | scholar_agent)
-    >> S.merge("web", "scholar", into="research")
-    >> S.default(confidence=0.0)
-    >> S.rename(research="input")
-    >> writer_agent
+    Agent("researcher").writes("findings")
+    >> S.pick("findings")                  # Keep only "findings"
+    >> S.rename(findings="input")          # Rename for next agent
+    >> S.default(depth="comprehensive")    # Add default value
+    >> Agent("writer").reads("input")
 )
 ```
+
+---
 
 ## Transform Reference
 
-| Factory                 | Purpose                  |
-| ----------------------- | ------------------------ |
-| `S.pick(*keys)`         | Keep only specified keys |
-| `S.drop(*keys)`         | Remove specified keys    |
-| `S.rename(**kw)`        | Rename keys              |
-| `S.default(**kw)`       | Fill missing keys        |
-| `S.merge(*keys, into=)` | Combine keys             |
-| `S.transform(key, fn)`  | Map a single value       |
-| `S.compute(**fns)`      | Derive new keys          |
-| `S.guard(pred)`         | Assert invariant         |
-| `S.log(*keys)`          | Debug-print              |
+| Factory | Purpose | Type | Example |
+|---------|---------|------|---------|
+| `S.pick(*keys)` | Keep only named keys | Replacement | `S.pick("name", "email")` |
+| `S.drop(*keys)` | Remove named keys | Replacement | `S.drop("_debug")` |
+| `S.rename(**kw)` | Rename keys | Replacement | `S.rename(old="new")` |
+| `S.set(**kv)` | Set explicit values | Delta | `S.set(status="ready")` |
+| `S.default(**kv)` | Fill missing keys | Delta | `S.default(score=0.0)` |
+| `S.merge(*keys, into=)` | Combine keys | Delta | `S.merge("a", "b", into="c")` |
+| `S.transform(key, fn)` | Apply function to value | Delta | `S.transform("title", str.upper)` |
+| `S.compute(**fns)` | Derive new keys from state | Delta | `S.compute(length=lambda s: len(s["text"]))` |
+| `S.guard(pred, msg=)` | Assert invariant | Inspection | `S.guard(lambda s: "data" in s)` |
+| `S.log(*keys)` | Debug print to stderr | Inspection | `S.log("web", "docs")` |
+| `S.identity()` | No-op pass-through | Inspection | `S.identity()` |
+| `S.capture(*keys)` | Capture function args | Delta | `S.capture("user_message")` |
 
-## `S.pick(*keys)`
+:::{note}
+**Replacement** transforms set unmentioned session-scoped keys to `None`. **Delta** transforms only update specified keys, preserving everything else.
+:::
 
-Keep only the specified keys in state, dropping everything else:
+---
 
-```python
-# After this, state only contains "name" and "email"
-pipeline = agent >> S.pick("name", "email") >> next_agent
+## Visual Before/After for Each Transform
+
+### `S.pick(*keys)`
+
+```mermaid
+graph LR
+    subgraph Before
+        B["state = {name: 'Jo', email: 'jo@x', _debug: true}"]
+    end
+    subgraph "After S.pick('name', 'email')"
+        A["state = {name: 'Jo', email: 'jo@x'}"]
+    end
+    B --> A
 ```
 
-## `S.drop(*keys)`
+### `S.drop(*keys)`
 
-Remove the specified keys from state:
-
-```python
-# Remove temporary/internal keys before the next step
-pipeline = agent >> S.drop("_internal", "_debug") >> next_agent
+```mermaid
+graph LR
+    subgraph Before
+        B["state = {name: 'Jo', _debug: true, _internal: {...}}"]
+    end
+    subgraph "After S.drop('_debug', '_internal')"
+        A["state = {name: 'Jo'}"]
+    end
+    B --> A
 ```
 
-## `S.rename(**kw)`
+### `S.rename(**mapping)`
 
-Rename keys in state. The keyword argument maps old names to new names:
-
-```python
-# Rename "research" to "input" for the next agent
-pipeline = researcher >> S.rename(research="input") >> writer
+```mermaid
+graph LR
+    subgraph Before
+        B["state = {research: 'findings...', score: 0.8}"]
+    end
+    subgraph "After S.rename(research='input')"
+        A["state = {input: 'findings...', score: 0.8}"]
+    end
+    B --> A
 ```
 
-## `S.default(**kw)`
+### `S.merge(*keys, into=)`
 
-Fill in missing keys with default values. Existing keys are not overwritten:
-
-```python
-# Ensure "confidence" exists with a default of 0.0
-pipeline = agent >> S.default(confidence=0.0) >> evaluator
+```mermaid
+graph LR
+    subgraph Before
+        B["state = {web: 'Web results...', papers: 'Paper results...'}"]
+    end
+    subgraph "After S.merge('web', 'papers', into='research')"
+        A["state = {web: '...', papers: '...', research: 'Web results...\nPaper results...'}"]
+    end
+    B --> A
 ```
 
-## `S.merge(*keys, into=)`
+### `S.default(**kv)`
 
-Combine multiple keys into a single key:
-
-```python
-# Merge "web" and "scholar" results into "research"
-pipeline = (
-    (web_agent | scholar_agent)
-    >> S.merge("web", "scholar", into="research")
-    >> writer
-)
+```mermaid
+graph LR
+    subgraph Before
+        B["state = {name: 'Jo'}"]
+    end
+    subgraph "After S.default(score=0.0, lang='en')"
+        A["state = {name: 'Jo', score: 0.0, lang: 'en'}"]
+    end
+    B --> A
 ```
 
-## `S.transform(key, fn)`
+:::{note}
+`S.default()` does **not** overwrite existing keys. If `state["score"]` already exists, it's kept as-is.
+:::
 
-Apply a function to transform a single value in state:
+### `S.transform(key, fn)`
 
-```python
-# Uppercase the "title" value
-pipeline = agent >> S.transform("title", str.upper) >> next_agent
+```mermaid
+graph LR
+    subgraph Before
+        B["state = {title: 'hello world'}"]
+    end
+    subgraph "After S.transform('title', str.upper)"
+        A["state = {title: 'HELLO WORLD'}"]
+    end
+    B --> A
 ```
 
-## `S.compute(**fns)`
+### `S.compute(**factories)`
 
-Derive new keys by applying functions to the state:
-
-```python
-# Compute a new "summary_length" key from the existing state
-pipeline = agent >> S.compute(
-    summary_length=lambda s: len(s.get("summary", "")),
-    has_citations=lambda s: "cite" in s.get("text", "").lower()
-) >> evaluator
+```mermaid
+graph LR
+    subgraph Before
+        B["state = {text: 'Hello world'}"]
+    end
+    subgraph "After S.compute(length=lambda s: len(s['text']))"
+        A["state = {text: 'Hello world', length: 11}"]
+    end
+    B --> A
 ```
 
-## `S.guard(pred)`
+### `S.guard(pred)`
 
-Assert an invariant on the state. Raises an error if the predicate fails:
+```mermaid
+flowchart LR
+    STATE["state"] --> CHECK{"pred(state)?"}
+    CHECK -->|"true"| PASS["Continue"]
+    CHECK -->|"false"| FAIL["Raise ValueError"]
 
-```python
-# Ensure "data" key is present before proceeding
-pipeline = agent >> S.guard(lambda s: "data" in s) >> processor
+    style CHECK fill:#f59e0b,color:#fff
+    style PASS fill:#10b981,color:#fff
+    style FAIL fill:#e94560,color:#fff
 ```
 
-## `S.log(*keys)`
+---
 
-Debug-print specified keys from state. Useful during development:
+## Replacement vs Delta Transforms
 
-```python
-# Print "web" and "scholar" values for debugging
-pipeline = (
-    (web_agent | scholar_agent)
-    >> S.log("web", "scholar")
-    >> S.merge("web", "scholar", into="research")
-    >> writer
-)
+```mermaid
+graph TB
+    subgraph "Replacement (S.pick, S.drop, S.rename)"
+        R1["Replaces session-scoped keys.<br/>Unmentioned keys set to None."]
+    end
+
+    subgraph "Delta (S.default, S.merge, S.transform, S.compute, S.set)"
+        D1["Additive merge.<br/>Only specified keys updated.<br/>Existing keys preserved."]
+    end
+
+    subgraph "Inspection (S.guard, S.log, S.identity)"
+        I1["No state mutation.<br/>Side-effects only."]
+    end
 ```
 
-## STransform Composition
+:::{warning}
+When mixing Replacement and Delta transforms in a chain, Replacement wins for keys it doesn't mention --- they become `None`. Place Replacement transforms (`S.pick`, `S.drop`) **after** Delta transforms to avoid losing data.
+:::
 
-All `S.xxx()` methods return `STransform` objects that support two composition operators:
+---
 
-### `>>` — Chain (sequential)
+## Composition
+
+### `>>` --- Chain (sequential)
 
 ```python
-# Clean state then merge — runs in order
-cleanup = S.drop("_internal") >> S.merge("web", "scholar", into="research")
+# Runs in order: drop → merge → rename
+cleanup = S.drop("_internal") >> S.merge("web", "scholar", into="research") >> S.rename(research="input")
 pipeline = agent >> cleanup >> writer
 ```
 
-### `+` — Combine (parallel)
+### `+` --- Combine (parallel)
 
 ```python
-# Apply multiple transforms to the same state at once
+# Both applied to the same state simultaneously
 setup = S.default(confidence=0.0) + S.rename(research="input")
 pipeline = agent >> setup >> writer
 ```
 
-### Composing with agents
+---
 
-STransform objects work seamlessly in pipelines:
-
-```python
-# STransform >> Agent works directly
-pipeline = S.capture("user_message") >> classifier >> handler
-```
-
-### Key tracking
-
-STransforms track which state keys they read and write:
+## Chaining Transforms: Progressive Example
 
 ```python
-t = S.rename(old="new")
-print(t._reads_keys)   # frozenset({'old'})
-print(t._writes_keys)  # frozenset({'new'})
+from adk_fluent import Agent, S
+
+pipeline = (
+    (Agent("web").writes("web") | Agent("scholar").writes("scholar"))
+    >> S.log("web", "scholar")                            # 1. Debug print
+    >> S.drop("_internal", "_debug")                      # 2. Remove internals
+    >> S.merge("web", "scholar", into="research")         # 3. Combine sources
+    >> S.default(confidence=0.0, format="markdown")       # 4. Fill defaults
+    >> S.rename(research="input")                         # 5. Rename for writer
+    >> S.pick("input", "confidence", "format")            # 6. Keep only needed keys
+    >> Agent("writer").reads("input").writes("draft")
+)
 ```
 
-This metadata powers the contract checker's data-flow analysis.
+State at each step:
+
+| Step | Transform | State Keys |
+|------|-----------|-----------|
+| Start | (after FanOut) | `web, scholar, _internal, _debug` |
+| 1 | `S.log` | `web, scholar, _internal, _debug` (unchanged, logs to stderr) |
+| 2 | `S.drop` | `web, scholar` |
+| 3 | `S.merge` | `web, scholar, research` |
+| 4 | `S.default` | `web, scholar, research, confidence, format` |
+| 5 | `S.rename` | `web, scholar, input, confidence, format` |
+| 6 | `S.pick` | `input, confidence, format` |
+
+---
 
 ## Complete Example
-
-The following pipeline demonstrates multiple transforms woven between agents:
-
-```
-Complete transform flow:
-
-  ┬─ web ────┐
-  └─ scholar ┘  (parallel)
-       │
-  S.log ──► S.merge ──► S.default ──► S.rename
-   debug      combine     fill gaps     rewire
-       │
-  writer @ Report
-       │
-  S.guard(confidence > 0)  ── fail? ──► raise
-```
 
 ```python
 from pydantic import BaseModel
@@ -214,14 +258,89 @@ class Report(BaseModel):
     confidence: float
 
 pipeline = (
-    (   Agent("web").model("gemini-2.5-flash").instruct("Search web.")
-      | Agent("scholar").model("gemini-2.5-flash").instruct("Search papers.")
+    # Parallel research
+    (   Agent("web", "gemini-2.5-flash").instruct("Search web.").writes("web")
+      | Agent("scholar", "gemini-2.5-flash").instruct("Search papers.").writes("scholar")
     )
+    # Transform chain
     >> S.log("web", "scholar")                          # Debug
     >> S.merge("web", "scholar", into="research")       # Combine
     >> S.default(confidence=0.0)                         # Default
     >> S.rename(research="input")                        # Rename
-    >> Agent("writer").model("gemini-2.5-flash").instruct("Write.") @ Report
-    >> S.guard(lambda s: s.get("confidence", 0) > 0)    # Assert
+    # Write with schema
+    >> Agent("writer", "gemini-2.5-flash").instruct("Write report from {input}.") @ Report
+    # Validate
+    >> S.guard(lambda s: s.get("confidence", 0) > 0, msg="Confidence must be positive")
 )
 ```
+
+---
+
+## Common Mistakes
+
+::::{grid} 1
+:gutter: 3
+
+:::{grid-item-card} Transforming state inside agent instructions
+:class-card: sd-border-danger
+
+```python
+# ❌ Don't manipulate state in instructions
+Agent("helper").instruct("Take the web and scholar results and combine them...")
+```
+
+```python
+# ✅ Use S transforms for data manipulation --- they're zero-cost
+(web | scholar) >> S.merge("web", "scholar", into="research") >> writer
+```
+:::
+
+:::{grid-item-card} S.pick before S.merge
+:class-card: sd-border-danger
+
+```python
+# ❌ S.pick removes keys that S.merge needs
+agent >> S.pick("web") >> S.merge("web", "scholar", into="research")
+# "scholar" is gone!
+```
+
+```python
+# ✅ Merge first, then pick
+agent >> S.merge("web", "scholar", into="research") >> S.pick("research")
+```
+:::
+
+:::{grid-item-card} Forgetting that S.pick nulls unmentioned keys
+:class-card: sd-border-danger
+
+```python
+# ❌ Picks "input" but "format" (needed by writer) is now None
+agent >> S.pick("input") >> writer  # writer needs {format}
+```
+
+```python
+# ✅ Include all keys the downstream agent needs
+agent >> S.pick("input", "format") >> writer
+```
+:::
+::::
+
+---
+
+## Interplay With Other Concepts
+
+| Combines With | To Achieve | Example |
+|--------------|-----------|---------|
+| [Expression Language](expression-language.md) | Inline transforms in pipelines | `a >> S.pick("k") >> b` |
+| [Data Flow](data-flow.md) | Explicit state contracts | `S.guard(lambda s: "k" in s)` |
+| [Context Engineering](context-engineering.md) | Prepare state for `.reads()` | `>> S.rename(old="new") >> agent.reads("new")` |
+| [Patterns](patterns.md) | Clean data between pattern steps | `fan_out_merge(...) >> S.pick("merged")` |
+
+---
+
+:::{seealso}
+- {doc}`data-flow` --- the five orthogonal data flow concerns
+- {doc}`expression-language` --- using S transforms with `>>` operator
+- {doc}`context-engineering` --- C module for controlling what agents see
+- {doc}`patterns` --- higher-order patterns that use transforms internally
+:::

--- a/docs/user-guide/structured-data.md
+++ b/docs/user-guide/structured-data.md
@@ -1,5 +1,13 @@
 # Structured Data
 
+:::{admonition} At a Glance
+:class: tip
+
+- `.returns(Schema)` or `@ Schema` constrains LLM output to structured JSON matching a Pydantic model
+- `.produces()` / `.consumes()` are static contract annotations for build-time validation
+- Use `check_contracts()` to verify data flow between agents at zero cost
+:::
+
 Agents that return free-form text are fine for chat, but production pipelines need predictable data. A classifier must emit a category string that a router can branch on. An extraction step must produce a JSON object that a downstream formatter can render. adk-fluent provides three complementary mechanisms for structured data flow: storing output in session state, enforcing typed output schemas, and declaring input schemas for tool-invoked agents.
 
 ## Storing Output in State: `.writes(key)`

--- a/docs/user-guide/temporal-guide.md
+++ b/docs/user-guide/temporal-guide.md
@@ -1,5 +1,13 @@
 # Temporal Guide
 
+:::{admonition} At a Glance
+:class: tip
+
+- Temporal backend provides durable execution with crash recovery and checkpointing
+- Deterministic operators (`>>`, `Route`, `S.*`) become replay-safe workflow code
+- Non-deterministic operators (LLM calls) become cached Temporal activities
+:::
+
 :::{admonition} In Development
 :class: warning
 

--- a/docs/user-guide/testing.md
+++ b/docs/user-guide/testing.md
@@ -1,32 +1,62 @@
 # Testing
 
-adk-fluent provides testing utilities for verifying agent pipelines without making LLM calls. Testing agents is fundamentally different from testing regular code -- you're testing *topology*, *data flow*, and *contracts*, not just input/output.
+:::{admonition} At a Glance
+:class: tip
 
-## Why Test Agents?
+- Test agents without LLM calls using contract checks, IR assertions, and mock backends
+- Testing pyramid: contracts (free) → topology (free) → mocks (free) → smoke (LLM) → eval (LLM)
+- `check_contracts()` catches the most common bugs at zero cost
+:::
 
-Without testing, you only discover broken pipelines in production:
+## Testing Pyramid
 
-- A `.writes("intent")` typo becomes `.writes("intnt")` and the downstream agent reads `None`
-- A context strategy change (`C.none()` removed) causes a classifier to hallucinate based on conversation history
-- A new agent added to a pipeline doesn't satisfy the next step's data contract
+```mermaid
+graph TB
+    subgraph "No LLM Calls (fast, free)"
+        L1["Contracts<br/>check_contracts()"]
+        L2["Topology<br/>.to_ir() + assertions"]
+        L3["Behavior<br/>AgentHarness + mock_backend"]
+    end
 
-adk-fluent's testing tools catch these at build time, not runtime.
+    subgraph "LLM Calls (slow, costs tokens)"
+        L4["Smoke Tests<br/>.test()"]
+        L5["Evaluation<br/>.eval() / EvalSuite"]
+    end
 
-## Testing Layers
+    L1 -->|"catches"| L1_ERR["Missing .writes(), broken data flow"]
+    L2 -->|"catches"| L2_ERR["Wrong wiring, missing agents"]
+    L3 -->|"catches"| L3_ERR["Bad state propagation, wrong responses"]
+    L4 -->|"catches"| L4_ERR["LLM misunderstanding, prompt issues"]
+    L5 -->|"catches"| L5_ERR["Quality regression, consistency"]
 
-| Layer | Tool | What it catches | LLM calls? |
-|---|---|---|---|
-| **Contracts** | `check_contracts()` | Data flow mismatches between agents | No |
-| **Topology** | `.to_ir()` + assertions | Missing agents, wrong wiring | No |
-| **Behavior** | `AgentHarness` + `mock_backend` | Wrong responses, missing state | No |
-| **Smoke** | `.test()` | Basic end-to-end correctness | Yes |
-| **Evaluation** | `.eval()` / `EvalSuite` | Quality, consistency, regression | Yes |
+    style L1 fill:#10b981,color:#fff
+    style L2 fill:#0ea5e9,color:#fff
+    style L3 fill:#f59e0b,color:#fff
+    style L4 fill:#a78bfa,color:#fff
+    style L5 fill:#e94560,color:#fff
+```
 
-Start from the top and work down. Each layer catches cheaper errors before you burn API tokens.
+Start from the top. Each layer catches cheaper errors before you burn API tokens.
 
-## Contract Verification
+---
 
-`check_contracts()` is the cheapest test you can write. It inspects the IR tree -- no execution, no API calls -- and verifies that sequential agents satisfy each other's data contracts:
+## Testing Methods at a Glance
+
+| Method | LLM? | Speed | What It Tests |
+|--------|------|-------|--------------|
+| `check_contracts(ir)` | No | Instant | Data flow between agents |
+| `.to_ir()` + assertions | No | Instant | Pipeline topology and wiring |
+| `AgentHarness` + `mock_backend` | No | Fast | Behavior with canned responses |
+| `.test(prompt, contains=)` | Yes | Slow | Basic end-to-end correctness |
+| `.mock(responses)` | No | Fast | Replace LLM with canned responses |
+| `.eval(prompt, expect=)` | Yes | Slow | Quality scoring |
+| `.eval_suite()` | Yes | Slow | Multi-case quality assessment |
+
+---
+
+## Layer 1: Contract Verification
+
+`check_contracts()` inspects the IR tree --- no execution, no API calls --- and verifies that agents satisfy each other's data contracts:
 
 ```python
 from pydantic import BaseModel
@@ -37,73 +67,57 @@ class Intent(BaseModel):
     category: str
     confidence: float
 
-# Valid: classifier produces what resolver consumes
+# ✅ Valid: classifier produces what resolver consumes
 pipeline = Agent("classifier").produces(Intent) >> Agent("resolver").consumes(Intent)
 issues = check_contracts(pipeline.to_ir())
-assert issues == []  # All good
+assert issues == []
 
-# Invalid: resolver consumes Intent but nothing produces it
+# ❌ Invalid: resolver consumes Intent but nothing produces it
 bad_pipeline = Agent("a") >> Agent("resolver").consumes(Intent)
 issues = check_contracts(bad_pipeline.to_ir())
-# ["Agent 'resolver' consumes key 'category' but no prior step produces it",
-#  "Agent 'resolver' consumes key 'confidence' but no prior step produces it"]
+# ["Agent 'resolver' consumes key 'category' but no prior step produces it", ...]
 ```
 
-Contract verification is static -- it inspects the IR tree without executing anything.
-
-:::{tip} Best Practice
-Add contract checks to every pipeline test. They cost nothing and catch the most common production bugs -- renamed state keys and missing data flow.
+:::{tip}
+Add contract checks to **every** pipeline test. They cost nothing and catch the most common production bugs: renamed state keys and missing data flow.
 :::
 
-## Mock Backend
+---
 
-`mock_backend()` creates a backend that returns canned responses, letting you test pipeline behavior deterministically:
+## Layer 2: Topology Assertions
 
-```python
-from adk_fluent import Agent
-from adk_fluent.testing import mock_backend
-
-mb = mock_backend({
-    "classifier": {"intent": "billing"},      # dict -> state_delta
-    "resolver": "Ticket #1234 created.",       # str -> content
-})
-
-ir = (Agent("classifier") >> Agent("resolver")).to_ir()
-compiled = mb.compile(ir)
-events = await mb.run(compiled, "My bill is wrong")
-
-# Events contain the canned responses
-assert events[0].state_delta == {"intent": "billing"}
-assert events[1].content == "Ticket #1234 created."
-```
-
-### Response Types
-
-| Mock value | Behavior | Use case |
-|---|---|---|
-| `str` | Agent returns this text as content | Simple response assertions |
-| `dict` | Agent writes these keys to state | Data flow testing |
-| `callable` | Called with `(prompt, state)`, returns `str` or `dict` | Dynamic/conditional responses |
-
-## AgentHarness
-
-`AgentHarness` wraps a builder and mock backend for ergonomic testing:
+Verify your pipeline has the right shape by inspecting the IR tree:
 
 ```python
-from adk_fluent import Agent
-from adk_fluent.testing import AgentHarness, mock_backend
+def test_topology():
+    ir = build_my_pipeline().to_ir()
+    agent_names = [node.name for node in ir.walk()]
+    assert "classifier" in agent_names
+    assert "resolver" in agent_names
 
-harness = AgentHarness(
-    Agent("helper").instruct("Help."),
-    backend=mock_backend({"helper": "I can help!"})
-)
-
-response = await harness.send("Hi")
-assert response.final_text == "I can help!"
-assert not response.errors
+def test_classifier_context_isolation():
+    """Verify classifier doesn't see conversation history."""
+    ir = build_my_pipeline().to_ir()
+    classifier_node = next(n for n in ir.walk() if n.name == "classifier")
+    assert classifier_node.include_contents == "none"
 ```
 
-### Testing Multi-Agent Pipelines
+---
+
+## Layer 3: Mock Backend
+
+`mock_backend()` creates a backend that returns canned responses for deterministic testing:
+
+```mermaid
+graph LR
+    INPUT["Test input"] --> HARNESS["AgentHarness"]
+    HARNESS --> MOCK["mock_backend<br/>classifier → {intent: 'billing'}<br/>resolver → 'Resolved.'"]
+    MOCK --> ASSERT["Assertions<br/>state, text, errors"]
+
+    style HARNESS fill:#0ea5e9,color:#fff
+    style MOCK fill:#f59e0b,color:#fff
+    style ASSERT fill:#10b981,color:#fff
+```
 
 ```python
 from adk_fluent import Agent, C
@@ -117,18 +131,61 @@ pipeline = (
 harness = AgentHarness(
     pipeline,
     backend=mock_backend({
-        "classifier": {"intent": "billing"},
-        "resolver": "Your billing issue has been resolved.",
+        "classifier": {"intent": "billing"},          # dict → state delta
+        "resolver": "Your billing issue is resolved.", # str → content
     })
 )
 
 response = await harness.send("My bill is wrong")
-assert response.final_text == "Your billing issue has been resolved."
+assert response.final_text == "Your billing issue is resolved."
+assert response.state.get("intent") == "billing"
 ```
 
-## pytest Integration
+### Mock Response Types
 
-Use these tools in standard pytest tests:
+| Mock Value | Behavior | Use Case |
+|-----------|----------|----------|
+| `str` | Agent returns this text as content | Simple response assertions |
+| `dict` | Agent writes these keys to state | Data flow testing |
+| `callable` | Called with `(prompt, state)`, returns `str` or `dict` | Dynamic/conditional responses |
+
+---
+
+## Layer 4: Smoke Tests
+
+`.test()` runs a real LLM call and checks the response:
+
+```python
+agent = Agent("helper", "gemini-2.5-flash").instruct("Help with math.")
+
+# Inline smoke test (sync, blocking)
+agent.test("What is 2+2?", contains="4")
+```
+
+---
+
+## Layer 5: Evaluation
+
+`.eval()` and `EvalSuite` for quality assessment:
+
+```python
+# Single evaluation
+agent.eval("Summarize quantum physics", expect="mentions superposition")
+
+# Full evaluation suite
+suite = agent.eval_suite()
+suite.add(E.case("What is 2+2?", expect="4"))
+suite.add(E.case("Capital of France?", expect="Paris"))
+report = suite.run()
+```
+
+:::{seealso}
+{doc}`evaluation` for the full E module reference.
+:::
+
+---
+
+## pytest Integration
 
 ```python
 import pytest
@@ -137,7 +194,7 @@ from adk_fluent.testing import check_contracts, mock_backend, AgentHarness
 
 
 def test_contracts_satisfied():
-    """Contract checks are cheap -- run on every pipeline."""
+    """Contract checks are cheap --- run on every pipeline."""
     pipeline = build_my_pipeline()
     issues = check_contracts(pipeline.to_ir())
     assert not issues, f"Contract violations: {issues}"
@@ -152,14 +209,14 @@ def test_topology():
 
 
 @pytest.mark.asyncio
-async def test_pipeline_response():
+async def test_pipeline_behavior():
     """Behavior test with mock backend."""
     harness = AgentHarness(
         build_my_pipeline(),
-        backend=mock_backend({"step1": "data", "step2": "result"})
+        backend=mock_backend({"classifier": {"intent": "billing"}, "resolver": "Resolved."})
     )
     response = await harness.send("test input")
-    assert "result" in response.final_text
+    assert "Resolved" in response.final_text
 
 
 @pytest.mark.asyncio
@@ -169,110 +226,111 @@ async def test_state_propagation():
         build_my_pipeline(),
         backend=mock_backend({
             "classifier": {"intent": "billing"},
-            "resolver": "Resolved.",
+            "resolver": "Done.",
         })
     )
     response = await harness.send("test")
     assert response.state.get("intent") == "billing"
 ```
 
-### Test Organization
+### Recommended Test Organization
 
 ```
 tests/
-    test_contracts.py       # Contract checks for all pipelines (fast, no API)
-    test_topology.py        # IR shape assertions (fast, no API)
+    test_contracts.py       # Contract checks (instant, no API)
+    test_topology.py        # IR shape assertions (instant, no API)
     test_behavior.py        # Mock backend tests (fast, no API)
-    test_smoke.py           # .test() with real LLM (slow, requires API key)
-    test_eval.py            # .eval() quality checks (slow, requires API key)
+    test_smoke.py           # .test() with real LLM (slow, API key required)
+    test_eval.py            # .eval() quality checks (slow, API key required)
 ```
 
-## Interplay with Other Modules
+---
 
-### Testing + Contracts (`.produces()` / `.consumes()`)
+## Common Mistakes
 
-Contract annotations power `check_contracts()`. Without them, you're relying on runtime failures:
+::::{grid} 1
+:gutter: 3
+
+:::{grid-item-card} Calling real LLMs in CI
+:class-card: sd-border-danger
 
 ```python
-from pydantic import BaseModel
-from adk_fluent import Agent
-from adk_fluent.testing import check_contracts
+# ❌ Flaky, slow, costs money
+def test_agent():
+    result = agent.ask("test")  # Real LLM call in CI!
+    assert "hello" in result
+```
 
-class AnalysisResult(BaseModel):
-    summary: str
-    confidence: float
+```python
+# ✅ Mock everything in CI
+async def test_agent():
+    harness = AgentHarness(agent, backend=mock_backend({"helper": "hello"}))
+    result = await harness.send("test")
+    assert "hello" in result.final_text
+```
+:::
 
-# Annotate your agents with contracts
-pipeline = (
-    Agent("analyzer").produces(AnalysisResult).writes("analysis")
-    >> Agent("writer").consumes(AnalysisResult)
-)
+:::{grid-item-card} Testing only the final response
+:class-card: sd-border-danger
 
-# check_contracts() uses the annotations to verify data flow
+```python
+# ❌ Doesn't verify data flow --- only checks the end result
+assert response.final_text == "Success"
+```
+
+```python
+# ✅ Also verify intermediate state propagation
+assert response.state.get("intent") == "billing"    # State flows correctly
+assert response.state.get("resolved") == True         # Intermediate step ran
+assert response.final_text == "Success"               # Final output correct
+```
+:::
+
+:::{grid-item-card} Skipping contract checks
+:class-card: sd-border-danger
+
+```python
+# ❌ No contract validation --- bugs found at runtime
+pipeline = Agent("a").writes("intnt") >> Agent("b").reads("intent")
+# "intnt" typo silently causes b to read None
+```
+
+```python
+# ✅ Contract checks catch typos at build time
 issues = check_contracts(pipeline.to_ir())
-assert not issues
+# ["Agent 'b' consumes 'intent' but no prior step produces it"]
 ```
+:::
+::::
 
-See [Structured Data](structured-data.md) for contract details.
+---
 
-### Testing + Context Engineering
+## Interplay With Other Concepts
 
-Context strategy bugs are invisible without testing. A classifier with `C.none()` removed will still "work" but produce worse results because it hallucinates based on conversation history:
+| Combines With | To Achieve | Example |
+|--------------|-----------|---------|
+| [Structured Data](structured-data.md) | Contract annotations for `check_contracts()` | `.produces(Intent).consumes(Intent)` |
+| [Context Engineering](context-engineering.md) | Verify context isolation in IR | `assert node.include_contents == "none"` |
+| [Guards](guards.md) | Verify guards are attached | `assert ir.guard_specs` |
+| [Middleware](middleware.md) | Verify middleware compiled into app | `assert app.plugins` |
+| [Evaluation](evaluation.md) | Quality scoring with E module | `.eval_suite()` |
 
-```python
-def test_classifier_context_isolation():
-    """Verify the classifier doesn't see conversation history."""
-    ir = build_my_pipeline().to_ir()
-    classifier_node = next(n for n in ir.walk() if n.name == "classifier")
-    # The classifier should have context isolation
-    assert classifier_node.include_contents == "none"
-```
-
-See [Context Engineering](context-engineering.md).
-
-### Testing + Guards
-
-Guards compile to callbacks. Test that they're attached:
-
-```python
-from adk_fluent import Agent, G
-
-agent = Agent("safe").instruct("Help.").guard(G.pii("redact") | G.length(max=500))
-ir = agent.to_ir()
-assert ir.guard_specs  # Guards are attached
-```
-
-See [Guards](guards.md).
-
-### Testing + Middleware
-
-Middleware applies at the app level. Test it via `.to_app()`:
-
-```python
-from adk_fluent import Agent
-from adk_fluent._middleware import M
-
-pipeline = (Agent("a") >> Agent("b")).middleware(M.retry(3) | M.log())
-app = pipeline.to_app()
-# Verify middleware is compiled into the app
-assert app.plugins  # Middleware plugin is attached
-```
-
-See [Middleware](middleware.md).
+---
 
 ## Best Practices
 
-1. **Always test contracts first.** `check_contracts()` is free and catches the most common bugs
-2. **Mock everything in CI.** Never call real LLMs in CI -- use `mock_backend()` for deterministic tests
-3. **Test topology, not just behavior.** Assert that agents exist, are wired correctly, and have the right context strategy
-4. **Separate fast and slow tests.** Contract/topology/mock tests run in milliseconds. `.test()` and `.eval()` require API calls -- gate these behind a marker or env var
-5. **Test state propagation explicitly.** Assert that `.writes()` keys appear in downstream state, not just that the final response looks right
+1. **Always test contracts first.** `check_contracts()` is free and catches the most common bugs.
+2. **Mock everything in CI.** Never call real LLMs in CI --- use `mock_backend()`.
+3. **Test topology, not just behavior.** Assert agents exist, are wired correctly, and have the right context strategy.
+4. **Separate fast and slow tests.** Gate `.test()` and `.eval()` behind markers or env vars.
+5. **Test state propagation explicitly.** Assert `.writes()` keys appear in downstream state.
+
+---
 
 :::{seealso}
-- [Structured Data](structured-data.md) -- `.produces()`, `.consumes()`, and contract annotations
-- [Context Engineering](context-engineering.md) -- `C.none()`, `C.from_state()`, and why context isolation matters for testing
-- [Guards](guards.md) -- `G.pii()`, `G.length()`, and safety validation
-- [Middleware](middleware.md) -- `M.retry()`, `M.log()`, and app-level middleware
-- [Evaluation](evaluation.md) -- `E.case()`, `EvalSuite`, and quality assessment
-- [Error Reference](error-reference.md) -- every error with fix-it examples
+- {doc}`structured-data` --- `.produces()`, `.consumes()`, and contract annotations
+- {doc}`context-engineering` --- context isolation and why it matters for testing
+- {doc}`guards` --- safety validation with the G module
+- {doc}`evaluation` --- quality assessment with the E module
+- {doc}`error-reference` --- every error with fix-it examples
 :::

--- a/docs/user-guide/transfer-control.md
+++ b/docs/user-guide/transfer-control.md
@@ -1,5 +1,13 @@
 # Transfer Control
 
+:::{admonition} At a Glance
+:class: tip
+
+- `.sub_agent()` adds transfer targets (LLM decides routing); `.agent_tool()` wraps as callable tool (parent controls)
+- `.isolate()` is the most predictable pattern --- agent completes its task, then returns to parent
+- Always set `.describe()` on sub-agents to help the coordinator pick the right specialist
+:::
+
 In multi-agent systems, the LLM decides when to hand off a conversation to another agent. Transfer control flags let you constrain which agents are valid transfer targets, shaping how conversations flow through your agent hierarchy.
 
 :::{tip}

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -1,0 +1,103 @@
+# Troubleshooting
+
+:::{admonition} At a Glance
+:class: tip
+
+Error message → cause → fix lookup table. Find your error, understand why it happens, fix it.
+:::
+
+## Build Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `AttributeError: 'xxx' is not a recognized field. Did you mean: 'yyy'?` | Typo in builder method | Use the suggested method name |
+| `ValueError: Agent 'x' has no model set` | Missing `.model()` or second positional arg | Add `Agent("name", "gemini-2.5-flash")` |
+| `ValueError: Agent 'x' has no instruction` | Missing `.instruct()` | Add `.instruct("Your prompt here")` |
+| `TypeError: build() got unexpected keyword argument` | Passing native ADK kwargs to builder | Use fluent methods instead: `.instruct()`, `.model()`, etc. |
+
+## Data Flow Errors
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Agent reads `None` from state | Upstream agent forgot `.writes()` | Add `.writes("key")` to the upstream agent |
+| Agent sees duplicate data | Three channels converging (history + state + template) | Add `.reads("key")` to suppress history on downstream agent |
+| `{key}` template resolves to empty string | Key not in state when template resolves | Ensure upstream writes the key; check pipeline ordering |
+| Route always takes the default branch | State key doesn't match any `.eq()` value | Check the actual state value; add `.log()` before Route |
+
+## Context Errors
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Agent doesn't see user's original message | `.reads()` or `C.none()` suppresses history | Use `S.capture("user_msg")` before the agent, then `.reads("user_msg")` |
+| Agent hallucinates from prior agents' output | Full history includes other agents' reasoning | Add `.context(C.user_only())` or `.context(C.none())` |
+| Token limit exceeded | Too much history in context | Use `C.window(n=3)` or `C.budget(max_tokens=4000)` |
+
+## Execution Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `RuntimeError: cannot run sync in async event loop` | Using `.ask()` or `.map()` in Jupyter/FastAPI | Use `.ask_async()` or `.map_async()` instead |
+| `TypeError: Agent expected, got Builder` | Passing builder where ADK expects agent | Call `.build()` first |
+| Infinite loop | `until()` predicate never satisfied | Always set `max=` parameter: `* until(pred, max=5)` |
+| Parallel branches produce wrong results | Both branches write to same state key | Use distinct `.writes()` keys, then `S.merge()` |
+
+## Contract Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `Agent 'x' consumes key 'y' but no prior step produces it` | Missing `.produces()` or `.writes()` upstream | Add `.produces(Schema)` or `.writes("key")` |
+| `Contract mismatch: expected 'x', got 'y'` | Schema field name mismatch | Align Pydantic model field names |
+
+## Import Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `ImportError: cannot import 'xxx' from adk_fluent` | Wrong import path | Always import from top-level: `from adk_fluent import Agent, S, C` |
+| `ModuleNotFoundError: adk_fluent` | Not installed | `pip install adk-fluent` |
+| `ImportError: A2A requires extra` | Missing optional dependency | `pip install adk-fluent[a2a]` |
+
+---
+
+## Debugging Techniques
+
+### 1. Inspect builder state
+
+```python
+print(agent.explain())       # Full builder state
+print(agent.data_flow())     # Five-concern snapshot
+print(agent.llm_anatomy())   # What the LLM sees
+```
+
+### 2. Log state between pipeline steps
+
+```python
+pipeline = agent_a >> S.log("key1", "key2") >> agent_b
+```
+
+### 3. Visualize topology
+
+```python
+print(pipeline.to_mermaid())  # Copy-paste into mermaid.live
+```
+
+### 4. Check contracts
+
+```python
+from adk_fluent.testing import check_contracts
+issues = check_contracts(pipeline.to_ir())
+print(issues)  # List of data flow problems
+```
+
+### 5. Run diagnostic report
+
+```python
+print(agent.doctor())  # Formatted diagnostic with suggestions
+```
+
+---
+
+:::{seealso}
+- {doc}`error-reference` --- complete error catalog
+- {doc}`testing` --- testing strategies and mock backend
+- {doc}`faq` --- common questions
+:::

--- a/docs/user-guide/visibility.md
+++ b/docs/user-guide/visibility.md
@@ -1,5 +1,13 @@
 # Visibility
 
+:::{admonition} At a Glance
+:class: tip
+
+- Control which agents appear in the user-facing topology via `.show()`, `.hide()`, `.transparent()`
+- Hidden agents still execute --- visibility only affects what's reported to the user
+- Use `.hide()` for internal utility agents, `.transparent()` for pass-through coordinators
+:::
+
 In multi-agent pipelines, not every agent's output should be shown to the end-user. A 5-agent pipeline that streams all 5 responses creates a confusing, noisy experience. The visibility system lets you control which agents produce user-facing output and which remain internal.
 
 ## The Real Problem


### PR DESCRIPTION
…, and 7 new pages

Full rewrites (9 pages): architecture-and-concepts, expression-language, data-flow, builders, patterns, state-transforms, context-engineering, callbacks, testing.

New pages (7): concept-map, cheat-sheet, glossary, faq, troubleshooting, performance, design-philosophy.

Enhanced remaining 19 pages with At a Glance admonitions, Common Mistakes grids, Interplay tables, and See Also footers.

Updated index.md with decision flowchart and toctree entries for all new pages.