### PR TITLE
fix(reactor): lint + strict-pyright cleanups after 0.17.0 landing

### DIFF
--- a/python/examples/cookbook/81_reactor_native.py
+++ b/python/examples/cookbook/81_reactor_native.py
@@ -76,9 +76,7 @@ def test_compile_walks_composite_builders() -> None:
     R.signal("a", 0)
     R.signal("b", 0)
 
-    pipeline = Pipeline("flow").step(
-        Agent("x").on(R.changed("a"), lambda c: None)
-    )
+    pipeline = Pipeline("flow").step(Agent("x").on(R.changed("a"), lambda c: None))
     fanout = (
         FanOut("parallel")
         .branch(Agent("y").on(R.changed("a"), lambda c: None))
@@ -122,9 +120,9 @@ async def test_end_to_end_declarative_reactor() -> None:
     task = asyncio.create_task(reactor.run())
     await asyncio.sleep(0.05)
 
-    temp.set(80)   # rising but below 90 — no fire
-    temp.set(95)   # rising above 90 — fires
-    temp.set(92)   # falling — no fire
+    temp.set(80)  # rising but below 90 — no fire
+    temp.set(95)  # rising above 90 — fires
+    temp.set(92)  # falling — no fire
     await asyncio.sleep(0.1)
 
     reactor.stop()

--- a/python/src/adk_fluent/_base.py
+++ b/python/src/adk_fluent/_base.py
@@ -589,6 +589,7 @@ class BuilderBase:
     _config: dict[str, Any]
     _callbacks: dict[str, list[Callable]]
     _lists: dict[str, list]
+    _reactor_rules: list  # lazily initialized in .on()
 
     def _init_storage(self, name: str, **config_extras: Any) -> None:
         """Canonical storage initialization. Called by codegen __init__ and PrimitiveBuilderBase.

--- a/python/src/adk_fluent/_reactor/_namespace.py
+++ b/python/src/adk_fluent/_reactor/_namespace.py
@@ -154,10 +154,7 @@ class SignalRegistry:
         try:
             return self._signals[name]
         except KeyError as exc:
-            raise KeyError(
-                f"Signal {name!r} is not registered. "
-                f"Create it with R.signal({name!r}, ...) first."
-            ) from exc
+            raise KeyError(f"Signal {name!r} is not registered. Create it with R.signal({name!r}, ...) first.") from exc
 
     def has(self, name: str) -> bool:
         return name in self._signals

--- a/python/src/adk_fluent/_reactor/_namespace.py
+++ b/python/src/adk_fluent/_reactor/_namespace.py
@@ -43,7 +43,7 @@ from __future__ import annotations
 import contextlib
 import threading
 from collections.abc import Awaitable, Callable, Iterable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from adk_fluent._reactor._predicate import SignalPredicate


### PR DESCRIPTION
## Summary

Two small cleanups the 0.17.0 direct-to-master landing missed:

- Drop unused `dataclasses.field` import in `python/src/adk_fluent/_reactor/_namespace.py` (F401 from ruff).
- Declare `_reactor_rules: list` at the `BuilderBase` class level so strict pyright accepts the lazy assignment inside `.on()` — mirrors the existing `_config / _callbacks / _lists` declaration pattern on lines 589–591.

Both errors surfaced when PR #128 ran its own `python · lint` and `python · typecheck` jobs against master's tree. The reactor work passed local tests but skipped these two strict checks — the review-then-merge flow would have caught it before shipping.

## Test plan

- [x] `uv run ruff check .` → clean
- [x] `uv run pyright src/adk_fluent/_base.py` → 0 errors
- [x] `uv run pytest tests/manual/test_reactor_namespace.py` → 21 passed
- [ ] CI lint + typecheck jobs green on this PR

## Followup

Once merged, PR #128 (restore grouped badge hero) will rebase on master to pick up the fix and its CI should go green.

https://claude.ai/code/session_01RrpZXeMDvzkPuEqwTaY2VX